### PR TITLE
If a user cancels a movie request, the parent movie status is not set back to unknown so another request can’t be made. 

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -163,16 +163,16 @@ export class MediaRequest {
     }
     const seasonRequestRepository = getRepository(SeasonRequest);
     if (this.status === MediaRequestStatus.APPROVED) {
-      this.media.status = MediaStatus.PROCESSING;
-      mediaRepository.save(this.media);
+      media.status = MediaStatus.PROCESSING;
+      mediaRepository.save(media);
     }
 
     if (
       this.media.mediaType === MediaType.MOVIE &&
       this.status === MediaRequestStatus.DECLINED
     ) {
-      this.media.status = MediaStatus.UNKNOWN;
-      mediaRepository.save(this.media);
+      media.status = MediaStatus.UNKNOWN;
+      mediaRepository.save(media);
     }
 
     /**
@@ -213,7 +213,7 @@ export class MediaRequest {
     });
     if (!fullMedia.requests || fullMedia.requests.length === 0) {
       fullMedia.status = MediaStatus.UNKNOWN;
-      mediaRepository.save(this.media);
+      mediaRepository.save(fullMedia);
     }
   }
 

--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -99,7 +99,7 @@ const MovieRequestModal: React.FC<RequestModalProps> = ({
       }
       addToast(
         <span>
-          {intl.formatMessage(messages.cancelrequest, {
+          {intl.formatMessage(messages.requestCancel, {
             title: data?.title,
             strong: function strong(msg) {
               return <strong>{msg}</strong>;

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -209,7 +209,8 @@ const TitleCard: React.FC<TitleCardProps> = ({
                       </svg>
                     </a>
                   </Link>
-                  {!currentStatus && (
+                  {(!currentStatus ||
+                    currentStatus === MediaStatus.UNKNOWN) && (
                     <button
                       onClick={() => setShowRequestModal(true)}
                       className="w-full h-7 text-center text-white bg-indigo-500 rounded-sm ml-2 hover:bg-indigo-400 focus:border-indigo-700 focus:ring-indigo active:bg-indigo-700 transition ease-in-out duration-150"


### PR DESCRIPTION
Story details: https://app.clubhouse.io/sct-dev/story/128