### PR TITLE
fix(ui): Restore original port input size

### DIFF
--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -365,6 +365,7 @@ const RadarrModal: React.FC<RadarrModalProps> = ({
                       name="port"
                       type="text"
                       placeholder="7878"
+                      className="port"
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setIsValidated(false);
                         setFieldValue('port', e.target.value);

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -491,6 +491,7 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
                       id="port"
                       name="port"
                       placeholder="32400"
+                      className="port"
                     />
                   </div>
                   {errors.port && touched.port && (

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -372,6 +372,7 @@ const SonarrModal: React.FC<SonarrModalProps> = ({
                       name="port"
                       type="text"
                       placeholder="8989"
+                      className="port"
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setIsValidated(false);
                         setFieldValue('port', e.target.value);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -89,6 +89,10 @@ select.rounded-r-only {
   @apply rounded-l-none;
 }
 
+input.port {
+  @apply w-24;
+}
+
 .protocol {
   @apply inline-flex items-center px-3 text-gray-100 bg-gray-600 border border-r-0 border-gray-500 cursor-default rounded-l-md sm:text-sm;
 }


### PR DESCRIPTION
#### Description

Size of the "port" text input fields in Plex, Sonarr, and Radarr settings should have class `w-24`.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/52870424/106574224-a2c69880-6508-11eb-8656-68b23f261859.png)