### PR TITLE
docs: Remove the issue lock as it will not allow users to edit [skip ci]

### DIFF
--- a/.github/workflows/invalid_template.yml
+++ b/.github/workflows/invalid_template.yml
@@ -15,5 +15,5 @@ jobs:
           issue-comment: >
             :wave: @{issue-author}, please edit your issue and follow the template provided.
           close-issue: false
-          lock-issue: true
+          lock-issue: false
           issue-lock-reason: 'resolved'


### PR DESCRIPTION
#### Description
Locking an issue will not allow the author to edit it. This will remove the lock from the workflow. 
#### Screenshot (if UI related)

#### Todos

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- Fixes #XXXX
