### PR TITLE
Change default internal port to 5055

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=BUILD_IMAGE /app/node_modules ./node_modules
 
 CMD yarn start
 
-EXPOSE 3000
+EXPOSE 5055

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Currently, Overseerr is only distributed through Docker images. If you have Dock
 docker run -d \
   -e LOG_LEVEL=info \
   -e TZ=Asia/Tokyo \
-  -p 5055:3000 \
+  -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \
   sctx/overseerr
@@ -76,7 +76,7 @@ After running Overseerr for the first time, configure it by visiting the web UI 
 
 ## API Documentation
 
-Full API documentation will soon be published automatically and available outside of running the app. Currently, you can access the API docs by running Overseerr locally and visiting http://localhost:3000/api-docs
+Full API documentation will soon be published automatically and available outside of running the app. Currently, you can access the API docs by running Overseerr locally and visiting http://localhost:5055/api-docs
 
 ## Community
 
@@ -124,4 +124,5 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile.local
     ports:
-      - 3000:3000
+      - 5055:5055
     volumes:
       - .:/app:rw,cached
       - /app/node_modules

--- a/server/index.ts
+++ b/server/index.ts
@@ -100,7 +100,7 @@ app
       }
     );
 
-    const port = Number(process.env.PORT) || 3000;
+    const port = Number(process.env.PORT) || 5055;
     const host = process.env.HOST;
     if (host) {
       server.listen(port, host, () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -114,7 +114,7 @@ CoreApp.getInitialProps = async (initialProps) => {
   if (ctx.res) {
     // Check if app is initialized and redirect if necessary
     const response = await axios.get<{ initialized: boolean }>(
-      `http://localhost:${process.env.PORT || 3000}/api/v1/settings/public`
+      `http://localhost:${process.env.PORT || 5055}/api/v1/settings/public`
     );
 
     const initialized = response.data.initialized;
@@ -130,7 +130,7 @@ CoreApp.getInitialProps = async (initialProps) => {
       try {
         // Attempt to get the user by running a request to the local api
         const response = await axios.get<User>(
-          `http://localhost:${process.env.PORT || 3000}/api/v1/auth/me`,
+          `http://localhost:${process.env.PORT || 5055}/api/v1/auth/me`,
           { headers: ctx.req ? { cookie: ctx.req.headers.cookie } : undefined }
         );
         user = response.data;

--- a/src/pages/movie/[movieId]/index.tsx
+++ b/src/pages/movie/[movieId]/index.tsx
@@ -17,7 +17,7 @@ MoviePage.getInitialProps = async (ctx) => {
   if (ctx.req) {
     const cookies = parseCookies(ctx);
     const response = await axios.get<MovieDetailsType>(
-      `http://localhost:${process.env.PORT || 3000}/api/v1/movie/${
+      `http://localhost:${process.env.PORT || 5055}/api/v1/movie/${
         ctx.query.movieId
       }${cookies.locale ? `?language=${cookies.locale}` : ''}`,
       {

--- a/src/pages/tv/[tvId]/index.tsx
+++ b/src/pages/tv/[tvId]/index.tsx
@@ -17,7 +17,7 @@ TvPage.getInitialProps = async (ctx) => {
   if (ctx.req) {
     const cookies = parseCookies(ctx);
     const response = await axios.get<TvDetailsType>(
-      `http://localhost:${process.env.PORT || 3000}/api/v1/tv/${
+      `http://localhost:${process.env.PORT || 5055}/api/v1/tv/${
         ctx.query.tvId
       }${cookies.locale ? `?language=${cookies.locale}` : ''}`,
       {


### PR DESCRIPTION
#### Description

This will change the default internal port to 5055. This will help avoid future confusion about which port to use or forward to.

This PR, once merged, will break access to Overseerr for anyone who is accessing the app through the Docker portforward of 5055 to 3000. It will need to be updated to 5055 internally as well.

The README is updated as well with the new command.

#### Todos

- [x] Sucessfully builds `yarn build`
