### PR TITLE
feat(ui): Add 'Available' filter to request list and update request status to AVAILABLE where appropriate

### DIFF
--- a/server/constants/media.ts
+++ b/server/constants/media.ts
@@ -3,6 +3,7 @@ export enum MediaRequestStatus {
   APPROVED,
   DECLINED,
   AVAILABLE,
+  PARTIALLY_AVAILABLE,
 }
 
 export enum MediaType {

--- a/server/job/sonarrsync/index.ts
+++ b/server/job/sonarrsync/index.ts
@@ -286,10 +286,31 @@ class JobSonarrSync {
               .includes(requestSeason.seasonNumber)
           )
         );
-
         if (request && request.status !== MediaRequestStatus.AVAILABLE) {
           request.status = MediaRequestStatus.AVAILABLE;
           await requestRepository.save(request);
+        } else {
+          const partiallyAvailableRequest = requests.find((request) =>
+            request.seasons.some((requestSeason) =>
+              media.seasons
+                .filter(
+                  (season) =>
+                    season[server4k ? 'status4k' : 'status'] ===
+                    MediaStatus.AVAILABLE
+                )
+                .map(({ seasonNumber }) => seasonNumber)
+                .includes(requestSeason.seasonNumber)
+            )
+          );
+          if (
+            partiallyAvailableRequest &&
+            partiallyAvailableRequest.status !==
+              MediaRequestStatus.PARTIALLY_AVAILABLE
+          ) {
+            partiallyAvailableRequest.status =
+              MediaRequestStatus.PARTIALLY_AVAILABLE;
+            await requestRepository.save(partiallyAvailableRequest);
+          }
         }
       }
     } else {

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -36,7 +36,10 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               media: entity,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
             });
+            request['status'] = MediaRequestStatus.AVAILABLE;
           });
+
+          await requestRepository.save(relatedRequests);
         }
       }
     }
@@ -97,7 +100,10 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               },
             ],
           });
+          request['status'] = MediaRequestStatus.AVAILABLE;
         }
+
+        await requestRepository.save(requests);
       }
     }
   }

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -36,7 +36,8 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               media: entity,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
             });
-            request['status'] = MediaRequestStatus.AVAILABLE;
+
+            request.status = MediaRequestStatus.AVAILABLE;
           });
 
           await requestRepository.save(relatedRequests);
@@ -100,10 +101,12 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               },
             ],
           });
-          request['status'] = MediaRequestStatus.AVAILABLE;
-        }
 
-        await requestRepository.save(requests);
+          if (request.status !== MediaRequestStatus.AVAILABLE) {
+            request.status = MediaRequestStatus.AVAILABLE;
+            await requestRepository.save(request);
+          }
+        }
       }
     }
   }

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -212,6 +212,11 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                   {intl.formatMessage(globalMessages.pending)}
                 </Badge>
               )}
+              {request.status === MediaRequestStatus.PARTIALLY_AVAILABLE && (
+                <Badge badgeType="success">
+                  {intl.formatMessage(globalMessages.partiallyavailable)}
+                </Badge>
+              )}
               {request.status === MediaRequestStatus.AVAILABLE && (
                 <Badge badgeType="success">
                   {intl.formatMessage(globalMessages.available)}

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -212,6 +212,11 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                   {intl.formatMessage(globalMessages.pending)}
                 </Badge>
               )}
+              {request.status === MediaRequestStatus.AVAILABLE && (
+                <Badge badgeType="success">
+                  {intl.formatMessage(globalMessages.available)}
+                </Badge>
+              )}
             </div>
           </div>
           <div className="flex items-center mt-2 text-sm leading-5 text-gray-300 sm:mt-0">

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -200,6 +200,8 @@ const RequestItem: React.FC<RequestItemProps> = ({
             status={
               requestData.status === MediaRequestStatus.AVAILABLE
                 ? MediaStatus.AVAILABLE
+                : requestData.status === MediaRequestStatus.PARTIALLY_AVAILABLE
+                ? MediaStatus.PARTIALLY_AVAILABLE
                 : requestData.media[requestData.is4k ? 'status4k' : 'status']
             }
             inProgress={

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -197,7 +197,11 @@ const RequestItem: React.FC<RequestItemProps> = ({
           </Badge>
         ) : (
           <StatusBadge
-            status={requestData.media[requestData.is4k ? 'status4k' : 'status']}
+            status={
+              requestData.status === MediaRequestStatus.AVAILABLE
+                ? MediaStatus.AVAILABLE
+                : requestData.media[requestData.is4k ? 'status4k' : 'status']
+            }
             inProgress={
               (
                 requestData.media[

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -22,13 +22,14 @@ const messages = defineMessages({
   filterAll: 'All',
   filterPending: 'Pending',
   filterApproved: 'Approved',
+  filterAvailable: 'Available',
   noresults: 'No results.',
   showallrequests: 'Show All Requests',
   sortAdded: 'Request Date',
   sortModified: 'Last Modified',
 });
 
-type Filter = 'all' | 'approved' | 'pending';
+type Filter = 'all' | 'approved' | 'available' | 'pending';
 type Sort = 'added' | 'modified';
 
 const RequestList: React.FC = () => {
@@ -96,6 +97,9 @@ const RequestList: React.FC = () => {
               </option>
               <option value="approved">
                 {intl.formatMessage(messages.filterApproved)}
+              </option>
+              <option value="available">
+                {intl.formatMessage(messages.filterAvailable)}
               </option>
             </select>
           </div>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -152,6 +152,7 @@
   "components.RequestList.RequestItem.seasons": "Seasons",
   "components.RequestList.filterAll": "All",
   "components.RequestList.filterApproved": "Approved",
+  "components.RequestList.filterAvailable": "Available",
   "components.RequestList.filterPending": "Pending",
   "components.RequestList.mediaInfo": "Media Info",
   "components.RequestList.modifiedBy": "Last Modified By",


### PR DESCRIPTION
#### Description

Update `MediaRequestStatus` to `AVAILABLE` when appropriate, and add the "Available" filter option to the request list.

This is an alternative to #905 for implementing #656.  This PR tries to keep request statuses in sync with media statuses.

**Note:** 4K content doesn't get picked up until it is detected during a Radarr/Sonarr/Plex sync.  When we add availability notifications for 4K content, we can fix this.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/52870424/107400750-20257680-6ad0-11eb-95b3-96ebf011a65f.png)

#### Todos

- [x] Successful build
- [x] Translation keys
- [x] Update request status to `AVAILABLE` or `PARTIALLY_AVAILABLE` as new media becomes available
- [x] Update existing available request statuses during Radarr/Sonarr/Plex sync

#### Issues Fixed or Closed by this PR

- Fixes #656