### PR TITLE
Setting up Fail2ban with Overseerr

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,4 +19,4 @@
 ## Extending Overseerr
 
 * [Reverse Proxy Examples](extending-overseerr/reverse-proxy-examples.md)
-* [Fail2ban Configuration](extending-overseerr/fail2ban.md)
+* [Fail2ban Filter](extending-overseerr/fail2ban.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,4 +18,5 @@
 
 ## Extending Overseerr
 
-- [Reverse Proxy Examples](extending-overseerr/reverse-proxy-examples.md)
+* [Reverse Proxy Examples](extending-overseerr/reverse-proxy-examples.md)
+* [Fail2ban Configuration](extending-overseerr/fail2ban.md)

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -1,0 +1,87 @@
+# Protecting Your Server Using Fail2ban
+
+{% hint style="warning" %}
+If your OS runs `firewalld`, make sure it is running and Overseerr is accessible before continue.
+{% endhint %}
+
+### Setting up Fail2ban
+
+After installing Fail2ban, the configuration files should be at `/etc/fail2ban`. Make a **copy** of `jail.conf` and `fail2ban.conf` to the same directoy, replacing the extension `.conf` with `.local`.
+
+Edit `jail.local` and under JAILS, paste the configuration below:
+
+```
+[overseerr]
+enabled         = true
+port            = 5055
+logpath         = /root/snap/overseerr/common/logs/overseerr.log
+filter          = overseerr
+maxretry        = 5
+findtime        = 120
+bantime         = 600
+#action         = iptables-allports
+action          = firewallcmd-allports
+#backend        = systemd
+```
+
+**logpath:** Path to the log file which is provided to the filter.
+**filter:** Name of the filter to be used by the jail to detect matches.
+**maxretry:** Number of matches that triggers ban action on the IP.
+**findtime:** The counter is set to zero if no match is found within "findtime" seconds.
+**bantime:** Duration (in seconds) for IP to be banned for. Negative number for "permanent" ban.
+
+By default, Fail2ban logs all its actions into `/var/log/fail2ban.log`. Although it's not recommended due to performance issues, you can change it to systemd (journalctl). For that, uncomment the last line of the configuration. Save the file and quit.
+
+Create the file `/etc/fail2ban/filter.d/overseerr.conf`, add the lines below, save and quit:
+
+```
+[Definition]
+failregex = .*\[info\]\[Auth\]\: Failed login attempt.*"ip":"<HOST>"
+```
+
+Enable automatic initialization and start Fail2ban:
+
+`
+systemctl --now enable fail2ban.service
+`
+
+### Testing Fail2ban
+
+Check if your configuration was loaded correctly issuing the command `fail2ban-client -d`. You should see something similar to it:
+
+```
+['set', 'syslogsocket', 'auto']
+['set', 'loglevel', 'INFO']
+['set', 'logtarget', '/var/log/fail2ban.log']
+['set', 'dbfile', '/var/lib/fail2ban/fail2ban.sqlite3']
+['set', 'dbmaxmatches', 10]
+['set', 'dbpurgeage', '1d']
+['add', 'overseerr', 'auto']
+['set', 'overseerr', 'usedns', 'warn']
+['set', 'overseerr', 'addfailregex', '.*\\[info\\]\\[Auth\\]\\: Failed login attempt.*"ip":"<HOST>"']
+['set', 'overseerr', 'maxretry', 5]
+['set', 'overseerr', 'maxmatches', 5]
+['set', 'overseerr', 'findtime', '120']
+['set', 'overseerr', 'bantime', '600']
+['set', 'overseerr', 'ignorecommand', '']
+['set', 'overseerr', 'logencoding', 'auto']
+['set', 'overseerr', 'addlogpath', '/root/snap/overseerr/common/logs/overseerr.log', 'head']
+['set', 'overseerr', 'addaction', 'firewallcmd-allports']
+['multi-set', 'overseerr', 'action', 'firewallcmd-allports', [['actionstart', 'firewall-cmd --direct --add-chain <family> filter f2b-overseerr\nfirewall-cmd --direct --add-rule <family> filter f2b-overseerr 1000 -j RETURN\nfirewall-cmd --direct --add-rule <family> filter INPUT_direct 0 -j f2b-overseerr'], ['actionstop', 'firewall-cmd --direct --remove-rule <family> filter INPUT_direct 0 -j f2b-overseerr\nfirewall-cmd --direct --remove-rules <family> filter f2b-overseerr\nfirewall-cmd --direct --remove-chain <family> filter f2b-overseerr'], ['actioncheck', "firewall-cmd --direct --get-chains <family> filter | sed -e 's, ,\\n,g' | grep -q '^f2b-overseerr$'"], ['actionban', 'firewall-cmd --direct --add-rule <family> filter f2b-overseerr 0 -s <ip> -j REJECT --reject-with <rejecttype>'], ['actionunban', 'firewall-cmd --direct --remove-rule <family> filter f2b-overseerr 0 -s <ip> -j REJECT --reject-with <rejecttype>'], ['name', 'overseerr'], ['actname', 'firewallcmd-allports'], ['port', '1:65535'], ['protocol', 'tcp'], ['family', 'ipv4'], ['chain', 'INPUT_direct'], ['zone', 'public'], ['service', 'ssh'], ['rejecttype', 'icmp-port-unreachable'], ['blocktype', 'REJECT --reject-with <rejecttype>'], ['rich-blocktype', "reject type='<rejecttype>'"], ['family?family=inet6', 'ipv6'], ['rejecttype?family=inet6', 'icmp6-port-unreachable']]]
+['start', 'overseerr']
+```
+
+{% hint style="danger" %}
+The login tries should be done from a different device (cellphone/tablet), otherwise, you will lock yourself out of the server for the X amount of time set up in your configuration files.
+{% endhint %}
+
+Now, running the command `tail -f /var/log/fail2ban.log`, access Overseerr and type a wrong password for a local user five times. I should see the messages below:
+
+`
+2021-01-24 21:22:34,085 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:34
+2021-01-24 21:22:35,688 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:35
+2021-01-24 21:22:36,622 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:36
+2021-01-24 21:22:38,559 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:38
+2021-01-24 21:22:41,264 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:41
+2021-01-24 21:22:41,444 fail2ban.actions        [756640]: NOTICE  [overseerr] Ban 172.88.220.196
+`

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -4,10 +4,6 @@
 If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
 {% endhint %}
 
-{% hint style="danger" %}
-If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
-{% endhint %}
-
 {% hint style="warning" %}
 If your OS runs `firewalld`, make sure it is running and that Overseerr is accessible before continuing.
 {% endhint %}

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -8,7 +8,7 @@ If your OS runs `firewalld`, make sure it is running and that Overseerr is acces
 
 After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make ***copies*** of `jail.conf` and `fail2ban.conf` in the same directoy, replacing the `.conf` extensions with `.local`.
 
-Next, open `jail.local` in a text editor.  Add the following jail configuration under `JAILS`:
+Next, open `jail.local` in a text editor.  Add the following jail configuration:
 
 ```
 [overseerr]

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -4,10 +4,6 @@
 If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
 {% endhint %}
 
-{% hint style="warning" %}
-If your OS runs `firewalld`, make sure it is running and that Overseerr is accessible before continuing.
-{% endhint %}
-
 ### Configuring Fail2ban
 
 After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make a copy of `jail.conf` in the same directory, replacing the `.conf` extensions with `.local`.

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -1,93 +1,14 @@
-# Protecting Your Server Using Fail2ban
+# Fail2ban Filter
 
 {% hint style="warning" %}
 If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
 {% endhint %}
 
-### Configuring Fail2ban
-
-After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make a copy of `jail.conf` in the same directory, replacing the `.conf` extensions with `.local`.
-
-Next, open `jail.local` in a text editor.  Add the following jail configuration:
-
-```
-[overseerr]
-enabled         = true
-port            = 5055
-logpath         = /path/to/overseerr.log
-filter          = overseerr
-maxretry        = 5
-findtime        = 120
-bantime         = 600
-#action         = iptables-allports
-action          = firewallcmd-allports
-#backend        = systemd
-```
-
-Parameter|Description
----|---
-`logpath`|Path to the log file to be parsed by the filter.
-`filter`|Name of the filter to be used to detect matches.
-`maxretry`|Number of matches required be found within `findtime` seconds to trigger a ban action.
-`findtime`|The time (in seconds) within which `maxretry` matches must be found to trigger a ban action.
-`bantime`|Duration (in seconds) to ban matched IP adresses which have exceeded the `maxretry` limit. Set to a negative value for "permanent" bans.
-
-By default, Fail2ban logs all its actions into `/var/log/fail2ban.log`. Although it's not recommended due to performance issues, you can change it to `systemd` (`journalctl`) by uncommenting the last line of the configuration.
-
-Save the file and exit your text editor.
-
-Now, create the file `/etc/fail2ban/filter.d/overseerr.conf` and add the following:
+To use Fail2ban with Overseerr, create a new file named `overseerr.local` in your Fail2ban `filter.d` directory with the following filter definition:
 
 ```
 [Definition]
 failregex = .*\[info\]\[Auth\]\: Failed login attempt.*"ip":"<HOST>"
 ```
 
-Once again, save the file and exit your text editor.
-
-Finally, enable automatic initialization and start Fail2ban by running the following command:
-
-```bash
-systemctl --now enable fail2ban.service
-```
-
-### Testing Fail2ban
-
-Check if your configuration was loaded correctly by issuing the command `fail2ban-client -d`. You should see something similar to the following:
-
-```
-['set', 'syslogsocket', 'auto']
-['set', 'loglevel', 'INFO']
-['set', 'logtarget', '/var/log/fail2ban.log']
-['set', 'dbfile', '/var/lib/fail2ban/fail2ban.sqlite3']
-['set', 'dbmaxmatches', 10]
-['set', 'dbpurgeage', '1d']
-['add', 'overseerr', 'auto']
-['set', 'overseerr', 'usedns', 'warn']
-['set', 'overseerr', 'addfailregex', '.*\\[info\\]\\[Auth\\]\\: Failed login attempt.*"ip":"<HOST>"']
-['set', 'overseerr', 'maxretry', 5]
-['set', 'overseerr', 'maxmatches', 5]
-['set', 'overseerr', 'findtime', '120']
-['set', 'overseerr', 'bantime', '600']
-['set', 'overseerr', 'ignorecommand', '']
-['set', 'overseerr', 'logencoding', 'auto']
-['set', 'overseerr', 'addlogpath', '/root/snap/overseerr/common/logs/overseerr.log', 'head']
-['set', 'overseerr', 'addaction', 'firewallcmd-allports']
-['multi-set', 'overseerr', 'action', 'firewallcmd-allports', [['actionstart', 'firewall-cmd --direct --add-chain <family> filter f2b-overseerr\nfirewall-cmd --direct --add-rule <family> filter f2b-overseerr 1000 -j RETURN\nfirewall-cmd --direct --add-rule <family> filter INPUT_direct 0 -j f2b-overseerr'], ['actionstop', 'firewall-cmd --direct --remove-rule <family> filter INPUT_direct 0 -j f2b-overseerr\nfirewall-cmd --direct --remove-rules <family> filter f2b-overseerr\nfirewall-cmd --direct --remove-chain <family> filter f2b-overseerr'], ['actioncheck', "firewall-cmd --direct --get-chains <family> filter | sed -e 's, ,\\n,g' | grep -q '^f2b-overseerr$'"], ['actionban', 'firewall-cmd --direct --add-rule <family> filter f2b-overseerr 0 -s <ip> -j REJECT --reject-with <rejecttype>'], ['actionunban', 'firewall-cmd --direct --remove-rule <family> filter f2b-overseerr 0 -s <ip> -j REJECT --reject-with <rejecttype>'], ['name', 'overseerr'], ['actname', 'firewallcmd-allports'], ['port', '1:65535'], ['protocol', 'tcp'], ['family', 'ipv4'], ['chain', 'INPUT_direct'], ['zone', 'public'], ['service', 'ssh'], ['rejecttype', 'icmp-port-unreachable'], ['blocktype', 'REJECT --reject-with <rejecttype>'], ['rich-blocktype', "reject type='<rejecttype>'"], ['family?family=inet6', 'ipv6'], ['rejecttype?family=inet6', 'icmp6-port-unreachable']]]
-['start', 'overseerr']
-```
-
-{% hint style="danger" %}
-The login attempts in the next step should be initiated from a secondary device (e.g., a cellphone or tablet). Otherwise, you may lock yourself out of your server for the `bantime` defined in `jail.local`.
-{% endhint %}
-
-Now, while running the command `tail -f /var/log/fail2ban.log`, attempt to log in as a local user to Overseerr using an incorrect password `maxretry` times. You should see output similar to the following:
-
-```
-2021-01-24 21:22:34,085 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:34
-2021-01-24 21:22:35,688 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:35
-2021-01-24 21:22:36,622 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:36
-2021-01-24 21:22:38,559 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:38
-2021-01-24 21:22:41,264 fail2ban.filter         [756640]: INFO    [overseerr] Found 172.88.220.196 - 2021-01-24 21:22:41
-2021-01-24 21:22:41,444 fail2ban.actions        [756640]: NOTICE  [overseerr] Ban 172.88.220.196
-```
+You can then add a jail using this filter in `jail.local`.  Please see the [Fail2ban documetation](https://www.fail2ban.org/wiki/index.php/Manual) for details on how to configure the jail.

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -14,7 +14,7 @@ Next, open `jail.local` in a text editor.  Add the following jail configuration 
 [overseerr]
 enabled         = true
 port            = 5055
-logpath         = /root/snap/overseerr/common/logs/overseerr.log
+logpath         = /path/to/overseerr.log
 filter          = overseerr
 maxretry        = 5
 findtime        = 120

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -6,7 +6,7 @@ If your OS runs `firewalld`, make sure it is running and that Overseerr is acces
 
 ### Configuring Fail2ban
 
-After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make ***copies*** of `jail.conf` and `fail2ban.conf` in the same directoy, replacing the `.conf` extensions with `.local`.
+After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make a copy of `jail.conf` in the same directoy, replacing the `.conf` extensions with `.local`.
 
 Next, open `jail.local` in a text editor.  Add the following jail configuration:
 

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -1,5 +1,9 @@
 # Protecting Your Server Using Fail2ban
 
+{% hint style="warning" %}
+If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
+{% endhint %}
+
 {% hint style="danger" %}
 If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
 {% endhint %}

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -1,7 +1,7 @@
 # Fail2ban Filter
 
 {% hint style="warning" %}
-If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
+If you are running Overseerr behind a reverse proxy, make sure that the `PROXY` environment variable is set to `yes`.
 {% endhint %}
 
 To use Fail2ban with Overseerr, create a new file named `overseerr.local` in your Fail2ban `filter.d` directory with the following filter definition:

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -11,4 +11,4 @@ To use Fail2ban with Overseerr, create a new file named `overseerr.local` in you
 failregex = .*\[info\]\[Auth\]\: Failed login attempt.*"ip":"<HOST>"
 ```
 
-You can then add a jail using this filter in `jail.local`.  Please see the [Fail2ban documetation](https://www.fail2ban.org/wiki/index.php/Manual) for details on how to configure the jail.
+You can then add a jail using this filter in `jail.local`.  Please see the [Fail2ban documetation](https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jails) for details on how to configure the jail.

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -1,5 +1,9 @@
 # Protecting Your Server Using Fail2ban
 
+{% hint style="danger" %}
+If you are running Overseerr in a Docker container, make sure that the `PROXY` environment variable is set to `yes`.
+{% endhint %}
+
 {% hint style="warning" %}
 If your OS runs `firewalld`, make sure it is running and that Overseerr is accessible before continuing.
 {% endhint %}

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -6,7 +6,7 @@ If your OS runs `firewalld`, make sure it is running and that Overseerr is acces
 
 ### Configuring Fail2ban
 
-After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make a copy of `jail.conf` in the same directoy, replacing the `.conf` extensions with `.local`.
+After installing Fail2ban, the configuration files should be located at `/etc/fail2ban`. Make a copy of `jail.conf` in the same directory, replacing the `.conf` extensions with `.local`.
 
 Next, open `jail.local` in a text editor.  Add the following jail configuration:
 


### PR DESCRIPTION
#### Description
This is a tutorial on how to setup fail2ban to protect Overseerr servers from brute-force attacks.

#### Issues Fixed or Closed by this PR

Users will be able to take advantage of the feature added via PR #714 