### PR TITLE
fix(search): use same roundiness as other inputs

### DIFF
--- a/src/components/Layout/SearchInput/index.tsx
+++ b/src/components/Layout/SearchInput/index.tsx
@@ -29,7 +29,7 @@ const SearchInput: React.FC = () => {
           <input
             id="search_field"
             style={{ paddingRight: searchValue.length > 0 ? '1.75rem' : '' }}
-            className="block w-full py-2 pl-10 text-white placeholder-gray-300 bg-gray-900 border border-gray-600 rounded-full focus:border-gray-500 focus:outline-none focus:ring-0 focus:placeholder-gray-400 sm:text-base"
+            className="block w-full py-2 pl-10 text-white placeholder-gray-300 bg-gray-900 border border-gray-600 rounded-md focus:border-gray-500 focus:outline-none focus:ring-0 focus:placeholder-gray-400 sm:text-base"
             placeholder={intl.formatMessage(messages.searchPlaceholder)}
             type="search"
             value={searchValue}


### PR DESCRIPTION
#### Description
The search bar is not following the rest of the theme

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/14110063/107128847-4de8a080-68c1-11eb-9c89-52c881dab1ca.png)


#### Todos

- [x] Sucessfully builds `yarn build`
