### PR TITLE
Add snapcraft build yaml and workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -54,9 +54,6 @@ jobs:
 
       - name: Publish Snap Package
         uses: snapcore/action-publish@v1
-        if: >
-          github.event_name != 'pull_request' &&
-          (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop')
         with:
           store_login: ${{ secrets.SNAP_LOGIN }}
           snap: ${{ steps.build.outputs.snap }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Lint
+    name: Lint & Build Test
     runs-on: ubuntu-latest
     container: node:12.18-alpine
     steps:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Lint
     runs-on: ubuntu-latest
     container: node:12.18-alpine
     steps:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -2,7 +2,7 @@ name: Publish Snap
 
 on:
   push:
-    branches: [develop, add-snap-package]
+    branches: [develop]
     tags: [v*]
     pull_request: ~
 
@@ -60,7 +60,7 @@ jobs:
       - name: Upload Snap Package
         uses: actions/upload-artifact@v2
         with:
-          name: Overseerr-test-snap-package-${{ matrix.architecture }}
+          name: overseerr-snap-package-${{ matrix.architecture }}
           path: ${{ steps.build.outputs.snap }}
 
       - name: Review Snap Package

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -7,8 +7,23 @@ on:
     pull_request: ~
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: node:12.18-alpine
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install dependencies
+        env:
+          HUSKY_SKIP_INSTALL: 1
+        run: yarn
+      - name: lint
+        run: yarn lint
+      - name: build
+        run: yarn build
   build-snap:
     name: Build Snap Package (${{ matrix.architecture }})
+    needs: test
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -19,8 +19,6 @@ jobs:
         run: yarn
       - name: lint
         run: yarn lint
-      - name: build
-        run: yarn build
   build-snap:
     name: Build Snap Package (${{ matrix.architecture }})
     needs: test

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,6 +20,8 @@ jobs:
         run: yarn
       - name: lint
         run: yarn lint
+      - name: build
+        run: yarn build
   build-snap:
     name: Build Snap Package (${{ matrix.architecture }})
     needs: test

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,90 @@
+name: Publish Snap
+
+on:
+  push:
+    branches: [develop, add-snap-package]
+    tags: [v*]
+    pull_request: ~
+
+jobs:
+  build-snap:
+    name: Build Snap Package (${{ matrix.architecture }})
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - amd64
+          - arm64
+          - armhf
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prepare
+        run: |
+          git fetch --prune --unshallow --tags
+          if [[ $GITHUB_REF == refs/tags/* || $GITHUB_REF == refs/heads/master ]]; then
+            echo ::set-output name=RELEASE::stable
+          else
+            echo ::set-output name=RELEASE::edge
+          fi
+
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build Snap Package
+        uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: build
+        with:
+          architecture: ${{ matrix.architecture }}
+
+      - name: Upload Snap Package
+        uses: actions/upload-artifact@v2
+        with:
+          name: Overseerr-test-snap-package-${{ matrix.architecture }}
+          path: ${{ steps.build.outputs.snap }}
+
+      - name: Review Snap Package
+        uses: diddlesnaps/snapcraft-review-tools-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+
+      - name: Publish Snap Package
+        uses: snapcore/action-publish@v1
+        if: >
+          github.event_name != 'pull_request' &&
+          (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop')
+        with:
+          store_login: ${{ secrets.SNAP_LOGIN }}
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ steps.prepare.outputs.RELEASE }}
+
+  discord:
+    name: Discord Notification
+    needs: build-snap
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Build Job Status
+        uses: technote-space/workflow-conclusion-action@v1
+
+      - name: Combine Job Status
+        id: status
+        run: |
+          failures=(neutral, skipped, timed_out, action_required)
+          if [[ ${array[@]} =~ $WORKFLOW_CONCLUSION ]]; then
+            echo ::set-output name=status::failure
+          else
+            echo ::set-output name=status::$WORKFLOW_CONCLUSION
+          fi
+
+      - name: Post Status to Discord
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: ${{ steps.status.outputs.status }}
+          title: ${{ github.workflow }}
+          nofail: true

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,7 @@ After running Overseerr for the first time, configure it by visiting the web UI 
 
 {% tabs %}
 {% tab title="Basic" %}
+
 ```bash
 docker run -d \
   -e LOG_LEVEL=info \
@@ -21,9 +22,11 @@ docker run -d \
   --restart unless-stopped \
   sctx/overseerr
 ```
+
 {% endtab %}
 
 {% tab title="UID/GID" %}
+
 ```text
 docker run -d \
   --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ] \
@@ -34,9 +37,11 @@ docker run -d \
   --restart unless-stopped \
    sctx/overseerr
 ```
+
 {% endtab %}
 
 {% tab title="Manual Update" %}
+
 ```text
 # Stop the Overseerr container
 docker stop overseerr
@@ -50,6 +55,7 @@ docker pull sctx/overseerr
 # Run the Overseerr container with the same parameters as before
 docker run -d ...
 ```
+
 {% endtab %}
 {% endtabs %}
 
@@ -70,7 +76,7 @@ Use a 3rd party updating mechanism such as [Watchtower](https://github.com/conta
 Please refer to the [docker for windows documentation](https://docs.docker.com/docker-for-windows/) for installation.
 
 {% hint style="danger" %}
-**WSL2 will need to be installed to prevent DB corruption! Please see** [**Docker Desktop WSL 2 backend**](https://docs.docker.com/docker-for-windows/wsl/) **on how to enable WSL2. The command below will only work with WSL2 installed! Details below.**
+**WSL2 will need to be installed to prevent DB corruption! Please see** [**Docker Desktop WSL 2 backend**](https://docs.docker.com/docker-for-windows/wsl/) **on how to enable WSL2. The command below will only work with WSL2 installed!**
 {% endhint %}
 
 ```bash
@@ -81,116 +87,74 @@ docker run -d -e LOG_LEVEL=info -e TZ=Asia/Tokyo -p 5055:5055 -v "/your/path/her
 Docker on Windows works differently than it does on Linux; it uses a VM to run a stripped-down Linux and then runs docker within that. The volume mounts are exposed to the docker in this VM via SMB mounts. While this is fine for media, it is unacceptable for the `/app/config` directory because SMB does not support file locking. This will eventually corrupt your database which can lead to slow behavior and crashes. If you must run in docker on Windows, you should put the `/app/config` directory mount inside the VM and not on the Windows host. It's worth noting that this warning also extends to other containers which use SQLite databases.
 {% endhint %}
 
-## Linux \(Unsupported\)
+## Linux
+
+{% hint style="info" %}
+The [Overseerr snap](https://snapcraft.io/overseerr) is the only supported linux install method. Currently, the listening port cannot be changed. Port `5055` will need to be available on your host. To install snapd please refer to [Installing snapd](https://snapcraft.io/docs/installing-snapd).
+{% endhint %}
+
+**To install:**
+
+```
+sudo snap install overseerr
+```
+
+**Updating:**
+Snap will keep Overseerr up-to-date automatically. You can force a refresh by using the following command.
+
+```
+sudo snap refresh
+```
+
+**To install the development build:**
+
+```
+sudo snap install overseerr --edge
+```
+
+{% hint style="danger" %}
+This version can break any moment. Be prepared to troubleshoot any issues that arise!
+{% endhint %}
+
+## Third Party
+
 {% tabs %}
 
-{% tab title="Ubuntu 16.04+/Debian" %}
-{% hint style="danger" %}
-This install method is **not currently supported**. Docker is the only install method supported. Do not create issues or ask for support unless you are able to reproduce the issue with Docker.
-{% endhint %}
-
-```bash
-# Install nodejs
-sudo apt-get install -y curl git gnupg2
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-sudo apt-get install -y nodejs
-# Install yarn
-curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt-get update && sudo apt-get install yarn
-# Install Overseerr
-cd ~ && git clone https://github.com/sct/overseerr.git
-cd overseerr
-yarn install
-yarn build
-yarn start
-```
-
-**Updating**
-
-In order to update, you will need to re-build overseer.
-```bash
-cd ~/.overseerr
-git pull
-yarn install
-yarn build
-yarn start
-```
-{% endtab %}
-
-{% tab title="Ubuntu ARM" %}
-{% hint style="danger" %}
-This install method is **not currently supported**. Docker is the only install method supported. Do not create issues or ask for support unless you are able to reproduce the issue with Docker.
-{% endhint %}
-
-```bash
-# Install nodejs
-sudo apt-get install -y curl git gnupg2 build-essential
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-sudo apt-get install -y nodejs
-# Install yarn
-curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt-get update && sudo apt-get install yarn
-# Install Overseerr
-cd ~ && git clone https://github.com/sct/overseerr.git
-cd overseerr
-npm config set python "$(which python3)"
-yarn install
-yarn build
-yarn start
-```
-
-**Updating**
-
-In order to update, you will need to re-build overseer.
-```bash
-cd ~/.overseerr
-git pull
-yarn install
-yarn build
-yarn start
-```
-{% endtab %}
-
-{% tab title="ArchLinux \(3rd Party\)" %}
-Built from tag \(master\): [https://aur.archlinux.org/packages/overseerr/](https://aur.archlinux.org/packages/overseerr/)  
-Built from latest \(develop\): [aur.archlinux.org/packages/overseerr-git](https://aur.archlinux.org/packages/overseerr-git/)  
-**To install these just use your favorite AUR package manager:**
-
-```bash
-yay -S overseer
-```
-{% endtab %}
-
-{% tab title="Gentoo \(3rd Party\)" %}
+{% tab title="Gentoo" %}
 Portage overlay [GitHub Repository](https://github.com/chriscpritchard/overseerr-overlay)
 
 Efforts will be made to keep up to date with the latest releases, however, this cannot be guaranteed.
 
 To enable using eselect repository, run:
+
 ```bash
 eselect repository add overseerr-overlay git https://github.com/chriscpritchard/overseerr-overlay.git
 ```
 
 Once complete, you can just run:
+
 ```bash
 emerge www-apps/overseerr
 ```
+
 {% endtab %}
 
-{% endtabs %}
-
-## Swizzin \(Third party\)
+{% tab title="Swizzin" %}
 The installation is not implemented via docker, but barebones. The latest released version of overseerr will be used.
 Please see the [swizzin documentation](https://swizzin.ltd/applications/overseerr) for more information.
 
 To install, run the following:
+
 ```bash
 box install overseerr
 ```
 
 To upgrade, run the following:
+
 ```bash
 box upgrade overseerr
 ```
+
+{% endtab %}
+
+{% endtabs %}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ parts:
       # Set COMMIT_TAG before the build begins
       export COMMIT_TAG=$(cat $SNAPCRAFT_PART_BUILD/commit.txt)
       snapcraftctl build
+      yarn lint
       yarn build
       # Copy files needed for staging
       cp $SNAPCRAFT_PART_BUILD/committag.json $SNAPCRAFT_PART_INSTALL/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: overseerr-test
+name: overseerr
 adopt-info: overseerr
 license: MIT
 summary: Request management and media discovery tool for the Plex ecosystem.
@@ -88,9 +88,6 @@ apps:
     environment:
       PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
       OVERSEERR_SNAP: "True"
+      CONFIG_DIRECTORY: $SNAP_USER_COMMON
       LOG_LEVEL: "debug"
       NODE_ENV: "production"
-
-layout:
-  $SNAP/config:
-    bind: $SNAP_COMMON/config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,87 @@
+name: overseerr-test
+adopt-info: overseerr
+license: MIT
+summary: Request management and media discovery tool for the Plex ecosystem.
+description: >
+  Overseerr is a free and open source software application for managing requests for your media library.
+  It integrates with your existing services such as Sonarr, Radarr and Plex!
+base: core18
+confinement: strict
+
+parts:
+  overseerr:
+    plugin: nodejs
+    nodejs-version: "12.18.4"
+    nodejs-package-manager: "yarn"
+    build-packages:
+      - git
+      - on arm64:
+        - build-essential
+        - automake
+      - on armhf:
+        - libatomic1
+        - build-essential
+        - automake
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      COMMIT=$(git rev-parse HEAD)
+      COMMIT_SHORT=$(git rev-parse --short HEAD)
+      VERSION='v'$(cat package.json | grep 'version' | head -1 | sed 's/.*"\(.*\)"\,/\1/')
+      if [ "$VERSION" = "v0.1.0" ]; then
+        SNAP_VERSION=$COMMIT_SHORT
+        GRADE=devel
+      else
+        SNAP_VERSION=$VERSION
+        GRADE=stable
+      fi
+      echo "{\"commitShort\": \"$COMMIT_SHORT\", \
+      \"version\": \"$VERSION\", \
+      \"snapVersion\": \"$SNAP_VERSION\", \
+      \"snapGrade\": \"$GRADE\", \
+      \"branch\": \"$BRANCH\", \
+      \"commit\": \"$COMMIT\"}"
+      echo "{\"commitTag\": \"$COMMIT\"}" > committag.json
+      export COMMIT_TAG=$COMMIT
+      snapcraftctl set-version "$SNAP_VERSION"
+      snapcraftctl set-grade "$GRADE"
+    build-environment:
+      - PATH: "$SNAPCRAFT_PART_BUILD/node_modules/.bin:$SNAPCRAFT_PART_BUILD/../npm/bin:$PATH"
+    override-build: |
+      set -e
+      export COMMIT_TAG=$(cat $SNAPCRAFT_PART_BUILD/commit.txt)
+      if [ "$ARCH" != "x86_64" ]; then
+        npm config set python "$(which python3)"
+      fi
+      snapcraftctl build
+      yarn build
+      cp $SNAPCRAFT_PART_BUILD/committag.json $SNAPCRAFT_PART_INSTALL/
+      cp -R $SNAPCRAFT_PART_BUILD/.next $SNAPCRAFT_PART_INSTALL/
+      cp -R $SNAPCRAFT_PART_BUILD/dist $SNAPCRAFT_PART_INSTALL/
+      cp -R $SNAPCRAFT_PART_BUILD/node_modules $SNAPCRAFT_PART_INSTALL/
+      rm -rf $SNAPCRAFT_PART_INSTALL/.github && rm $SNAPCRAFT_PART_INSTALL/.gitbook.yaml
+    stage:
+      [ .next, ./* ]
+    prime:
+      [ .next, ./* ]
+
+apps:
+  deamon:
+    command: /bin/sh -c "cd $SNAP && node dist/index.js"
+    daemon: simple
+    restart-condition: on-failure
+    restart-delay: 5s
+    plugs:
+      - home
+      - network
+      - network-bind
+    environment:
+      PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+      OVERSEERR_SNAP: "True"
+      LOG_LEVEL: "debug"
+      NODE_ENV: "production"
+
+layout:
+  $SNAP/config:
+    bind: $SNAP_COMMON/config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,7 +62,6 @@ parts:
       # Set COMMIT_TAG before the build begins
       export COMMIT_TAG=$(cat $SNAPCRAFT_PART_BUILD/commit.txt)
       snapcraftctl build
-      yarn lint
       yarn build
       # Copy files needed for staging
       cp $SNAPCRAFT_PART_BUILD/committag.json $SNAPCRAFT_PART_INSTALL/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ parts:
     plugin: nodejs
     nodejs-version: "12.18.4"
     nodejs-package-manager: "yarn"
+    nodejs-yarn-version: v1.22.5
     build-packages:
       - git
       - on arm64:
@@ -25,6 +26,7 @@ parts:
     source: .
     override-pull: |
       snapcraftctl pull
+      # Get information to determine snap grade and version
       BRANCH=$(git rev-parse --abbrev-ref HEAD)
       COMMIT=$(git rev-parse HEAD)
       COMMIT_SHORT=$(git rev-parse --short HEAD)
@@ -36,6 +38,9 @@ parts:
         SNAP_VERSION=$VERSION
         GRADE=stable
       fi
+      # Write COMMIT_TAG as it is needed durring the build process
+      echo $COMMIT > commit.txt
+      # Print debug info for build version
       echo "{\"commitShort\": \"$COMMIT_SHORT\", \
       \"version\": \"$VERSION\", \
       \"snapVersion\": \"$SNAP_VERSION\", \
@@ -43,23 +48,27 @@ parts:
       \"branch\": \"$BRANCH\", \
       \"commit\": \"$COMMIT\"}"
       echo "{\"commitTag\": \"$COMMIT\"}" > committag.json
-      export COMMIT_TAG=$COMMIT
+      # Set snap version and grade
       snapcraftctl set-version "$SNAP_VERSION"
       snapcraftctl set-grade "$GRADE"
     build-environment:
       - PATH: "$SNAPCRAFT_PART_BUILD/node_modules/.bin:$SNAPCRAFT_PART_BUILD/../npm/bin:$PATH"
     override-build: |
       set -e
-      export COMMIT_TAG=$(cat $SNAPCRAFT_PART_BUILD/commit.txt)
+      # On arm builds "python" cannot be found. Set python to python3
       if [ "$ARCH" != "x86_64" ]; then
         npm config set python "$(which python3)"
       fi
+      # Set COMMIT_TAG before the build begins
+      export COMMIT_TAG=$(cat $SNAPCRAFT_PART_BUILD/commit.txt)
       snapcraftctl build
       yarn build
+      # Copy files needed for staging
       cp $SNAPCRAFT_PART_BUILD/committag.json $SNAPCRAFT_PART_INSTALL/
       cp -R $SNAPCRAFT_PART_BUILD/.next $SNAPCRAFT_PART_INSTALL/
       cp -R $SNAPCRAFT_PART_BUILD/dist $SNAPCRAFT_PART_INSTALL/
       cp -R $SNAPCRAFT_PART_BUILD/node_modules $SNAPCRAFT_PART_INSTALL/
+      # Remove .github and gitbook as it will fail snap lint
       rm -rf $SNAPCRAFT_PART_INSTALL/.github && rm $SNAPCRAFT_PART_INSTALL/.gitbook.yaml
     stage:
       [ .next, ./* ]


### PR DESCRIPTION
#### Description
These changes provide a build process for snap packages. This will allow linux users to be able to install overseerr "natively". 

I created a workflow file that has been tested on my [fork](https://github.com/samwiseg0/overseerr/actions?query=workflow%3A%22Publish+Snap%22). It is currently triggered by a push to `develop` and any tags that start with `v`. At the end of the workflow is a discord notification for the workflow.  This can be removed if you prefer. 

#### Prerequisites needed

- [x] Create snapcraft account and register `overseerr`
- [x] Add `SNAP_LOGIN` to action secrets
- [x] Add `DISCORD_WEBHOOK` to action secrets
- [x] Ability to set the config directory

#### Outstanding items

- [x] Remove `add-snap-package` from workflow
- [x] Change snapcraft `name` to `overseerr`
- [x] Change workflow build filename
- [x] Remove `layout` in snapcraft yaml
- [x] Add `SNAP_USER_COMMON` ENV for config storage

#### Snapcraft secret
Run this command to get the snapcraft secret. Currently the workflow only supports `edge` and `stable`. 

```
snapcraft export-login --snaps overseerr --channels edge,stable -
```

#### Items completed

- [X] Update documentation
