### PR TITLE
fix: add name, short_name and start_url to manifest

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,20 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#1e2937","display":"standalone"}
+{
+  "name": "Overseerr",
+  "short_name": "Overseerr",
+  "start_url": "./",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#1e2937",
+  "display": "standalone"
+}


### PR DESCRIPTION
#### Description
This adds some missing parameters to the manifest for browsers to install it correctly.

#### Screenshot (if UI related)
N/A

- [x] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR
None
