### PR TITLE
fix(ui): Don't display empty dropdown when no trailer available

### DIFF
--- a/src/components/Common/ButtonWithDropdown/index.tsx
+++ b/src/components/Common/ButtonWithDropdown/index.tsx
@@ -92,8 +92,8 @@ const ButtonWithDropdown: React.FC<ButtonWithDropdownProps> = ({
       >
         {text}
       </button>
-      <span className="relative z-10 block -ml-px">
-        {children && (
+      {children && (
+        <span className="relative z-10 block -ml-px">
           <button
             type="button"
             className={`relative inline-flex items-center h-full px-2 py-2 text-sm font-medium leading-5 text-white transition duration-150 ease-in-out rounded-r-md focus:z-10 ${styleClasses.dropdownSideButtonClasses}`}
@@ -117,25 +117,25 @@ const ButtonWithDropdown: React.FC<ButtonWithDropdownProps> = ({
               </svg>
             )}
           </button>
-        )}
-        <Transition
-          show={isOpen}
-          enter="transition ease-out duration-100 opacity-0"
-          enterFrom="transform opacity-0 scale-95"
-          enterTo="transform opacity-100 scale-100"
-          leave="transition ease-in duration-75 opacity-100"
-          leaveFrom="transform opacity-100 scale-100"
-          leaveTo="transform opacity-0 scale-95"
-        >
-          <div className="absolute right-0 w-56 mt-2 -mr-1 origin-top-right rounded-md shadow-lg">
-            <div
-              className={`rounded-md ring-1 ring-black ring-opacity-5 ${styleClasses.dropdownClasses}`}
-            >
-              <div className="py-1">{children}</div>
+          <Transition
+            show={isOpen}
+            enter="transition ease-out duration-100 opacity-0"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75 opacity-100"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <div className="absolute right-0 w-56 mt-2 -mr-1 origin-top-right rounded-md shadow-lg">
+              <div
+                className={`rounded-md ring-1 ring-black ring-opacity-5 ${styleClasses.dropdownClasses}`}
+              >
+                <div className="py-1">{children}</div>
+              </div>
             </div>
-          </div>
-        </Transition>
-      </span>
+          </Transition>
+        </span>
+      )}
     </span>
   );
 };

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -417,10 +417,17 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
                 }
               }}
             >
-              {data.mediaInfo?.plexUrl ||
-              (data.mediaInfo?.plexUrl4k &&
-                (hasPermission(Permission.REQUEST_4K) ||
-                  hasPermission(Permission.REQUEST_4K_MOVIE))) ? (
+              {(
+                trailerUrl
+                  ? data.mediaInfo?.plexUrl ||
+                    (data.mediaInfo?.plexUrl4k &&
+                      (hasPermission(Permission.REQUEST_4K) ||
+                        hasPermission(Permission.REQUEST_4K_MOVIE)))
+                  : data.mediaInfo?.plexUrl &&
+                    data.mediaInfo?.plexUrl4k &&
+                    (hasPermission(Permission.REQUEST_4K) ||
+                      hasPermission(Permission.REQUEST_4K_MOVIE))
+              ) ? (
                 <>
                   {data.mediaInfo?.plexUrl &&
                     data.mediaInfo?.plexUrl4k &&
@@ -435,17 +442,16 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
                         {intl.formatMessage(messages.play4konplex)}
                       </ButtonWithDropdown.Item>
                     )}
-                  {(data.mediaInfo?.plexUrl || data.mediaInfo?.plexUrl4k) &&
-                    trailerUrl && (
-                      <ButtonWithDropdown.Item
-                        onClick={() => {
-                          window.open(trailerUrl, '_blank');
-                        }}
-                        buttonType="ghost"
-                      >
-                        {intl.formatMessage(messages.watchtrailer)}
-                      </ButtonWithDropdown.Item>
-                    )}
+                  {trailerUrl && (
+                    <ButtonWithDropdown.Item
+                      onClick={() => {
+                        window.open(trailerUrl, '_blank');
+                      }}
+                      buttonType="ghost"
+                    >
+                      {intl.formatMessage(messages.watchtrailer)}
+                    </ButtonWithDropdown.Item>
+                  )}
                 </>
               ) : null}
             </ButtonWithDropdown>

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -443,35 +443,41 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
                 }
               }}
             >
-              {data.mediaInfo?.plexUrl ||
-              (data.mediaInfo?.plexUrl4k &&
-                (hasPermission(Permission.REQUEST_4K) ||
-                  hasPermission(Permission.REQUEST_4K_TV))) ? (
-                <>
-                  {data.mediaInfo?.plexUrl &&
+              {(
+                trailerUrl
+                  ? data.mediaInfo?.plexUrl ||
+                    (data.mediaInfo?.plexUrl4k &&
+                      (hasPermission(Permission.REQUEST_4K) ||
+                        hasPermission(Permission.REQUEST_4K_TV)))
+                  : data.mediaInfo?.plexUrl &&
                     data.mediaInfo?.plexUrl4k &&
                     (hasPermission(Permission.REQUEST_4K) ||
-                      hasPermission(Permission.REQUEST_4K_TV)) && (
-                      <ButtonWithDropdown.Item
-                        onClick={() => {
-                          window.open(data.mediaInfo?.plexUrl4k, '_blank');
-                        }}
-                        buttonType="ghost"
-                      >
-                        {intl.formatMessage(messages.play4konplex)}
-                      </ButtonWithDropdown.Item>
-                    )}
-                  {(data.mediaInfo?.plexUrl || data.mediaInfo?.plexUrl4k) &&
-                    trailerUrl && (
-                      <ButtonWithDropdown.Item
-                        onClick={() => {
-                          window.open(trailerUrl, '_blank');
-                        }}
-                        buttonType="ghost"
-                      >
-                        {intl.formatMessage(messages.watchtrailer)}
-                      </ButtonWithDropdown.Item>
-                    )}
+                      hasPermission(Permission.REQUEST_4K_TV))
+              ) ? (
+                <>
+                  {data.mediaInfo?.plexUrl &&
+                  data.mediaInfo?.plexUrl4k &&
+                  (hasPermission(Permission.REQUEST_4K) ||
+                    hasPermission(Permission.REQUEST_4K_TV)) ? (
+                    <ButtonWithDropdown.Item
+                      onClick={() => {
+                        window.open(data.mediaInfo?.plexUrl4k, '_blank');
+                      }}
+                      buttonType="ghost"
+                    >
+                      {intl.formatMessage(messages.play4konplex)}
+                    </ButtonWithDropdown.Item>
+                  ) : null}
+                  {trailerUrl ? (
+                    <ButtonWithDropdown.Item
+                      onClick={() => {
+                        window.open(trailerUrl, '_blank');
+                      }}
+                      buttonType="ghost"
+                    >
+                      {intl.formatMessage(messages.watchtrailer)}
+                    </ButtonWithDropdown.Item>
+                  ) : null}
                 </>
               ) : null}
             </ButtonWithDropdown>


### PR DESCRIPTION
#### Description

Currently, when an item is available on Plex but there is no trailer available, an empty dropdown is shown.  This PR fixes that behavior.

#### Screenshot (if UI related)

Current:
![image](https://user-images.githubusercontent.com/52870424/106503743-0bbff900-6494-11eb-8e94-0b3c780f5d1c.png)

Fixed:
![image](https://user-images.githubusercontent.com/52870424/106503762-11b5da00-6494-11eb-9a49-1c964c0a028f.png)

#### Todos

- [x] Successful build `docker build`

#### Issues Fixed or Closed by this PR

- Fixes #787