### PR TITLE
fix(ui): Dynamically generate path to config in warning message

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1479,14 +1479,14 @@ paths:
                     type: string
   /status/appdata:
     get:
-      summary: Get /app/data volume status
-      description: For Docker installs, returns whether or not the /app/data volume mount was configured properly. Always returns true for non-Docker installs.
+      summary: Get application data volume status
+      description: For Docker installs, returns whether or not the volume mount was configured properly. Always returns true for non-Docker installs.
       security: []
       tags:
         - public
       responses:
         '200':
-          description: /app/data volume status
+          description: Application data volume status and path
           content:
             application/json:
               schema:
@@ -1495,6 +1495,9 @@ paths:
                   appData:
                     type: boolean
                     example: true
+                  appDataPath:
+                    type: string
+                    example: /app/config
   /settings/main:
     get:
       summary: Get main settings

--- a/server/api/animelist.ts
+++ b/server/api/animelist.ts
@@ -8,7 +8,9 @@ const UPDATE_INTERVAL_MSEC = 24 * 3600 * 1000; // how often to download new mapp
 // originally at https://raw.githubusercontent.com/ScudLee/anime-lists/master/anime-list.xml
 const MAPPING_URL =
   'https://raw.githubusercontent.com/Anime-Lists/anime-lists/master/anime-list.xml';
-const LOCAL_PATH = path.join(__dirname, '../../config/anime-list.xml');
+const LOCAL_PATH = process.env.CONFIG_DIRECTORY
+  ? `${process.env.CONFIG_DIRECTORY}/anime-list.xml`
+  : path.join(__dirname, '../../config/anime-list.xml');
 
 const mappingRegexp = new RegExp(/;[0-9]+-([0-9]+)/g);
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,7 +15,7 @@ import personRoutes from './person';
 import collectionRoutes from './collection';
 import { getAppVersion, getCommitTag } from '../utils/appVersion';
 import serviceRoutes from './service';
-import { appDataStatus } from '../utils/appDataVolume';
+import { appDataStatus, appDataPath } from '../utils/appDataVolume';
 
 const router = Router();
 
@@ -31,6 +31,7 @@ router.get('/status', (req, res) => {
 router.get('/status/appdata', (_req, res) => {
   return res.status(200).json({
     appData: appDataStatus(),
+    appDataPath: appDataPath(),
   });
 });
 

--- a/server/utils/appDataVolume.ts
+++ b/server/utils/appDataVolume.ts
@@ -6,3 +6,7 @@ const DOCKER_PATH = path.join(__dirname, '../../config/DOCKER');
 export const appDataStatus = (): boolean => {
   return !existsSync(DOCKER_PATH);
 };
+
+export const appDataPath = (): string => {
+  return path.join(__dirname, '../../config');
+};

--- a/server/utils/appDataVolume.ts
+++ b/server/utils/appDataVolume.ts
@@ -1,12 +1,16 @@
 import { existsSync } from 'fs';
 import path from 'path';
 
-const DOCKER_PATH = path.join(__dirname, '../../config/DOCKER');
+const CONFIG_PATH = process.env.CONFIG_DIRECTORY
+  ? process.env.CONFIG_DIRECTORY
+  : path.join(__dirname, '../../config');
+
+const DOCKER_PATH = `${CONFIG_PATH}/DOCKER`;
 
 export const appDataStatus = (): boolean => {
   return !existsSync(DOCKER_PATH);
 };
 
 export const appDataPath = (): string => {
-  return path.join(__dirname, '../../config');
+  return CONFIG_PATH;
 };

--- a/src/components/AppDataWarning/index.tsx
+++ b/src/components/AppDataWarning/index.tsx
@@ -6,12 +6,12 @@ import Alert from '../Common/Alert';
 const messages = defineMessages({
   dockerVolumeMissing: 'Docker Volume Mount Missing',
   dockerVolumeMissingDescription:
-    'The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.',
+    'The <code>{appDataPath}</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.',
 });
 
 const AppDataWarning: React.FC = () => {
   const intl = useIntl();
-  const { data, error } = useSWR<{ appData: boolean }>(
+  const { data, error } = useSWR<{ appData: boolean; appDataPath: string }>(
     '/api/v1/status/appdata'
   );
 
@@ -31,6 +31,7 @@ const AppDataWarning: React.FC = () => {
             code: function code(msg) {
               return <code className="bg-opacity-50">{msg}</code>;
             },
+            appDataPath: data.appDataPath,
           })}
         </Alert>
       )}

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1,6 +1,6 @@
 {
   "components.AppDataWarning.dockerVolumeMissing": "Docker Volume Mount Missing",
-  "components.AppDataWarning.dockerVolumeMissingDescription": "The <code>/app/config</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.",
+  "components.AppDataWarning.dockerVolumeMissingDescription": "The <code>{appDataPath}</code> volume mount was not configured properly. All data will be cleared when the container is stopped or restarted.",
   "components.CollectionDetails.movies": "Movies",
   "components.CollectionDetails.numberofmovies": "Number of Movies: {count}",
   "components.CollectionDetails.overview": "Overview",


### PR DESCRIPTION
#### Description

Currently, the path to `/app/config` is hardcoded in the warning message if the volume mount was not configured properly for a Docker install.

This PR dynamically generates the path instead, so that if the path changes in the future or third-party images use a different path, the warning message is accurate/helpful to the user.

#### Todos

- [x] Successful build
- [x] Translation keys