### PR TITLE
Changing parameter name to use correct 'port' #276

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -61,7 +61,7 @@ class PlexAPI {
 
     this.plexClient = new NodePlexAPI({
       hostname: settings.plex.ip,
-      post: settings.plex.port,
+      port: settings.plex.port,
       token: plexToken,
       authenticator: {
         authenticate: (

--- a/server/types/plex-api.d.ts
+++ b/server/types/plex-api.d.ts
@@ -2,7 +2,7 @@ declare module 'plex-api' {
   export default class PlexAPI {
     constructor(intiialOptions: {
       hostname: string;
-      post: number;
+      port: number;
       token?: string;
       authenticator: {
         authenticate: (


### PR DESCRIPTION
#### Description
Corrects issue where the parameter 'port' for plex-api was incorrectly called 'post'.

#### Screenshot (if UI related)

#### Todos

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- Fixes #276 
