### PR TITLE
feat: lookup movie by imdbid if tmdbid does not exits for plex movie agent

### DIFF
--- a/server/job/plexsync/index.ts
+++ b/server/job/plexsync/index.ts
@@ -89,6 +89,12 @@ class JobPlexSync {
             newMedia.tmdbId = Number(tmdbMatch);
           }
         });
+        if (newMedia.imdbId && !newMedia.tmdbId) {
+          const tmdbMovie = await this.tmdb.getMovieByImdbId({
+            imdbId: newMedia.imdbId,
+          });
+          newMedia.tmdbId = tmdbMovie.id;
+        }
 
         const has4k = metadata.Media.some(
           (media) => media.videoResolution === '4k'

--- a/server/job/plexsync/index.ts
+++ b/server/job/plexsync/index.ts
@@ -95,6 +95,9 @@ class JobPlexSync {
           });
           newMedia.tmdbId = tmdbMovie.id;
         }
+        if (!newMedia.tmdbId) {
+          throw new Error('Unable to find TMDB ID');
+        }
 
         const has4k = metadata.Media.some(
           (media) => media.videoResolution === '4k'


### PR DESCRIPTION
#### Description

In case movie for Plex movie agent library does not have tmdbid - try looking it up by imdbid. 

#### Screenshot (if UI related)

No UI changed

#### Todos

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

afaik, no issue for this
