### PR TITLE
fix(ui): Size cards appropriately based on base font size

### DIFF
--- a/src/components/Common/ListView/index.tsx
+++ b/src/components/Common/ListView/index.tsx
@@ -37,7 +37,7 @@ const ListView: React.FC<ListViewProps> = ({
           {intl.formatMessage(messages.noresults)}
         </div>
       )}
-      <ul className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8">
+      <ul className="cardList">
         {items?.map((title) => {
           let titleCard: React.ReactNode;
 
@@ -90,22 +90,12 @@ const ListView: React.FC<ListViewProps> = ({
               break;
           }
 
-          return (
-            <li
-              key={title.id}
-              className="flex flex-col items-center col-span-1 text-center"
-            >
-              {titleCard}
-            </li>
-          );
+          return <li key={title.id}>{titleCard}</li>;
         })}
         {isLoading &&
           !isReachingEnd &&
           [...Array(20)].map((_item, i) => (
-            <li
-              key={`placeholder-${i}`}
-              className="flex flex-col items-center col-span-1 text-center"
-            >
+            <li key={`placeholder-${i}`}>
               <TitleCard.Placeholder canExpand />
             </li>
           ))}

--- a/src/components/MovieDetails/MovieCast/index.tsx
+++ b/src/components/MovieDetails/MovieCast/index.tsx
@@ -45,13 +45,10 @@ const MovieCast: React.FC = () => {
           {intl.formatMessage(messages.fullcast)}
         </Header>
       </div>
-      <ul className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8">
+      <ul className="cardList">
         {data?.credits.cast.map((person, index) => {
           return (
-            <li
-              key={`cast-${person.id}-${index}`}
-              className="flex flex-col items-center col-span-1 text-center"
-            >
+            <li key={`cast-${person.id}-${index}`}>
               <PersonCard
                 name={person.name}
                 personId={person.id}

--- a/src/components/MovieDetails/MovieCrew/index.tsx
+++ b/src/components/MovieDetails/MovieCrew/index.tsx
@@ -45,13 +45,10 @@ const MovieCrew: React.FC = () => {
           {intl.formatMessage(messages.fullcrew)}
         </Header>
       </div>
-      <ul className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8">
+      <ul className="cardList">
         {data?.credits.crew.map((person, index) => {
           return (
-            <li
-              key={`crew-${person.id}-${index}`}
-              className="flex flex-col items-center col-span-1 text-center"
-            >
+            <li key={`crew-${person.id}-${index}`}>
               <PersonCard
                 name={person.name}
                 personId={person.id}

--- a/src/components/TvDetails/TvCast/index.tsx
+++ b/src/components/TvDetails/TvCast/index.tsx
@@ -47,13 +47,10 @@ const TvCast: React.FC = () => {
           {intl.formatMessage(messages.fullseriescast)}
         </Header>
       </div>
-      <ul className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8">
+      <ul className="cardList">
         {data?.credits.cast.map((person) => {
           return (
-            <li
-              key={person.id}
-              className="flex flex-col items-center col-span-1 text-center"
-            >
+            <li key={person.id}>
               <PersonCard
                 name={person.name}
                 personId={person.id}

--- a/src/components/TvDetails/TvCrew/index.tsx
+++ b/src/components/TvDetails/TvCrew/index.tsx
@@ -47,13 +47,10 @@ const TvCrew: React.FC = () => {
           {intl.formatMessage(messages.fullseriescrew)}
         </Header>
       </div>
-      <ul className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8">
+      <ul className="cardList">
         {data?.credits.crew.map((person, index) => {
           return (
-            <li
-              key={`crew-${person.id}-${index}`}
-              className="flex flex-col items-center col-span-1 text-center"
-            >
+            <li key={`crew-${person.id}-${index}`}>
               <PersonCard
                 name={person.name}
                 personId={person.id}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -15,12 +15,12 @@ body {
   background: #f19a30;
 }
 
-.cardList {
-  @apply grid w-full grid-cols-2 gap-6 sm:grid-cols-none sm:gap-0 sm:flex sm:flex-wrap sm:-mx-2;
+ul.cardList {
+  @apply grid max-w-6xl grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8;
 }
 
-.cardList > li {
-  @apply flex flex-col items-center col-span-1 text-center sm:flex-none sm:mb-4 sm:mx-2 sm:inline-block sm:w-36 md:w-44;
+ul.cardList > li {
+  @apply flex flex-col items-center col-span-1 text-center;
 }
 
 .titleCard {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,7 +16,7 @@ body {
 }
 
 ul.cardList {
-  @apply grid justify-between gap-4;
+  @apply grid gap-4;
   grid-template-columns: repeat(auto-fill, minmax(9.375rem, 1fr));
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,7 +16,8 @@ body {
 }
 
 ul.cardList {
-  @apply grid max-w-6xl grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8;
+  @apply grid gap-6;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
 }
 
 ul.cardList > li {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -15,6 +15,14 @@ body {
   background: #f19a30;
 }
 
+.cardList {
+  @apply grid w-full grid-cols-2 gap-6 sm:grid-cols-none sm:gap-0 sm:flex sm:flex-wrap sm:-mx-2;
+}
+
+.cardList > li {
+  @apply flex flex-col items-center col-span-1 text-center sm:flex-none sm:mb-4 sm:mx-2 sm:inline-block sm:w-36 md:w-44;
+}
+
 .titleCard {
   @apply relative bg-gray-800 bg-cover rounded-lg;
   padding-bottom: 150%;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,8 +16,8 @@ body {
 }
 
 ul.cardList {
-  @apply grid gap-6;
-  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  @apply grid justify-between gap-4;
+  grid-template-columns: repeat(auto-fill, minmax(9.375rem, 1fr));
 }
 
 ul.cardList > li {


### PR DESCRIPTION
#### Description

Use consistent card sizes on non-mobile screens, so that they match those on the "Discover" home page.

This not only makes the card lists more pleasant to view at high resolutions, but also allows them to scale appropriately when zooming in/out.

#### Screenshot (if UI related)
**Before:**
![screenshotbefore](https://user-images.githubusercontent.com/52870424/107133130-14a93400-68b3-11eb-9a7b-40364163d1e4.png)
![image](https://user-images.githubusercontent.com/52870424/107133134-1bd04200-68b3-11eb-88e5-ff437388f6e8.png)

**After:**
![image](https://user-images.githubusercontent.com/52870424/107133138-212d8c80-68b3-11eb-8ee5-6a05b0197745.png)
![image](https://user-images.githubusercontent.com/52870424/107133165-47532c80-68b3-11eb-84bf-89e1cc466f26.png)

#### Todos

- [x] Successful build

#### Issues Fixed or Closed by this PR

- Fixes #869