### PR TITLE
fix(services): improve logging for when Radarr movie already exists

### DIFF
--- a/server/api/radarr.ts
+++ b/server/api/radarr.ts
@@ -76,11 +76,9 @@ class RadarrAPI {
     }
   };
 
-  public addMovie = async (
-    options: RadarrMovieOptions
-  ): Promise<RadarrMovie> => {
+  public addMovie = async (options: RadarrMovieOptions): Promise<void> => {
     try {
-      const response = await this.axios.post<RadarrMovie>(`/movie`, {
+      await this.axios.post<RadarrMovie>(`/movie`, {
         title: options.title,
         qualityProfileId: options.qualityProfileId,
         profileId: options.profileId,
@@ -94,15 +92,15 @@ class RadarrAPI {
           searchForMovie: options.searchNow,
         },
       });
-
-      return response.data;
     } catch (e) {
-      logger.error('Something went wrong adding a movie to Radarr', {
-        label: 'Radarr',
-        message: e.message,
-        options,
-      });
-      throw new Error(`[Radarr] Failed to add movie: ${e.message}`);
+      logger.error(
+        'Failed to add movie to Radarr. This might happen if the movie already exists, in which case you can safely ignore this error.',
+        {
+          label: 'Radarr',
+          errorMessage: e.message,
+          options,
+        }
+      );
     }
   };
 


### PR DESCRIPTION
#### Description

Cleaned up the logging to not throw an error when the movie already exists in Radarr. Added more helpful logging so the user can understand what failed and why.

#### Todos

- [X] Successfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- References #260 
