### PR TITLE
fix(plex-sync): get correct Plex metadata for Hama movie items

### DIFF
--- a/server/job/plexsync/index.ts
+++ b/server/job/plexsync/index.ts
@@ -353,6 +353,25 @@ class JobPlexSync {
     }
   }
 
+  // movies with hama agent actually are tv shows with at least one episode in it
+  // try to get first episode of any season - cannot hardcode season or episode number
+  // because sometimes user can have it in other season/ep than s01e01
+  private async processHamaMovie(
+    metadata: PlexMetadata,
+    tmdbMovie: TmdbMovieDetails | undefined,
+    tmdbMovieId: number
+  ) {
+    const season = metadata.Children?.Metadata[0];
+    if (season) {
+      const episodes = await this.plexClient.getChildrenMetadata(
+        season.ratingKey
+      );
+      if (episodes) {
+        await this.processMovieWithId(episodes[0], tmdbMovie, tmdbMovieId);
+      }
+    }
+  }
+
   private async processShow(plexitem: PlexLibraryItem) {
     const mediaRepository = getRepository(Media);
 
@@ -431,8 +450,8 @@ class JobPlexSync {
             // if lookup of tvshow above failed, then try movie with tmdbid/imdbid
             // note - some tv shows have imdbid set too, that's why this need to go second
             if (result?.tmdbId) {
-              return await this.processMovieWithId(
-                plexitem,
+              return await this.processHamaMovie(
+                metadata,
                 undefined,
                 result.tmdbId
               );
@@ -440,8 +459,8 @@ class JobPlexSync {
               const tmdbMovie = await this.tmdb.getMovieByImdbId({
                 imdbId: result.imdbId,
               });
-              return await this.processMovieWithId(
-                plexitem,
+              return await this.processHamaMovie(
+                metadata,
                 tmdbMovie,
                 tmdbMovie.id
               );


### PR DESCRIPTION
#### Description

Existing code was expecting ratingKey to reference media item when adding movie.
But Hama stores movies as tv show episodes - so wrong ratingKey was used.
This change looks up first episode in first seasons for Plex media metadata (for 4K detection).

#### Screenshot (if UI related)

#### Todos

- [ ] Sucessfully builds `yarn build`
- [ ] Translation Keys `yarn i18n:extract`
- [ ] Database migration created (if required)

#### Issues Fixed or Closed by this PR

- Fixes #898
