### PR TITLE
fix(frontend): approve and decline button in manage slideover will now fit on mobile

### DIFF
--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -84,7 +84,7 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
               </div>
             )}
           </div>
-          <div className="ml-2 flex-shrink-0 flex">
+          <div className="ml-2 flex-shrink-0 flex flex-wrap">
             {request.status === MediaRequestStatus.PENDING && (
               <>
                 <span className="mr-1">


### PR DESCRIPTION

#### Description
The approve and decline buttons will not fit in the container on mobile UI. Previously, they would be cut off on smaller mobile devices.
#### Screenshot (if UI related)
![Screenshot 2020-12-21 134153](https://user-images.githubusercontent.com/8635678/102810787-5416d200-4392-11eb-9be0-b65065986936.png)

- [x] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

