### PR TITLE
fix(login): fix the gap when 'use your overseer account' was selected

### DIFF
--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -147,10 +147,10 @@ const Login: React.FC = () => {
                   {settings.currentSettings.localLogin && (
                     <div>
                       <button
-                        className={`w-full py-2 text-sm text-center text-gray-400 transition-colors duration-200 bg-gray-800 cursor-default focus:outline-none bg-opacity-70 sm:rounded-t-lg hover:bg-gray-700 hover:cursor-pointer ${
+                        className={`w-full py-2 text-sm text-center text-gray-400 transition-colors duration-200 bg-gray-800 cursor-default focus:outline-none bg-opacity-70 hover:bg-gray-700 hover:cursor-pointer ${
                           openIndexes.includes(1)
                             ? 'text-indigo-500'
-                            : 'sm:rounded-b-lg '
+                            : 'sm:rounded-b-lg'
                         }`}
                         onClick={() => handleClick(1)}
                       >


### PR DESCRIPTION
#### Description
Removes the rounded corners when use your overseer account is selected

#### Screenshot (if UI related)
Before:
![image](https://user-images.githubusercontent.com/14110063/107131353-bfcae500-68d5-11eb-8708-895fd864eb31.png)
After:
![image](https://user-images.githubusercontent.com/14110063/107131379-06204400-68d6-11eb-9df4-a9275cbfcd8b.png)


#### Todos

- [x] Sucessfully builds `yarn build`
