### PR TITLE
build(release): Add snap package to the release workflow [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
   discord:
     name: Send Discord Notification
     needs: build_and_push
+    if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
     steps:
       - name: Get Build Job Status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    name: Lint & Test Build
     runs-on: ubuntu-20.04
     container: node:12.18-alpine
     steps:
@@ -41,6 +42,57 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: npx semantic-release
+  build-snap:
+    name: Build Snap Package (${{ matrix.architecture }})
+    needs: semantic-release
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - amd64
+          - arm64
+          - armhf
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prepare
+        run: |
+          git fetch --prune --unshallow --tags
+          if [[ $GITHUB_REF == refs/tags/* || $GITHUB_REF == refs/heads/master ]]; then
+            echo ::set-output name=RELEASE::stable
+          else
+            echo ::set-output name=RELEASE::edge
+          fi
+
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build Snap Package
+        uses: diddlesnaps/snapcraft-multiarch-action@v1
+        id: build
+        with:
+          architecture: ${{ matrix.architecture }}
+
+      - name: Upload Snap Package
+        uses: actions/upload-artifact@v2
+        with:
+          name: overseerr-snap-package-${{ matrix.architecture }}
+          path: ${{ steps.build.outputs.snap }}
+
+      - name: Review Snap Package
+        uses: diddlesnaps/snapcraft-review-tools-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+
+      - name: Publish Snap Package
+        uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAP_LOGIN }}
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ steps.prepare.outputs.RELEASE }}
   discord:
     name: Send Discord Notification
     needs: semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
   discord:
     name: Send Discord Notification
     needs: semantic-release
+    if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Get Build Job Status

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -3,8 +3,6 @@ name: Publish Snap
 on:
   push:
     branches: [develop]
-    tags: [v*]
-    pull_request: ~
 
 jobs:
   test:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -75,7 +75,7 @@ jobs:
   discord:
     name: Send Discord Notification
     needs: build-snap
-    if: always() && github.event_name != 'pull_request'
+    if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Get Build Job Status

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -74,10 +74,10 @@ jobs:
           store_login: ${{ secrets.SNAP_LOGIN }}
           snap: ${{ steps.build.outputs.snap }}
           release: ${{ steps.prepare.outputs.RELEASE }}
-
   discord:
     name: Send Discord Notification
     needs: build-snap
+    if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
     steps:
       - name: Get Build Job Status


### PR DESCRIPTION
#### Changes:
- [x] Set discord to `always()` so the notification is always sent
- [x] Add snap workflow to releases
- [x] Remove tag trigger from snap