### PR TITLE
fix(lang): Translate language names & change zh-Hant language code to zh-TW

### DIFF
--- a/src/components/Layout/LanguagePicker/index.tsx
+++ b/src/components/Layout/LanguagePicker/index.tsx
@@ -17,61 +17,61 @@ type AvailableLanguageObject = Record<
 >;
 
 const availableLanguages: AvailableLanguageObject = {
+  de: {
+    code: 'de',
+    display: 'Deutsch',
+  },
   en: {
     code: 'en',
     display: 'English',
   },
-  ja: {
-    code: 'ja',
-    display: 'Japanese',
+  es: {
+    code: 'es',
+    display: 'Español',
   },
   fr: {
     code: 'fr',
     display: 'Français',
   },
-  'nb-NO': {
-    code: 'nb-NO',
-    display: 'Norwegian Bokmål',
-  },
-  de: {
-    code: 'de',
-    display: 'German',
-  },
-  ru: {
-    code: 'ru',
-    display: 'Russian',
+  it: {
+    code: 'it',
+    display: 'Italiano',
   },
   nl: {
     code: 'nl',
     display: 'Nederlands',
   },
-  es: {
-    code: 'es',
-    display: 'Spanish',
-  },
-  it: {
-    code: 'it',
-    display: 'Italian',
+  'nb-NO': {
+    code: 'nb-NO',
+    display: 'Norsk Bokmål',
   },
   'pt-BR': {
     code: 'pt-BR',
-    display: 'Portuguese (Brazil)',
+    display: 'Português (Brasil)',
   },
   'pt-PT': {
     code: 'pt-PT',
-    display: 'Portuguese (Portugal)',
-  },
-  sr: {
-    code: 'sr',
-    display: 'Serbian',
+    display: 'Português (Portugal)',
   },
   sv: {
     code: 'sv',
-    display: 'Swedish',
+    display: 'Svenska',
   },
-  'zh-Hant': {
-    code: 'zh-Hant',
-    display: 'Chinese (Traditional)',
+  ru: {
+    code: 'ru',
+    display: 'pусский',
+  },
+  sr: {
+    code: 'sr',
+    display: 'српски језик‬',
+  },
+  ja: {
+    code: 'ja',
+    display: '日本語',
+  },
+  'zh-TW': {
+    code: 'zh-TW',
+    display: '中文（臺灣）',
   },
 };
 

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,20 +1,20 @@
 import React, { ReactNode } from 'react';
 
 export type AvailableLocales =
+  | 'de'
   | 'en'
+  | 'es'
+  | 'it'
   | 'ja'
   | 'fr'
   | 'nb-NO'
-  | 'de'
-  | 'ru'
   | 'nl'
-  | 'es'
-  | 'it'
   | 'pt-BR'
   | 'pt-PT'
+  | 'ru'
   | 'sr'
   | 'sv'
-  | 'zh-Hant';
+  | 'zh-TW';
 
 interface LanguageContextProps {
   locale: AvailableLocales;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,31 +20,31 @@ import { SettingsProvider } from '../context/SettingsContext';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loadLocaleData = (locale: AvailableLocales): Promise<any> => {
   switch (locale) {
-    case 'ja':
-      return import('../i18n/locale/ja.json');
-    case 'fr':
-      return import('../i18n/locale/fr.json');
-    case 'nb-NO':
-      return import('../i18n/locale/nb_NO.json');
     case 'de':
       return import('../i18n/locale/de.json');
-    case 'ru':
-      return import('../i18n/locale/ru.json');
-    case 'nl':
-      return import('../i18n/locale/nl.json');
     case 'es':
       return import('../i18n/locale/es.json');
+    case 'fr':
+      return import('../i18n/locale/fr.json');
     case 'it':
       return import('../i18n/locale/it.json');
+    case 'ja':
+      return import('../i18n/locale/ja.json');
+    case 'nb-NO':
+      return import('../i18n/locale/nb_NO.json');
+    case 'nl':
+      return import('../i18n/locale/nl.json');
     case 'pt-BR':
       return import('../i18n/locale/pt_BR.json');
     case 'pt-PT':
       return import('../i18n/locale/pt_PT.json');
+    case 'ru':
+      return import('../i18n/locale/ru.json');
     case 'sr':
       return import('../i18n/locale/sr.json');
     case 'sv':
       return import('../i18n/locale/sv.json');
-    case 'zh-Hant':
+    case 'zh-TW':
       return import('../i18n/locale/zh_Hant.json');
     default:
       return import('../i18n/locale/en.json');


### PR DESCRIPTION
#### Description

Display language names in their respective languages in the language picker/dropdown, and order them alphabetically.

Also, correct the `zh-Hant` language code to `zh-TW`, which is what is expected by the TMDb API.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/52870424/106374724-a8c74880-6353-11eb-8c64-fb0a92c9f045.png)

#### Todos

- [x] Successful build