### PR TITLE
Add search clear icon & fix on ios

### DIFF
--- a/src/assets/cross.svg
+++ b/src/assets/cross.svg
@@ -1,0 +1,1 @@
+<svg fill="#fff" stroke="#fff" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,7 +7,7 @@ body {
 }
 
 .plex-button {
-  @apply w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 transition ease-in-out duration-150 text-center;
+  @apply flex justify-center w-full px-4 py-2 text-sm font-medium text-center text-white transition duration-150 ease-in-out bg-indigo-600 border border-transparent rounded-md;
   background-color: #cc7b19;
 }
 
@@ -16,7 +16,7 @@ body {
 }
 
 .titleCard {
-  @apply relative bg-cover rounded-lg bg-gray-800;
+  @apply relative bg-gray-800 bg-cover rounded-lg;
   padding-bottom: 150%;
 }
 
@@ -34,7 +34,7 @@ body {
 }
 
 .error-message {
-  @apply flex items-center justify-center text-center text-gray-300 relative top-0 left-0 bottom-0 right-0 h-screen flex-col;
+  @apply relative top-0 bottom-0 left-0 right-0 flex flex-col items-center justify-center h-screen text-center text-gray-300;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -46,4 +46,13 @@ body {
 .hide-scrollbar {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
+}
+
+/* Add icon to search field, to clear, also fixes ios */
+#search_field::-webkit-search-cancel-button {
+  position:relative;
+  -webkit-appearance: none;
+  height: 25px;
+  width: 25px;
+  background-image: url('../assets/cross.svg');
 }


### PR DESCRIPTION
#### Description

Add SVG to replace browser own rendered clear button, for search input. 
Add CSS to use the SVG, also fixes IOS not showing the button.

Can someone test this with an iOS device, and if necessary suggest changes? I don't know if React has a sort of Scoped CSS equivalent like Vue, maybe that would be better than global, but I am not sure myself.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/8655212/102728312-0fa01d80-4323-11eb-8403-43f73adf24f8.png)

#### Todos

- [x] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- Fixes #423
