### PR TITLE
feat(docker): Check for /app/config volume mount during setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN yarn install --production --ignore-scripts --prefer-offline
 RUN rm -rf src && \
   rm -rf server
 
+RUN touch config/DOCKER
+
 RUN echo "{\"commitTag\": \"${COMMIT_TAG}\"}" > committag.json
 
 

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1477,6 +1477,24 @@ paths:
                     example: 1.0.0
                   commitTag:
                     type: string
+  /status/appdata:
+    get:
+      summary: Get /app/data volume status
+      description: For Docker installs, returns whether or not the /app/data volume mount was configured properly. Always returns true for non-Docker installs.
+      security: []
+      tags:
+        - public
+      responses:
+        '200':
+          description: /app/data volume status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  appData:
+                    type: boolean
+                    example: true
   /settings/main:
     get:
       summary: Get main settings

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "migration:run": "ts-node --project server/tsconfig.json ./node_modules/.bin/typeorm migration:run",
     "format": "prettier --write ."
   },
-  "browser": {
-    "fs": false
-  },
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^0.2.0-da179ca",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "migration:run": "ts-node --project server/tsconfig.json ./node_modules/.bin/typeorm migration:run",
     "format": "prettier --write ."
   },
+  "browser": {
+    "fs": false
+  },
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^0.2.0-da179ca",

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,6 +15,7 @@ import personRoutes from './person';
 import collectionRoutes from './collection';
 import { getAppVersion, getCommitTag } from '../utils/appVersion';
 import serviceRoutes from './service';
+import { appDataStatus } from '../utils/appDataVolume';
 
 const router = Router();
 
@@ -24,6 +25,12 @@ router.get('/status', (req, res) => {
   return res.status(200).json({
     version: getAppVersion(),
     commitTag: getCommitTag(),
+  });
+});
+
+router.get('/status/appdata', (_req, res) => {
+  return res.status(200).json({
+    appData: appDataStatus(),
   });
 });
 

--- a/server/utils/appDataVolume.ts
+++ b/server/utils/appDataVolume.ts
@@ -1,0 +1,8 @@
+import { existsSync } from 'fs';
+import path from 'path';
+
+const DOCKER_PATH = path.join(__dirname, '../../config/DOCKER');
+
+export const appDataStatus = (): boolean => {
+  return !existsSync(DOCKER_PATH);
+};

--- a/src/components/AppDataWarning/index.tsx
+++ b/src/components/AppDataWarning/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import useSWR from 'swr';
+import Alert from '../Common/Alert';
+
+const messages = defineMessages({
+  dockerVolumeMissing: 'Docker Volume Mount Missing',
+  dockerVolumeMissingDescription:
+    'The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.',
+});
+
+const AppDataWarning: React.FC = () => {
+  const intl = useIntl();
+  const { data, error } = useSWR<{ appData: boolean }>(
+    '/api/v1/status/appdata'
+  );
+
+  if (!data && !error) {
+    return null;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <>
+      {!data.appData && (
+        <Alert title={intl.formatMessage(messages.dockerVolumeMissing)}>
+          {intl.formatMessage(messages.dockerVolumeMissingDescription, {
+            code: function code(msg) {
+              return <code className="bg-opacity-50">{msg}</code>;
+            },
+          })}
+        </Alert>
+      )}
+    </>
+  );
+};
+
+export default AppDataWarning;

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -11,6 +11,8 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import Badge from '../Common/Badge';
 import LanguagePicker from '../Layout/LanguagePicker';
 import PageTitle from '../Common/PageTitle';
+import { existsSync } from 'fs';
+import Alert from '../Common/Alert';
 
 const messages = defineMessages({
   setup: 'Setup',
@@ -23,6 +25,9 @@ const messages = defineMessages({
   tip: 'Tip',
   syncingbackground:
     'Syncing will run in the background. You can continue the setup process in the meantime.',
+  dockerVolumeMissing: 'Docker Volume Mount Missing',
+  dockerVolumeMissingDescription:
+    'The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.',
 });
 
 const Setup: React.FC = () => {
@@ -66,6 +71,15 @@ const Setup: React.FC = () => {
           className="w-auto mx-auto mb-10 max-h-32"
           alt="Logo"
         />
+        {existsSync('config/DOCKER') && (
+          <Alert title={intl.formatMessage(messages.dockerVolumeMissing)}>
+            {intl.formatMessage(messages.dockerVolumeMissingDescription, {
+              code: function code(msg) {
+                return <code className="bg-opacity-50">{msg}</code>;
+              },
+            })}
+          </Alert>
+        )}
         <nav className="relative z-50">
           <ul
             className="bg-gray-800 bg-opacity-50 border border-gray-600 divide-y divide-gray-600 rounded-md md:flex md:divide-y-0"

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -11,8 +11,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import Badge from '../Common/Badge';
 import LanguagePicker from '../Layout/LanguagePicker';
 import PageTitle from '../Common/PageTitle';
-import { existsSync } from 'fs';
-import Alert from '../Common/Alert';
+import AppDataWarning from '../AppDataWarning';
 
 const messages = defineMessages({
   setup: 'Setup',
@@ -71,15 +70,7 @@ const Setup: React.FC = () => {
           className="w-auto mx-auto mb-10 max-h-32"
           alt="Logo"
         />
-        {existsSync('config/DOCKER') && (
-          <Alert title={intl.formatMessage(messages.dockerVolumeMissing)}>
-            {intl.formatMessage(messages.dockerVolumeMissingDescription, {
-              code: function code(msg) {
-                return <code className="bg-opacity-50">{msg}</code>;
-              },
-            })}
-          </Alert>
-        )}
+        <AppDataWarning />
         <nav className="relative z-50">
           <ul
             className="bg-gray-800 bg-opacity-50 border border-gray-600 divide-y divide-gray-600 rounded-md md:flex md:divide-y-0"

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -24,9 +24,6 @@ const messages = defineMessages({
   tip: 'Tip',
   syncingbackground:
     'Syncing will run in the background. You can continue the setup process in the meantime.',
-  dockerVolumeMissing: 'Docker Volume Mount Missing',
-  dockerVolumeMissingDescription:
-    'The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.',
 });
 
 const Setup: React.FC = () => {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1,4 +1,6 @@
 {
+  "components.AppDataWarning.dockerVolumeMissing": "Docker Volume Mount Missing",
+  "components.AppDataWarning.dockerVolumeMissingDescription": "The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.",
   "components.CollectionDetails.movies": "Movies",
   "components.CollectionDetails.numberofmovies": "Number of Movies: {count}",
   "components.CollectionDetails.overview": "Overview",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -506,8 +506,6 @@
   "components.Setup.configureplex": "Configure Plex",
   "components.Setup.configureservices": "Configure Services",
   "components.Setup.continue": "Continue",
-  "components.Setup.dockerVolumeMissing": "Docker Volume Mount Missing",
-  "components.Setup.dockerVolumeMissingDescription": "The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.",
   "components.Setup.finish": "Finish Setup",
   "components.Setup.finishing": "Finishing…",
   "components.Setup.loginwithplex": "Log in with Plex",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -504,6 +504,8 @@
   "components.Setup.configureplex": "Configure Plex",
   "components.Setup.configureservices": "Configure Services",
   "components.Setup.continue": "Continue",
+  "components.Setup.dockerVolumeMissing": "Docker Volume Mount Missing",
+  "components.Setup.dockerVolumeMissingDescription": "The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.",
   "components.Setup.finish": "Finish Setup",
   "components.Setup.finishing": "Finishing…",
   "components.Setup.loginwithplex": "Log in with Plex",


### PR DESCRIPTION
#### Description

A common issue for users who aren't familiar with Docker is that they find their Overseerr configuration/data wiped after an update/restart of the container.

This PR adds the creation of a zero-byte file to the Docker image in `/app/config`, which would only be visible to the container if the volume mount was not properly configured.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/52870424/106714393-cb629700-65c9-11eb-9653-3334221da83d.png)

#### Todos

- [x] Successful build
- [x] Translation keys