### PR TITLE
docs(reverse-proxy): Add note for bundled sample SWAG (#681) [skip ci]

### DIFF
--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -8,6 +8,8 @@ Base URLs cannot be configured in Overseerr. With this limitation, only subdomai
 
 ### Subdomain
 
+As of 2020/12/18 a sample is bundled in SWAG. This page is still the only source of truth, so the sample is not guaranteed to be up to date. If you catch an inconsistency, report it to the linuxserver team, or do a pull-request against the proxy-confs repository to update the sample.
+
 Place in the `proxy-confs` folder as `overseerr.subdomain.conf`
 
 Example Configuration:

--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -10,11 +10,11 @@ Base URLs cannot be configured in Overseerr. With this limitation, only subdomai
 
 As of 2020/12/18 a sample is bundled in SWAG. This page is still the only source of truth, so the sample is not guaranteed to be up to date. If you catch an inconsistency, report it to the linuxserver team, or do a pull-request against the proxy-confs repository to update the sample.
 
-Place in the `proxy-confs` folder as `overseerr.subdomain.conf`
+Rename the sample file `overseerr.subdomain.conf.sample` to `overseerr.subdomain.conf` in the `proxy-confs`folder, or create `overseerr.subdomain.conf` in the same folder with the example below. 
 
 Example Configuration:
 
-```text
+```nginx
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;

--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -8,7 +8,7 @@ Base URLs cannot be configured in Overseerr. With this limitation, only subdomai
 
 ### Subdomain
 
-As of 2020/12/18 a sample is bundled in SWAG. This page is still the only source of truth, so the sample is not guaranteed to be up to date. If you catch an inconsistency, report it to the linuxserver team, or do a pull-request against the proxy-confs repository to update the sample.
+A sample is bundled in SWAG. This page is still the only source of truth, so the sample is not guaranteed to be up to date. If you catch an inconsistency, report it to the linuxserver team, or do a pull-request against the proxy-confs repository to update the sample.
 
 Rename the sample file `overseerr.subdomain.conf.sample` to `overseerr.subdomain.conf` in the `proxy-confs`folder, or create `overseerr.subdomain.conf` in the same folder with the example below. 
 


### PR DESCRIPTION
#### Description

The example is currently bundled in SWAG, change wording to enable the subdomain the same way as the other samples
