### PR TITLE
fix(ip logging): add env var for proxy to fix ip logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ## Getting Started
 
-Check out our documenation for steps on how to install and run Overseerr:
+Check out our documentation for steps on how to install and run Overseerr:
 
 https://docs.overseerr.dev/getting-started/installation
 
@@ -58,6 +58,7 @@ Currently, Overseerr is only distributed through Docker images. If you have Dock
 docker run -d \
   -e LOG_LEVEL=info \
   -e TZ=Asia/Tokyo \
+  -e PROXY=<yes|no>
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \

--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -10,7 +10,7 @@ Base URLs cannot be configured in Overseerr. With this limitation, only subdomai
 
 A sample is bundled in SWAG. This page is still the only source of truth, so the sample is not guaranteed to be up to date. If you catch an inconsistency, report it to the linuxserver team, or do a pull-request against the proxy-confs repository to update the sample.
 
-Rename the sample file `overseerr.subdomain.conf.sample` to `overseerr.subdomain.conf` in the `proxy-confs`folder, or create `overseerr.subdomain.conf` in the same folder with the example below. 
+Rename the sample file `overseerr.subdomain.conf.sample` to `overseerr.subdomain.conf` in the `proxy-confs`folder, or create `overseerr.subdomain.conf` in the same folder with the example below.
 
 Example Configuration:
 
@@ -122,6 +122,8 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     # Prevent Sniff Mimetype (X-Content-Type-Options)
     add_header X-Content-Type-Options "nosniff" always;
+    # Tell crawling bots to not index the site
+    add_header X-Robots-Tag "noindex, nofollow" always;
 
     access_log /var/log/nginx/overseerr.example.com-access.log;
     error_log /var/log/nginx/overseerr.example.com-error.log;
@@ -131,4 +133,3 @@ server {
     }
 }
 ```
-

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,6 +17,7 @@ After running Overseerr for the first time, configure it by visiting the web UI 
 docker run -d \
   -e LOG_LEVEL=info \
   -e TZ=Asia/Tokyo \
+  -e PROXY=<yes|no> \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \
@@ -32,6 +33,7 @@ docker run -d \
   --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ] \
   -e LOG_LEVEL=info \
   -e TZ=Asia/Tokyo \
+  -e PROXY=<yes|no> \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \

--- a/server/index.ts
+++ b/server/index.ts
@@ -61,6 +61,9 @@ app
     startJobs();
 
     const server = express();
+    if (process.env.PROXY === 'yes') {
+      server.enable('trust proxy');
+    }
     server.use(cookieParser());
     server.use(bodyParser.json());
     server.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
#### Description
adds support for passing `PROXY` as an env var, which will be used to enable trusting proxy in express. This is required for the ip logging of failed authentication requests to work correctly.

#### Todos

- [x] Sucessfully builds `yarn build`

#### Issues Fixed or Closed by this PR

- Closes #752 
