### PR TITLE
fix(ui): Limit max width of forms & lists

### DIFF
--- a/src/components/Common/List/index.tsx
+++ b/src/components/Common/List/index.tsx
@@ -7,11 +7,13 @@ interface ListItemProps {
 
 const ListItem: React.FC<ListItemProps> = ({ title, children }) => {
   return (
-    <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
-      <dt className="block text-sm font-medium text-gray-400">{title}</dt>
-      <dd className="flex text-sm text-white sm:mt-0 sm:col-span-2">
-        <span className="flex-grow">{children}</span>
-      </dd>
+    <div>
+      <div className="max-w-5xl py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+        <dt className="block text-sm font-medium text-gray-400">{title}</dt>
+        <dd className="flex text-sm text-white sm:mt-0 sm:col-span-2">
+          <span className="flex-grow">{children}</span>
+        </dd>
+      </div>
     </div>
   );
 };

--- a/src/components/Common/List/index.tsx
+++ b/src/components/Common/List/index.tsx
@@ -8,7 +8,7 @@ interface ListItemProps {
 const ListItem: React.FC<ListItemProps> = ({ title, children }) => {
   return (
     <div>
-      <div className="max-w-5xl py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+      <div className="max-w-6xl py-4 sm:grid sm:grid-cols-3 sm:gap-4">
         <dt className="block text-sm font-medium text-gray-400">{title}</dt>
         <dd className="flex text-sm text-white sm:mt-0 sm:col-span-2">
           <span className="flex-grow">{children}</span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,7 +50,7 @@ body {
 }
 
 .form-row {
-  @apply max-w-5xl mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start;
+  @apply max-w-6xl mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start;
 }
 
 .form-input {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,7 +50,7 @@ body {
 }
 
 .form-row {
-  @apply mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start;
+  @apply max-w-5xl mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start;
 }
 
 .form-input {


### PR DESCRIPTION
#### Description

Limits width of forms & lists, so that the gap between labels & their corresponding items does not become too big on large screens or when zoomed out.

#### Todos

- [x] Successful build

#### Issues Fixed or Closed by this PR

- Fixes #844