### PR TITLE
build(snap): Fix snap to pull from latest master [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        run: git checkout HEAD
 
       - name: Prepare
         id: prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,10 @@ jobs:
           - armhf
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
-        run: git checkout HEAD
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git checkout master
 
       - name: Prepare
         id: prepare


### PR DESCRIPTION
#### Description
Add `git checkout HEAD` to snap job to pull latest master. 

