### PR TITLE
fix(sonarr.ts, mediarequest.ts): add missing seasonFolder option

### DIFF
--- a/server/api/sonarr.ts
+++ b/server/api/sonarr.ts
@@ -76,6 +76,7 @@ interface AddSeriesOptions {
   title: string;
   profileId: number;
   seasons: number[];
+  seasonFolder: boolean;
   rootFolderPath: string;
   monitored?: boolean;
   searchNow?: boolean;
@@ -149,6 +150,7 @@ class SonarrAPI {
               monitored: false,
             }))
           ),
+          seasonFolder: options.seasonFolder,
           monitored: options.monitored,
           rootFolderPath: options.rootFolderPath,
           addOptions: {

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -335,6 +335,7 @@ export class MediaRequest {
           title: series.name,
           tvdbid: series.external_ids.tvdb_id,
           seasons: this.seasons.map((season) => season.seasonNumber),
+          seasonFolder: sonarrSettings.enableSeasonFolders,
           monitored: true,
           searchNow: true,
         });


### PR DESCRIPTION
#### Description

Fixes the issue where the "Season Folders" toggle in Sonarr options does not actually pass the value on to Sonarr when adding series.

#### Screenshot (if UI related)

None.

#### Todos

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

None.
