### PR TITLE
build(docker): Leverage GitHub cache using actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -60,6 +67,8 @@ jobs:
             sctx/overseerr:${{ github.sha }}
             ghcr.io/sct/overseerr:develop
             ghcr.io/sct/overseerr:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
   discord:
     name: Send Discord Notification
     needs: build_and_push


### PR DESCRIPTION
#### Description

Since we recently made changes to the `Dockerfile`, I decided to look through some of the GitHub Actions logs today and discovered that we actually aren't caching anything at all. 😅

This PR leverages [GitHub cache](https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows) using [`actions/cache`](https://github.com/actions/cache), as described here: https://github.com/docker/build-push-action#leverage-github-cache