### PR TITLE
feat(login): add request ip to the failed request log

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@supercharge/request-ip": "^1.1.2",
     "@svgr/webpack": "^5.5.0",
     "ace-builds": "^1.4.12",
     "axios": "^0.21.1",

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -151,6 +151,7 @@ authRoutes.post('/local', async (req, res, next) => {
       logger.info('Failed login attempt from user with incorrect credentials', {
         label: 'Auth',
         account: {
+          ip: req.ip,
           email: body.email,
           password: '__REDACTED__',
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,11 @@
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.2.tgz#9390a8127c0dcba61ebd7fdcc748655e191bdd68"
   integrity sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q==
 
+"@supercharge/request-ip@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@supercharge/request-ip/-/request-ip-1.1.2.tgz#be9083aa50d3c6fc200f3ed5919e0b9c13fc8842"
+  integrity sha512-mtryG/uiSIVT0ga8A/F9hNEuBSbDxW7/m9PEtxIHqdkE/vr766m17mtLPhrXA4q4T+Qw44+33mg3Rtkl7o+OvQ==
+
 "@svgr/babel-plugin-add-jsx-attribute@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz#81ef61947bb268eb9d50523446f9c638fb355906"


### PR DESCRIPTION
#### Description
add middleware to overwrite req.ip with the ip (can exist in a variety of places inside the request otherwise)
add the ip to the failed auth log on local user login
one of the tasks on #646 

#### Todos

- [x] Sucessfully builds `yarn build`
