### PR TITLE
feat(tv): show cast for the entire show instead of only the last season

### DIFF
--- a/server/api/themoviedb.ts
+++ b/server/api/themoviedb.ts
@@ -126,6 +126,14 @@ export interface TmdbCreditCast {
   profile_path?: string;
 }
 
+export interface TmdbAggregateCreditCast extends TmdbCreditCast {
+  roles: {
+    credit_id: string;
+    character: string;
+    episode_count: number;
+  }[];
+}
+
 export interface TmdbCreditCrew {
   credit_id: string;
   gender?: number;
@@ -293,8 +301,10 @@ export interface TmdbTvDetails {
   type: string;
   vote_average: number;
   vote_count: number;
+  aggregate_credits: {
+    cast: TmdbAggregateCreditCast[];
+  };
   credits: {
-    cast: TmdbCreditCast[];
     crew: TmdbCreditCrew[];
   };
   external_ids: TmdbExternalIds;
@@ -499,7 +509,8 @@ class TheMovieDb {
       const response = await this.axios.get<TmdbTvDetails>(`/tv/${tvId}`, {
         params: {
           language,
-          append_to_response: 'credits,external_ids,keywords,videos',
+          append_to_response:
+            'aggregate_credits,credits,external_ids,keywords,videos',
         },
       });
 

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -3,7 +3,7 @@ import {
   ProductionCompany,
   Cast,
   Crew,
-  mapCast,
+  mapAggregateCast,
   mapCrew,
   ExternalIds,
   mapExternalIds,
@@ -193,7 +193,7 @@ export const mapTvDetails = (
     : undefined,
   posterPath: show.poster_path,
   credits: {
-    cast: show.credits.cast.map(mapCast),
+    cast: show.aggregate_credits.cast.map(mapAggregateCast),
     crew: show.credits.crew.map(mapCrew),
   },
   externalIds: mapExternalIds(show.external_ids),

--- a/server/models/common.ts
+++ b/server/models/common.ts
@@ -1,5 +1,6 @@
 import {
   TmdbCreditCast,
+  TmdbAggregateCreditCast,
   TmdbCreditCrew,
   TmdbExternalIds,
   TmdbVideo,
@@ -61,6 +62,18 @@ export const mapCast = (person: TmdbCreditCast): Cast => ({
   castId: person.cast_id,
   character: person.character,
   creditId: person.credit_id,
+  id: person.id,
+  name: person.name,
+  order: person.order,
+  gender: person.gender,
+  profilePath: person.profile_path,
+});
+
+export const mapAggregateCast = (person: TmdbAggregateCreditCast): Cast => ({
+  castId: person.cast_id,
+  // the first role is the one for which the actor appears the most as
+  character: person.roles[0].character,
+  creditId: person.roles[0].credit_id,
   id: person.id,
   name: person.name,
   order: person.order,


### PR DESCRIPTION
This uses TMDb's `aggregate_credits` instead of `credits` to get the show's cast for all seasons.

Fixes #775
