### PR TITLE
feat(api): /request/count endpoint

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -2490,7 +2490,7 @@ paths:
     get:
       summary: Returns request counts
       description: |
-        Returns the number of pending, approved, and available requests.
+        Returns the number of pending and approved requests.
       tags:
         - request
       responses:
@@ -2507,13 +2507,9 @@ paths:
                   approved:
                     type: number
                     example: 10
-                  available:
-                    type: number
-                    example: 50
                 required:
                   - pending
                   - approved
-                  - available
   /request/{requestId}:
     get:
       summary: Requests a specific MediaRequest

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -2486,6 +2486,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaRequest'
+  /request/count:
+    get:
+      summary: Returns request counts
+      description: |
+        Returns the number of pending, approved, and available requests.
+      tags:
+        - request
+      responses:
+        '200':
+          description: Request counts returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pending:
+                    type: number
+                    example: 0
+                  approved:
+                    type: number
+                    example: 10
+                  available:
+                    type: number
+                    example: 50
+                required:
+                  - pending
+                  - approved
+                  - available
   /request/{requestId}:
     get:
       summary: Requests a specific MediaRequest

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -236,14 +236,10 @@ requestRoutes.get('/count', async (_req, res, next) => {
     const approvedCount = await requestRepository.count({
       status: MediaRequestStatus.APPROVED,
     });
-    const availableCount = await requestRepository.count({
-      status: MediaRequestStatus.AVAILABLE,
-    });
 
     return res.status(200).json({
       pending: pendingCount,
       approved: approvedCount,
-      available: availableCount,
     });
   } catch (e) {
     next({ status: 500, message: e.message });

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -221,10 +221,34 @@ requestRoutes.post(
 
       next({ status: 500, message: 'Invalid media type' });
     } catch (e) {
-      next({ message: e.message, status: 500 });
+      next({ status: 500, message: e.message });
     }
   }
 );
+
+requestRoutes.get('/count', async (_req, res, next) => {
+  const requestRepository = getRepository(MediaRequest);
+
+  try {
+    const pendingCount = await requestRepository.count({
+      status: MediaRequestStatus.PENDING,
+    });
+    const approvedCount = await requestRepository.count({
+      status: MediaRequestStatus.APPROVED,
+    });
+    const availableCount = await requestRepository.count({
+      status: MediaRequestStatus.AVAILABLE,
+    });
+
+    return res.status(200).json({
+      pending: pendingCount,
+      approved: approvedCount,
+      available: availableCount,
+    });
+  } catch (e) {
+    next({ status: 500, message: e.message });
+  }
+});
 
 requestRoutes.get('/:requestId', async (req, res, next) => {
   const requestRepository = getRepository(MediaRequest);
@@ -392,6 +416,7 @@ requestRoutes.post<{
     }
   }
 );
+
 requestRoutes.get<{
   requestId: string;
   status: 'pending' | 'approve' | 'decline';


### PR DESCRIPTION
#### Description
Adds `/request/count` endpoint which returns count of pending, approved, and available requests.

#### Screenshot
![image](https://user-images.githubusercontent.com/52870424/104972071-b4fbef00-59be-11eb-950e-353add41c4c1.png)

#### Issues Fixed or Closed by this PR

- Fixes #678 
