### PR TITLE
feat(ui): Add 'Available' filter to request list and remove unused MediaRequestStatus.AVAILABLE enum value

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -27,13 +27,13 @@ tags:
   - name: tv
     description: Endpoints related to retrieving TV series and their details.
   - name: person
-    description: Endpoints related to retrieving Person details.
+    description: Endpoints related to retrieving person details.
   - name: media
     description: Endpoints related to media management.
   - name: collection
-    description: Endpoints related to retrieving Collection details.
+    description: Endpoints related to retrieving collection details.
   - name: service
-    description: Endpoinst related to getting Service (Radarr/Sonarr) details.
+    description: Endpoints related to getting service (Radarr/Sonarr) details.
 servers:
   - url: '{server}/api/v1'
     variables:
@@ -3095,7 +3095,7 @@ paths:
           schema:
             type: string
             nullable: true
-            enum: [all, available, approved, pending, unavailable]
+            enum: [all, approved, available, pending, processing, unavailable]
         - in: query
           name: sort
           schema:
@@ -3187,6 +3187,12 @@ paths:
                   approved:
                     type: number
                     example: 10
+                  processing:
+                    type: number
+                    example: 4
+                  available:
+                    type: number
+                    example: 6
                 required:
                   - pending
                   - approved

--- a/server/constants/media.ts
+++ b/server/constants/media.ts
@@ -2,7 +2,6 @@ export enum MediaRequestStatus {
   PENDING = 1,
   APPROVED,
   DECLINED,
-  AVAILABLE,
 }
 
 export enum MediaType {

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { isAuthenticated } from '../middleware/auth';
 import { Permission } from '../lib/permissions';
-import { getRepository, FindOperator, FindOneOptions, In } from 'typeorm';
+import { getRepository } from 'typeorm';
 import { MediaRequest } from '../entity/MediaRequest';
 import TheMovieDb from '../api/themoviedb';
 import Media from '../entity/Media';
@@ -19,61 +19,98 @@ requestRoutes.get('/', async (req, res, next) => {
     const pageSize = req.query.take ? Number(req.query.take) : 20;
     const skip = req.query.skip ? Number(req.query.skip) : 0;
 
-    let statusFilter:
-      | MediaRequestStatus
-      | FindOperator<string | MediaRequestStatus>
-      | undefined = undefined;
+    let statusFilter: MediaRequestStatus[];
 
     switch (req.query.filter) {
       case 'available':
-        statusFilter = MediaRequestStatus.AVAILABLE;
-        break;
       case 'approved':
-        statusFilter = MediaRequestStatus.APPROVED;
+        statusFilter = [MediaRequestStatus.APPROVED];
         break;
       case 'pending':
-        statusFilter = MediaRequestStatus.PENDING;
+        statusFilter = [MediaRequestStatus.PENDING];
         break;
       case 'unavailable':
-        statusFilter = In([
+        statusFilter = [
           MediaRequestStatus.PENDING,
           MediaRequestStatus.APPROVED,
-        ]);
+        ];
         break;
       default:
-        statusFilter = In(Object.values(MediaRequestStatus));
+        statusFilter = [
+          MediaRequestStatus.PENDING,
+          MediaRequestStatus.APPROVED,
+          MediaRequestStatus.DECLINED,
+        ];
     }
 
-    let sortFilter: FindOneOptions<MediaRequest>['order'] = {
-      id: 'DESC',
-    };
+    let mediaStatusFilter: MediaStatus[];
+
+    switch (req.query.filter) {
+      case 'available':
+        mediaStatusFilter = [MediaStatus.AVAILABLE];
+        break;
+      case 'approved':
+      case 'pending':
+      case 'unavailable':
+        mediaStatusFilter = [
+          MediaStatus.UNKNOWN,
+          MediaStatus.PENDING,
+          MediaStatus.PROCESSING,
+          MediaStatus.PARTIALLY_AVAILABLE,
+        ];
+        break;
+      default:
+        mediaStatusFilter = [
+          MediaStatus.UNKNOWN,
+          MediaStatus.PENDING,
+          MediaStatus.PROCESSING,
+          MediaStatus.PARTIALLY_AVAILABLE,
+          MediaStatus.AVAILABLE,
+        ];
+    }
+
+    let sortFilter: string;
 
     switch (req.query.sort) {
       case 'modified':
-        sortFilter = {
-          updatedAt: 'DESC',
-        };
+        sortFilter = 'request.updatedAt';
         break;
+      default:
+        sortFilter = 'request.id';
     }
 
-    const [requests, requestCount] = req.user?.hasPermission(
-      [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
-      { type: 'or' }
-    )
-      ? await requestRepository.findAndCount({
-          order: sortFilter,
-          relations: ['media', 'modifiedBy'],
-          where: { status: statusFilter },
-          take: Number(req.query.take) ?? 20,
-          skip,
-        })
-      : await requestRepository.findAndCount({
-          where: { requestedBy: { id: req.user?.id }, status: statusFilter },
-          relations: ['media', 'modifiedBy'],
-          order: sortFilter,
-          take: Number(req.query.limit) ?? 20,
-          skip,
-        });
+    let query = requestRepository
+      .createQueryBuilder('request')
+      .leftJoinAndSelect('request.media', 'media')
+      .leftJoinAndSelect('request.seasons', 'seasons')
+      .leftJoinAndSelect('request.modifiedBy', 'modifiedBy')
+      .leftJoinAndSelect('request.requestedBy', 'requestedBy')
+      .where('request.status IN (:...requestStatus)', {
+        requestStatus: statusFilter,
+      })
+      .andWhere(
+        '(request.is4k = false AND media.status IN (:...mediaStatus)) OR (request.is4k = true AND media.status4k IN (:...mediaStatus))',
+        {
+          mediaStatus: mediaStatusFilter,
+        }
+      );
+
+    if (
+      req.user?.hasPermission(
+        [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
+        { type: 'or' }
+      )
+    ) {
+      query = query.andWhere('request.requestedBy.id = :id', {
+        id: req.user?.id,
+      });
+    }
+
+    const [requests, requestCount] = await query
+      .orderBy(sortFilter, 'DESC')
+      .take(pageSize)
+      .skip(skip)
+      .getManyAndCount();
 
     return res.status(200).json({
       pageInfo: {

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -96,7 +96,7 @@ requestRoutes.get('/', async (req, res, next) => {
       );
 
     if (
-      req.user?.hasPermission(
+      !req.user?.hasPermission(
         [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
         { type: 'or' }
       )

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -23,13 +23,14 @@ const messages = defineMessages({
   filterPending: 'Pending',
   filterApproved: 'Approved',
   filterAvailable: 'Available',
+  filterProcessing: 'Processing',
   noresults: 'No results.',
   showallrequests: 'Show All Requests',
   sortAdded: 'Request Date',
   sortModified: 'Last Modified',
 });
 
-type Filter = 'all' | 'approved' | 'pending';
+type Filter = 'all' | 'pending' | 'approved' | 'processing' | 'available';
 type Sort = 'added' | 'modified';
 
 const RequestList: React.FC = () => {
@@ -93,6 +94,9 @@ const RequestList: React.FC = () => {
               </option>
               <option value="approved">
                 {intl.formatMessage(messages.filterApproved)}
+              </option>
+              <option value="processing">
+                {intl.formatMessage(messages.filterProcessing)}
               </option>
               <option value="available">
                 {intl.formatMessage(messages.filterAvailable)}

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -22,6 +22,7 @@ const messages = defineMessages({
   filterAll: 'All',
   filterPending: 'Pending',
   filterApproved: 'Approved',
+  filterAvailable: 'Available',
   noresults: 'No results.',
   showallrequests: 'Show All Requests',
   sortAdded: 'Request Date',
@@ -92,6 +93,9 @@ const RequestList: React.FC = () => {
               </option>
               <option value="approved">
                 {intl.formatMessage(messages.filterApproved)}
+              </option>
+              <option value="available">
+                {intl.formatMessage(messages.filterAvailable)}
               </option>
             </select>
           </div>

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -523,13 +523,6 @@ const TvRequestModal: React.FC<RequestModalProps> = ({
                                 {intl.formatMessage(globalMessages.requested)}
                               </Badge>
                             )}
-                            {!mediaSeason &&
-                              seasonRequest?.status ===
-                                MediaRequestStatus.AVAILABLE && (
-                                <Badge badgeType="success">
-                                  {intl.formatMessage(globalMessages.available)}
-                                </Badge>
-                              )}
                             {mediaSeason?.[is4k ? 'status4k' : 'status'] ===
                               MediaStatus.PARTIALLY_AVAILABLE && (
                               <Badge badgeType="success">

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -152,6 +152,7 @@
   "components.RequestList.RequestItem.seasons": "Seasons",
   "components.RequestList.filterAll": "All",
   "components.RequestList.filterApproved": "Approved",
+  "components.RequestList.filterAvailable": "Available",
   "components.RequestList.filterPending": "Pending",
   "components.RequestList.mediaInfo": "Media Info",
   "components.RequestList.modifiedBy": "Last Modified By",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -154,6 +154,7 @@
   "components.RequestList.filterApproved": "Approved",
   "components.RequestList.filterAvailable": "Available",
   "components.RequestList.filterPending": "Pending",
+  "components.RequestList.filterProcessing": "Processing",
   "components.RequestList.mediaInfo": "Media Info",
   "components.RequestList.modifiedBy": "Last Modified By",
   "components.RequestList.next": "Next",


### PR DESCRIPTION
#### Description

Remove unused `MediaRequestStatus` enum value `AVAILABLE` , and add "Available" and "Processing" filter options to the request list page.

This is an alternative to #899 for implementing #656, using a more advanced query for the `/request` endpoint instead of trying to keep request statuses in sync with media statuses.

Currently still trying to find an elegant way to filter on and display availability for partial series requests (e.g., when a user only requests one season of a series and that becomes available, we should treat that as an available request even if other seasons are missing).

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/52870424/107849749-5c582000-6dcb-11eb-8093-7f0cf8e0e014.png)

#### Todos

- [x] Successful build
- [x] Translation keys
- [x] Add filters to request list
- [x] Update `/request/count` endpoint

#### Issues Fixed or Closed by this PR

- Fixes #656