### PR TITLE
fix(frontend): center text in movie auto-approve modal on small screens only

### DIFF
--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -168,7 +168,7 @@ const MovieRequestModal: React.FC<RequestModalProps> = ({
       okButtonType={'primary'}
       iconSvg={<DownloadIcon className="w-6 h-6" />}
     >
-      {text}
+      <p className="text-center md:text-left">{text}</p>
     </Modal>
   );
 };


### PR DESCRIPTION
#### Description
This centers the auto approve message in the movie request modal for small devices only. 
It seemed weird on bigger screens, and along with the side panel not being hidden on these bigger screens, this decision makes sense to me.

#### Screenshot (if UI related)
On small devices:
![image](https://user-images.githubusercontent.com/20923978/103158446-67cd9880-47d7-11eb-9736-4e8061c621e7.png)

On bigger devices:
![image](https://user-images.githubusercontent.com/20923978/103158439-52f10500-47d7-11eb-87b5-4591fa4aa938.png)

#### Todos
N/A

- [x] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- Fixes #507
