### PR TITLE
docs: added reminder to check default user permissions (#527) [skip ci]

### DIFF
--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -68,7 +68,7 @@ Perform these steps to verify the media item has a guid Overseerr can match.
 
 ### Why can't I see all my Plex users?
 
-**A:** Navigate to your **User List** in Overseerr and click **Import Users From Plex** button.
+**A:** Navigate to your **User List** in Overseerr and click **Import Users From Plex** button. Don't forget to check the default user permissions in the **Settings -&gt; General Settings** page beforehand.
 
 ### Can I create local users in Overseerr?
 


### PR DESCRIPTION
#### Description
Add a reminder to check default user permissions before importing users from plex since mass editing of users is not possible at this moment.

#### Screenshot (if UI related)
N/A

#### Todos
N/A

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR
N/A
