### PR TITLE
docs(api): Fix API endpoint tags

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -2449,7 +2449,6 @@ paths:
       description: Returns the currently logged-in user.
       tags:
         - auth
-        - users
       responses:
         '200':
           description: Object containing the logged-in user in JSON
@@ -2533,7 +2532,7 @@ paths:
       description: Sends a reset password email to the email if the user exists
       security: []
       tags:
-        - users
+        - auth
       responses:
         '200':
           description: OK
@@ -2562,7 +2561,7 @@ paths:
       description: Resets the password for a user if the given guid is connected to a user
       security: []
       tags:
-        - users
+        - auth
       responses:
         '200':
           description: OK


### PR DESCRIPTION
#### Description

Currently, the `/auth/me` endpoint is listed twice, and the `auth` endpoints relating to password resets are under the `users` tag.

I thought this was odd and that it must be a mistake, but if it's intentional please just close this PR.

#### Screenshot (if UI related)
**Before:**
![image](https://user-images.githubusercontent.com/52870424/107152154-4b735e80-6934-11eb-8b26-bb69270a71b3.png)

**After:**
![image](https://user-images.githubusercontent.com/52870424/107152415-ae192a00-6935-11eb-8aec-9fe2be977e6a.png)

#### Todos

- [x] Successful build