### PR TITLE
Dockerfile: Expose port 3000.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,5 @@ COPY --from=BUILD_IMAGE /app/.next ./.next
 COPY --from=BUILD_IMAGE /app/node_modules ./node_modules
 
 CMD yarn start
+
+EXPOSE 3000


### PR DESCRIPTION
Allows for automated nginx reverse proxy setups to identify the port used in the container without having to bind the port to the host/localhost.
