### PR TITLE
fix(frontend): Fix possible division by zero in download status

### DIFF
--- a/src/components/DownloadBlock/index.tsx
+++ b/src/components/DownloadBlock/index.tsx
@@ -21,20 +21,26 @@ const DownloadBlock: React.FC<DownloadBlockProps> = ({
         <div
           className="h-8 transition-all duration-200 ease-in-out bg-indigo-600"
           style={{
-            width: `${Math.round(
-              ((downloadItem.size - downloadItem.sizeLeft) /
-                downloadItem.size) *
-                100
-            )}%`,
+            width: `${
+              downloadItem.size
+                ? Math.round(
+                    ((downloadItem.size - downloadItem.sizeLeft) /
+                      downloadItem.size) *
+                      100
+                  )
+                : 0
+            }%`,
           }}
         />
         <div className="absolute inset-0 flex items-center justify-center w-full h-6 text-xs">
           <span>
-            {Math.round(
-              ((downloadItem.size - downloadItem.sizeLeft) /
-                downloadItem.size) *
-                100
-            )}
+            {downloadItem.size
+              ? Math.round(
+                  ((downloadItem.size - downloadItem.sizeLeft) /
+                    downloadItem.size) *
+                    100
+                )
+              : 0}
             %
           </span>
         </div>


### PR DESCRIPTION
#### Description

Currently, the download size is not verified to be nonzero, so it in some cases the download status is shown to the user as "NaN%."  This PR fixes this behavior.

#### Issues Fixed or Closed by this PR

- Fixes #829