### PR TITLE
build(armhf): Add libatomic1 to snap build for armhf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,6 +70,9 @@ parts:
       cp -R $SNAPCRAFT_PART_BUILD/node_modules $SNAPCRAFT_PART_INSTALL/
       # Remove .github and gitbook as it will fail snap lint
       rm -rf $SNAPCRAFT_PART_INSTALL/.github && rm $SNAPCRAFT_PART_INSTALL/.gitbook.yaml
+    stage-packages:
+      - on armhf:
+        - libatomic1
     stage:
       [ .next, ./* ]
     prime:


### PR DESCRIPTION
#### Description
This package seems to be a dependency to run overseerr on armhf platforms using snap. I am unable to test this past the syntax should be correct. 

