### PR TITLE
fix(requests): correctly clean up when tvdbid is missing

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -538,7 +538,9 @@ export class MediaRequest {
         const tvdbId = series.external_ids.tvdb_id ?? media.tvdbId;
 
         if (!tvdbId) {
-          this.handleRemoveParentUpdate();
+          const requestRepository = getRepository(MediaRequest);
+          await mediaRepository.remove(media);
+          await requestRepository.remove(this);
           throw new Error('Series was missing tvdb id');
         }
 


### PR DESCRIPTION
#### Description
cleans up media and mediarequest when request to sonarr has failed because of tvdbid

#### Todos

- [x] Sucessfully builds `yarn build`

#### Issues Fixed or Closed by this PR

- Fixes #873
