### PR TITLE
feat: allow to listen server on specific host interface

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -101,11 +101,20 @@ app
     );
 
     const port = Number(process.env.PORT) || 3000;
-    server.listen(port, () => {
-      logger.info(`Server ready on port ${port}`, {
-        label: 'Server',
+    const host = process.env.HOST;
+    if (host) {
+      server.listen(port, host, () => {
+        logger.info(`Server ready on ${host} port ${port}`, {
+          label: 'Server',
+        });
       });
-    });
+    } else {
+      server.listen(port, () => {
+        logger.info(`Server ready on port ${port}`, {
+          label: 'Server',
+        });
+      });
+    }
   })
   .catch((err) => {
     logger.error(err.stack);


### PR DESCRIPTION
#### Description

Allow to listen server on specific host interface. Name is passed in HOST env variable similarly to PORT env variable.

#### Screenshot (if UI related)

#### Todos

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- Fixes #273
