### PR TITLE
feat(ui): Add local login setting

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -71,6 +71,9 @@ components:
         hideAvailable:
           type: boolean
           example: false
+        localLogin:
+          type: boolean
+          example: true
         defaultPermissions:
           type: number
           example: 32

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -10,6 +10,7 @@ export interface PublicSettingsResponse {
   movie4kEnabled: boolean;
   series4kEnabled: boolean;
   hideAvailable: boolean;
+  localLogin: boolean;
 }
 
 export interface CacheItem {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -54,6 +54,7 @@ export interface MainSettings {
   csrfProtection: boolean;
   defaultPermissions: number;
   hideAvailable: boolean;
+  localLogin: boolean;
   trustProxy: boolean;
 }
 
@@ -65,6 +66,7 @@ interface FullPublicSettings extends PublicSettings {
   movie4kEnabled: boolean;
   series4kEnabled: boolean;
   hideAvailable: boolean;
+  localLogin: boolean;
 }
 
 export interface NotificationAgentConfig {
@@ -162,6 +164,7 @@ class Settings {
         csrfProtection: false,
         defaultPermissions: Permission.REQUEST,
         hideAvailable: false,
+        localLogin: true,
         trustProxy: false,
       },
       plex: {
@@ -296,6 +299,7 @@ class Settings {
         (sonarr) => sonarr.is4k && sonarr.isDefault
       ),
       hideAvailable: this.data.main.hideAvailable,
+      localLogin: this.data.main.localLogin,
     };
   }
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -134,10 +134,13 @@ authRoutes.post('/login', async (req, res, next) => {
 });
 
 authRoutes.post('/local', async (req, res, next) => {
+  const settings = getSettings();
   const userRepository = getRepository(User);
   const body = req.body as { email?: string; password?: string };
 
-  if (!body.email || !body.password) {
+  if (!settings.main.localLogin) {
+    return res.status(500).json({ error: 'Local user login is disabled' });
+  } else if (!body.email || !body.password) {
     return res
       .status(500)
       .json({ error: 'You must provide an email and a password' });

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -9,6 +9,7 @@ import Transition from '../Transition';
 import LanguagePicker from '../Layout/LanguagePicker';
 import LocalLogin from './LocalLogin';
 import Accordion from '../Common/Accordion';
+import useSettings from '../../hooks/useSettings';
 
 const messages = defineMessages({
   signinheader: 'Sign in to continue',
@@ -23,6 +24,7 @@ const Login: React.FC = () => {
   const [authToken, setAuthToken] = useState<string | undefined>(undefined);
   const { user, revalidate } = useUser();
   const router = useRouter();
+  const settings = useSettings();
 
   // Effect that is triggered when the `authToken` comes back from the Plex OAuth
   // We take the token and attempt to login. If we get a success message, we will
@@ -124,10 +126,14 @@ const Login: React.FC = () => {
               {({ openIndexes, handleClick, AccordionContent }) => (
                 <>
                   <button
-                    className={`text-sm w-full focus:outline-none transition-colors duration-200 py-2 bg-gray-800 hover:bg-gray-700 bg-opacity-70 hover:bg-opacity-70 sm:rounded-t-lg text-center text-gray-400 ${
+                    className={`w-full py-2 text-sm text-center text-gray-400 transition-colors duration-200 bg-gray-800 cursor-default focus:outline-none bg-opacity-70 sm:rounded-t-lg ${
                       openIndexes.includes(0) && 'text-indigo-500'
+                    } ${
+                      settings.currentSettings.localLogin &&
+                      'hover:bg-gray-700 hover:cursor-pointer'
                     }`}
                     onClick={() => handleClick(0)}
+                    disabled={!settings.currentSettings.localLogin}
                   >
                     {intl.formatMessage(messages.signinwithplex)}
                   </button>
@@ -139,21 +145,25 @@ const Login: React.FC = () => {
                       />
                     </div>
                   </AccordionContent>
-                  <button
-                    className={`text-sm w-full focus:outline-none transition-colors duration-200 py-2 bg-gray-800 hover:bg-gray-700 bg-opacity-70 hover:bg-opacity-70 text-center text-gray-400 ${
-                      openIndexes.includes(1)
-                        ? 'text-indigo-500'
-                        : 'sm:rounded-b-lg '
-                    }`}
-                    onClick={() => handleClick(1)}
-                  >
-                    {intl.formatMessage(messages.signinwithoverseerr)}
-                  </button>
-                  <AccordionContent isOpen={openIndexes.includes(1)}>
-                    <div className="px-10 py-8">
-                      <LocalLogin revalidate={revalidate} />
+                  {settings.currentSettings.localLogin && (
+                    <div>
+                      <button
+                        className={`w-full py-2 text-sm text-center text-gray-400 transition-colors duration-200 bg-gray-800 cursor-default focus:outline-none bg-opacity-70 sm:rounded-t-lg hover:bg-gray-700 hover:cursor-pointer ${
+                          openIndexes.includes(1)
+                            ? 'text-indigo-500'
+                            : 'sm:rounded-b-lg '
+                        }`}
+                        onClick={() => handleClick(1)}
+                      >
+                        {intl.formatMessage(messages.signinwithoverseerr)}
+                      </button>
+                      <AccordionContent isOpen={openIndexes.includes(1)}>
+                        <div className="px-10 py-8">
+                          <LocalLogin revalidate={revalidate} />
+                        </div>
+                      </AccordionContent>
                     </div>
-                  </AccordionContent>
+                  )}
                 </>
               )}
             </Accordion>

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -35,6 +35,9 @@ const messages = defineMessages({
   trustProxy: 'Enable Proxy Support',
   trustProxyTip:
     'Allows Overseerr to correctly register client IP addresses behind a proxy (Overseerr must be reloaded for changes to take effect)',
+  localLogin: 'Enable Local User Sign-In',
+  localLoginTip:
+    'Disabling this option only prevents new sign-ins (no user data is deleted)',
 });
 
 const SettingsMain: React.FC = () => {
@@ -83,6 +86,7 @@ const SettingsMain: React.FC = () => {
             csrfProtection: data?.csrfProtection,
             defaultPermissions: data?.defaultPermissions ?? 0,
             hideAvailable: data?.hideAvailable,
+            localLogin: data?.localLogin,
             trustProxy: data?.trustProxy,
           }}
           enableReinitialize
@@ -93,6 +97,7 @@ const SettingsMain: React.FC = () => {
                 csrfProtection: values.csrfProtection,
                 defaultPermissions: values.defaultPermissions,
                 hideAvailable: values.hideAvailable,
+                localLogin: values.localLogin,
                 trustProxy: values.trustProxy,
               });
 
@@ -232,6 +237,26 @@ const SettingsMain: React.FC = () => {
                       name="hideAvailable"
                       onChange={() => {
                         setFieldValue('hideAvailable', !values.hideAvailable);
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="localLogin" className="checkbox-label">
+                    <span className="mr-2">
+                      {intl.formatMessage(messages.localLogin)}
+                    </span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.localLoginTip)}
+                    </span>
+                  </label>
+                  <div className="form-input">
+                    <Field
+                      type="checkbox"
+                      id="localLogin"
+                      name="localLogin"
+                      onChange={() => {
+                        setFieldValue('localLogin', !values.localLogin);
                       }}
                     />
                   </div>

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -177,9 +177,7 @@ const SettingsMain: React.FC = () => {
                 </div>
                 <div className="form-row">
                   <label htmlFor="trustProxy" className="checkbox-label">
-                    <span className="mr-2">
-                      {intl.formatMessage(messages.trustProxy)}
-                    </span>
+                    <span>{intl.formatMessage(messages.trustProxy)}</span>
                     <span className="label-tip">
                       {intl.formatMessage(messages.trustProxyTip)}
                     </span>
@@ -243,9 +241,7 @@ const SettingsMain: React.FC = () => {
                 </div>
                 <div className="form-row">
                   <label htmlFor="localLogin" className="checkbox-label">
-                    <span className="mr-2">
-                      {intl.formatMessage(messages.localLogin)}
-                    </span>
+                    <span>{intl.formatMessage(messages.localLogin)}</span>
                     <span className="label-tip">
                       {intl.formatMessage(messages.localLoginTip)}
                     </span>

--- a/src/components/Settings/SettingsNotifications.tsx
+++ b/src/components/Settings/SettingsNotifications.tsx
@@ -205,7 +205,7 @@ const SettingsNotifications: React.FC = ({ children }) => {
               <Form className="section">
                 <div className="form-row">
                   <label htmlFor="name" className="checkbox-label">
-                    <span className="mr-2">
+                    <span>
                       {intl.formatMessage(messages.enablenotifications)}
                     </span>
                   </label>
@@ -222,7 +222,7 @@ const SettingsNotifications: React.FC = ({ children }) => {
                 </div>
                 <div className="form-row">
                   <label htmlFor="name" className="checkbox-label">
-                    <span className="mr-2">
+                    <span>
                       {intl.formatMessage(messages.autoapprovedrequests)}
                     </span>
                   </label>

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -351,7 +351,7 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
               <div className="form-row">
                 <label htmlFor="name" className="text-label">
                   <div className="flex flex-col">
-                    <span className="mr-2">
+                    <span>
                       <FormattedMessage {...messages.servername} />
                     </span>
                     <span className="text-gray-500">

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -20,7 +20,6 @@ import * as Yup from 'yup';
 import AddUserIcon from '../../assets/useradd.svg';
 import Alert from '../Common/Alert';
 import BulkEditModal from './BulkEditModal';
-import useSettings from '../../hooks/useSettings';
 
 const messages = defineMessages({
   userlist: 'User List',
@@ -61,15 +60,11 @@ const messages = defineMessages({
   passwordinfodescription:
     'Email notifications need to be configured and enabled in order to automatically generate passwords.',
   autogeneratepassword: 'Automatically generate password',
-  localLoginDisabled: 'Local User Sign-In Disabled',
-  localLoginDisabledMessage:
-    'The "Enable Local User Sign-In" setting is currently disabled. While local users can still be created and managed here, this setting will need to be enabled in order to grant local users access to Overseerr.',
 });
 
 const UserList: React.FC = () => {
   const intl = useIntl();
   const router = useRouter();
-  const settings = useSettings();
   const { addToast } = useToasts();
   const { data, error, revalidate } = useSWR<User[]>('/api/v1/user');
   const [isDeleting, setDeleting] = useState(false);
@@ -385,13 +380,6 @@ const UserList: React.FC = () => {
           </Button>
         </div>
       </div>
-      {!settings.currentSettings.localLogin && (
-        <div className="mt-4 -mb-5">
-          <Alert title={intl.formatMessage(messages.localLoginDisabled)}>
-            {intl.formatMessage(messages.localLoginDisabledMessage)}
-          </Alert>
-        </div>
-      )}
       <Table>
         <thead>
           <tr>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -20,6 +20,7 @@ import * as Yup from 'yup';
 import AddUserIcon from '../../assets/useradd.svg';
 import Alert from '../Common/Alert';
 import BulkEditModal from './BulkEditModal';
+import useSettings from '../../hooks/useSettings';
 
 const messages = defineMessages({
   userlist: 'User List',
@@ -60,11 +61,15 @@ const messages = defineMessages({
   passwordinfodescription:
     'Email notifications need to be configured and enabled in order to automatically generate passwords.',
   autogeneratepassword: 'Automatically generate password',
+  localLoginDisabled: 'Local User Sign-In Disabled',
+  localLoginDisabledMessage:
+    'The "Enable Local User Sign-In" setting is currently disabled. While local users can still be created and managed here, this setting will need to be enabled in order to grant local users access to Overseerr.',
 });
 
 const UserList: React.FC = () => {
   const intl = useIntl();
   const router = useRouter();
+  const settings = useSettings();
   const { addToast } = useToasts();
   const { data, error, revalidate } = useSWR<User[]>('/api/v1/user');
   const [isDeleting, setDeleting] = useState(false);
@@ -380,6 +385,13 @@ const UserList: React.FC = () => {
           </Button>
         </div>
       </div>
+      {!settings.currentSettings.localLogin && (
+        <div className="mt-4 -mb-5">
+          <Alert title={intl.formatMessage(messages.localLoginDisabled)}>
+            {intl.formatMessage(messages.localLoginDisabledMessage)}
+          </Alert>
+        </div>
+      )}
       <Table>
         <thead>
           <tr>

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -11,6 +11,7 @@ const defaultSettings = {
   movie4kEnabled: false,
   series4kEnabled: false,
   hideAvailable: false,
+  localLogin: false,
 };
 
 export const SettingsContext = React.createContext<SettingsContextProps>({

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -433,6 +433,8 @@
   "components.Settings.hideAvailable": "Hide Available Media",
   "components.Settings.hostname": "Hostname/IP",
   "components.Settings.librariesRemaining": "Libraries Remaining: {count}",
+  "components.Settings.localLogin": "Enable Local User Sign-In",
+  "components.Settings.localLoginTip": "Disabling this option only prevents new sign-ins (no user data is deleted)",
   "components.Settings.manualscan": "Manual Library Scan",
   "components.Settings.manualscanDescription": "Normally, this will only be run once every 24 hours. Overseerr will check your Plex server's recently added more aggressively. If this is your first time configuring Plex, a one-time full manual library scan is recommended!",
   "components.Settings.menuAbout": "About",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -579,8 +579,6 @@
   "components.UserList.importfromplex": "Import Users from Plex",
   "components.UserList.importfromplexerror": "Something went wrong while importing users from Plex.",
   "components.UserList.lastupdated": "Last Updated",
-  "components.UserList.localLoginDisabled": "Local User Sign-In Disabled",
-  "components.UserList.localLoginDisabledMessage": "The \"Enable Local User Sign-In\" setting is currently disabled. While local users can still be created and managed here, this setting will need to be enabled in order to grant local users access to Overseerr.",
   "components.UserList.localuser": "Local User",
   "components.UserList.password": "Password",
   "components.UserList.passwordinfo": "Password Information",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -579,6 +579,8 @@
   "components.UserList.importfromplex": "Import Users from Plex",
   "components.UserList.importfromplexerror": "Something went wrong while importing users from Plex.",
   "components.UserList.lastupdated": "Last Updated",
+  "components.UserList.localLoginDisabled": "Local User Sign-In Disabled",
+  "components.UserList.localLoginDisabledMessage": "The \"Enable Local User Sign-In\" setting is currently disabled. While local users can still be created and managed here, this setting will need to be enabled in order to grant local users access to Overseerr.",
   "components.UserList.localuser": "Local User",
   "components.UserList.password": "Password",
   "components.UserList.passwordinfo": "Password Information",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -142,6 +142,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     hideAvailable: false,
     movie4kEnabled: false,
     series4kEnabled: false,
+    localLogin: true,
   };
 
   let locale = 'en';


### PR DESCRIPTION
#### Description

This PR adds an option to disable local user logins.  When disabled, the "Use your Overseerr account" option is hidden on the sign-in page, and the API will reject local login requests.  ~~A warning is also shown on the User List page when the option is disabled.~~

In the event that Plex OAuth is unavailable, this setting can be modified in `settings.json` to re-enable local user login functionality.

#### Screenshot (if UI related)

Settings page:
![image](https://user-images.githubusercontent.com/52870424/106652668-c965ed00-6563-11eb-8b49-1f7f20c0a420.png)

Login page:
![image](https://user-images.githubusercontent.com/52870424/106653056-51e48d80-6564-11eb-8108-e32e60cfcc4a.png)

#### Todos

- [x] Successful build
- [x] Translation keys

#### Issues Fixed or Closed by this PR

- Fixes #647 and #766