### PR TITLE
fix(readme): Remove PROXY env var and correct grammar/inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
-**Overseerr** is a free and open source software application for managing requests for your media library. It integrates with your existing services such as **Sonarr**, **Radarr** and **Plex**!
+**Overseerr** is a free and open source software application for managing requests for your media library. It integrates with your existing services such as **[Sonarr](https://sonarr.tv/)**, **[Radarr](https://radarr.video/)** and **[Plex](https://www.plex.tv/)**!
 
 ## Current Features
 
 - Full Plex integration. Login and manage user access with Plex!
-- Integrates easily with your existing services. Currently Overseerr supports Sonarr and Radarr. More to come!
-- Syncs to your Plex library to know what titles you already have.
+- Easy integration with your existing services. Currently Overseerr supports Sonarr and Radarr. More to come!
+- Plex libraries sync to know what titles you already have.
 - Complex request system allowing users to request individual seasons or movies in a friendly, easy to use UI.
-- Incredibly simple request management UI. Don't dig through the app to simply approve recent requests.
-- Granular permission system
-- Mobile friendly design, for when you need to approve requests on the go!
+- Incredibly simple request management UI. Don't dig through the app to simply approve recent requests!
+- Granular permission system.
+- Mobile-friendly design, for when you need to approve requests on the go!
 
 ## In Development
 
@@ -46,13 +46,13 @@
 
 ## Getting Started
 
-Check out our documentation for steps on how to install and run Overseerr:
+Check out our documentation for instructions on how to install and run Overseerr:
 
 https://docs.overseerr.dev/getting-started/installation
 
 ## Running Overseerr
 
-Currently, Overseerr is only distributed through Docker images. If you have Docker, you can run Overseerr as per:
+Currently, Overseerr is primarily distributed as Docker images. If you have Docker, you can run Overseerr with:
 
 ```
 docker run -d \
@@ -66,7 +66,7 @@ docker run -d \
 
 After running Overseerr for the first time, configure it by visiting the web UI at http://[address]:5055 and completing the setup steps.
 
-⚠️ Overseerr is currently under very heavy, rapid development and things are likely to break often. We need all the help we can get to find bugs and get them fixed to hit a more stable release. If you would like to help test the bleeding edge, please use the image **sctx/overseerr:develop** instead! ⚠️
+⚠️ Overseerr is currently under very heavy, rapid development and things are likely to break often. We need all the help we can get to find bugs and get them fixed to hit a more stable release. If you would like to help test the bleeding edge, please use the `sctx/overseerr:develop` image instead! ⚠️
 
 ## Preview
 
@@ -77,7 +77,7 @@ After running Overseerr for the first time, configure it by visiting the web UI 
 - Check out the [Overseerr Documentation](https://docs.overseerr.dev/) before asking for help. Your question might already be in the [FAQ](https://docs.overseerr.dev/support/faq).
 - You can get support on [Discord](https://discord.gg/PkCWJSeCk7).
 - You can ask questions in the Help category of our [GitHub Discussions](https://github.com/sct/overseerr/discussions).
-- Bugs/Feature Requests can be opened via a [GitHub issue](https://github.com/sct/overseerr/issues).
+- Bug reports and feature requests can be submitted via [GitHub Issues](https://github.com/sct/overseerr/issues).
 
 ## API Documentation
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Currently, Overseerr is only distributed through Docker images. If you have Dock
 docker run -d \
   -e LOG_LEVEL=info \
   -e TZ=Asia/Tokyo \
-  -e PROXY=<yes|no>
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \


### PR DESCRIPTION
#### Description

`-e PROXY=<yes|no>` needs to be removed from `README.md` now that the setting has been moved to the UI.  (Also, it was missing a trailing `\` to escape the newline before. 😜)

Also added links to Sonarr, Radarr, and Plex and fixed some grammar errors/inconsistencies.

Do we want to mention the availability of Docker images on GitHub Container Registry (GHCR)?

#### Screenshot (if UI related)

N/A