### PR TITLE
feat(notif): Notification improvements

### DIFF
--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -45,8 +45,9 @@ These variables are only included in media related notifications, such as reques
 - `{{media_tmdbid}}` Media's TMDb ID.
 - `{{media_imdbid}}` Media's IMDb ID.
 - `{{media_tvdbid}}` Media's TVDB ID.
-- `{{media_status}}` Media's availability status. (Ex. `AVAILABLE` or `PENDING`)
-- `{{media_status4k}}` Media's 4K availability status. (Ex. `AVAILABLE` or `PENDING`)
+- `{{media_status}}` Media's availability status (e.g., `AVAILABLE` or `PENDING`).
+- `{{media_status4k}}` Media's 4K availability status.(e.g., `AVAILABLE` or `PENDING`).
+- `{{request_id}}` Request ID.
 
 ### Special Key Variables
 

--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -46,8 +46,7 @@ These variables are only included in media related notifications, such as reques
 - `{{media_imdbid}}` Media's IMDb ID.
 - `{{media_tvdbid}}` Media's TVDB ID.
 - `{{media_status}}` Media's availability status (e.g., `AVAILABLE` or `PENDING`).
-- `{{media_status4k}}` Media's 4K availability status.(e.g., `AVAILABLE` or `PENDING`).
-- `{{request_id}}` Request ID.
+- `{{media_status4k}}` Media's 4K availability status (e.g., `AVAILABLE` or `PENDING`).
 
 ### Special Key Variables
 
@@ -55,3 +54,4 @@ These variables must be used as a key in the JSON Payload. (Ex, `"{{extra}}": []
 
 - `{{extra}}` This will override the value of the property to be the pre-formatted "extra" array that can come along with certain notifications. Using this variable is _not required_.
 - `{{media}}` This will override the value of the property to `null` if there is no media object passed along with the notification.
+- `{{request}}` This will override the value of the property to `null` if there is no request object passed along with the notification.

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -111,6 +111,7 @@ export class MediaRequest {
           image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
           notifyUser: this.requestedBy,
           media,
+          requestId: this.id,
         });
       }
 
@@ -130,6 +131,7 @@ export class MediaRequest {
                 .join(', '),
             },
           ],
+          requestId: this.id,
         });
       }
     }
@@ -177,6 +179,7 @@ export class MediaRequest {
             image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
             notifyUser: this.requestedBy,
             media,
+            requestId: this.id,
           }
         );
       } else if (this.media.mediaType === MediaType.TV) {
@@ -199,6 +202,7 @@ export class MediaRequest {
                   .join(', '),
               },
             ],
+            requestId: this.id,
           }
         );
       }
@@ -454,6 +458,7 @@ export class MediaRequest {
               notifyUser: admin,
               media,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
+              requestId: this.id,
             });
           });
         logger.info('Sent request to Radarr', { label: 'Media Request' });
@@ -659,6 +664,7 @@ export class MediaRequest {
                     .join(', '),
                 },
               ],
+              requestId: this.id,
             });
           });
         logger.info('Sent request to Sonarr', { label: 'Media Request' });

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -111,7 +111,7 @@ export class MediaRequest {
           image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
           notifyUser: this.requestedBy,
           media,
-          requestId: this.id,
+          request: this,
         });
       }
 
@@ -131,7 +131,7 @@ export class MediaRequest {
                 .join(', '),
             },
           ],
-          requestId: this.id,
+          request: this,
         });
       }
     }
@@ -179,7 +179,7 @@ export class MediaRequest {
             image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
             notifyUser: this.requestedBy,
             media,
-            requestId: this.id,
+            request: this,
           }
         );
       } else if (this.media.mediaType === MediaType.TV) {
@@ -202,7 +202,7 @@ export class MediaRequest {
                   .join(', '),
               },
             ],
-            requestId: this.id,
+            request: this,
           }
         );
       }
@@ -458,7 +458,7 @@ export class MediaRequest {
               notifyUser: admin,
               media,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
-              requestId: this.id,
+              request: this,
             });
           });
         logger.info('Sent request to Radarr', { label: 'Media Request' });
@@ -664,7 +664,7 @@ export class MediaRequest {
                     .join(', '),
                 },
               ],
-              requestId: this.id,
+              request: this,
             });
           });
         logger.info('Sent request to Sonarr', { label: 'Media Request' });

--- a/server/lib/notifications/agents/agent.ts
+++ b/server/lib/notifications/agents/agent.ts
@@ -1,5 +1,6 @@
 import { Notification } from '..';
 import Media from '../../../entity/Media';
+import { MediaRequest } from '../../../entity/MediaRequest';
 import { User } from '../../../entity/User';
 import { NotificationAgentConfig } from '../../settings';
 
@@ -10,7 +11,7 @@ export interface NotificationPayload {
   image?: string;
   message?: string;
   extra?: { name: string; value: string }[];
-  requestId?: number;
+  request?: MediaRequest;
 }
 
 export abstract class BaseAgent<T extends NotificationAgentConfig> {

--- a/server/lib/notifications/agents/agent.ts
+++ b/server/lib/notifications/agents/agent.ts
@@ -10,6 +10,7 @@ export interface NotificationPayload {
   image?: string;
   message?: string;
   extra?: { name: string; value: string }[];
+  requestId?: number;
 }
 
 export abstract class BaseAgent<T extends NotificationAgentConfig> {

--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -98,11 +98,13 @@ class DiscordAgent
 
     const fields: Field[] = [];
 
-    fields.push({
-      name: 'Requested By',
-      value: payload.notifyUser.displayName ?? '',
-      inline: true,
-    });
+    if (payload.request) {
+      fields.push({
+        name: 'Requested By',
+        value: payload.notifyUser.displayName ?? '',
+        inline: true,
+      });
+    }
 
     switch (type) {
       case Notification.MEDIA_PENDING:

--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -98,104 +98,60 @@ class DiscordAgent
 
     const fields: Field[] = [];
 
+    fields.push({
+      name: 'Requested By',
+      value: payload.notifyUser.displayName ?? '',
+      inline: true,
+    });
+
     switch (type) {
       case Notification.MEDIA_PENDING:
         color = EmbedColors.ORANGE;
-        fields.push(
-          {
-            name: 'Requested By',
-            value: payload.notifyUser.displayName ?? '',
-            inline: true,
-          },
-          {
-            name: 'Status',
-            value: 'Pending Approval',
-            inline: true,
-          }
-        );
-
-        if (settings.main.applicationUrl) {
-          fields.push({
-            name: 'View Media',
-            value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
-          });
-        }
+        fields.push({
+          name: 'Status',
+          value: 'Pending Approval',
+          inline: true,
+        });
         break;
       case Notification.MEDIA_APPROVED:
         color = EmbedColors.PURPLE;
-        fields.push(
-          {
-            name: 'Requested By',
-            value: payload.notifyUser.displayName ?? '',
-            inline: true,
-          },
-          {
-            name: 'Status',
-            value: 'Processing Request',
-            inline: true,
-          }
-        );
-
-        if (settings.main.applicationUrl) {
-          fields.push({
-            name: 'View Media',
-            value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
-          });
-        }
+        fields.push({
+          name: 'Status',
+          value: 'Processing',
+          inline: true,
+        });
         break;
       case Notification.MEDIA_AVAILABLE:
         color = EmbedColors.GREEN;
-        fields.push(
-          {
-            name: 'Requested By',
-            value: payload.notifyUser.displayName ?? '',
-            inline: true,
-          },
-          {
-            name: 'Status',
-            value: 'Available',
-            inline: true,
-          }
-        );
-
-        if (settings.main.applicationUrl) {
-          fields.push({
-            name: 'View Media',
-            value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
-          });
-        }
+        fields.push({
+          name: 'Status',
+          value: 'Available',
+          inline: true,
+        });
         break;
       case Notification.MEDIA_DECLINED:
         color = EmbedColors.RED;
-        fields.push(
-          {
-            name: 'Requested By',
-            value: payload.notifyUser.displayName ?? '',
-            inline: true,
-          },
-          {
-            name: 'Status',
-            value: 'Declined',
-            inline: true,
-          }
-        );
-
-        if (settings.main.applicationUrl) {
-          fields.push({
-            name: 'View Media',
-            value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
-          });
-        }
+        fields.push({
+          name: 'Status',
+          value: 'Declined',
+          inline: true,
+        });
         break;
       case Notification.MEDIA_FAILED:
         color = EmbedColors.RED;
-        if (settings.main.applicationUrl) {
-          fields.push({
-            name: 'View Media',
-            value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
-          });
-        }
+        fields.push({
+          name: 'Status',
+          value: 'Failed',
+          inline: true,
+        });
         break;
+    }
+
+    if (settings.main.applicationUrl && payload.media) {
+      fields.push({
+        name: `Open in ${settings.main.applicationTitle}`,
+        value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
+      });
     }
 
     return {

--- a/server/lib/notifications/agents/pushover.ts
+++ b/server/lib/notifications/agents/pushover.ts
@@ -9,6 +9,9 @@ interface PushoverPayload {
   user: string;
   title: string;
   message: string;
+  url: string;
+  url_title: string;
+  priority: number;
   html: number;
 }
 
@@ -41,10 +44,19 @@ class PushoverAgent
   private constructMessageDetails(
     type: Notification,
     payload: NotificationPayload
-  ): { title: string; message: string } {
+  ): {
+    title: string;
+    message: string;
+    url: string | undefined;
+    url_title: string | undefined;
+    priority: number;
+  } {
     const settings = getSettings();
     let messageTitle = '';
     let message = '';
+    let url: string | undefined;
+    let url_title: string | undefined;
+    let priority = 0;
 
     const title = payload.subject;
     const plot = payload.message;
@@ -53,45 +65,70 @@ class PushoverAgent
     switch (type) {
       case Notification.MEDIA_PENDING:
         messageTitle = 'New Request';
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `<b>Requested By</b>\n${username}\n\n`;
-        message += `<b>Status</b>\nPending Approval\n`;
+        message += `<b>${title}</b>`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n<b>Requested By</b>\n${username}`;
+        message += `\n\n<b>Status</b>\nPending Approval`;
         break;
       case Notification.MEDIA_APPROVED:
         messageTitle = 'Request Approved';
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `<b>Requested By</b>\n${username}\n\n`;
-        message += `<b>Status</b>\nProcessing Request\n`;
+        message += `<b>${title}</b>`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n<b>Requested By</b>\n${username}`;
+        message += `\n\n<b>Status</b>\nProcessing`;
         break;
       case Notification.MEDIA_AVAILABLE:
         messageTitle = 'Now Available';
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `<b>Requested By</b>\n${username}\n\n`;
-        message += `<b>Status</b>\nAvailable\n`;
+        message += `<b>${title}</b>`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n<b>Requested By</b>\n${username}`;
+        message += `\n\n<b>Status</b>\nAvailable`;
         break;
       case Notification.MEDIA_DECLINED:
         messageTitle = 'Request Declined';
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `<b>Requested By</b>\n${username}\n\n`;
-        message += `<b>Status</b>\nDeclined\n`;
+        message += `<b>${title}</b>`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n<b>Requested By</b>\n${username}`;
+        message += `\n\n<b>Status</b>\nDeclined`;
+        priority = 1;
+        break;
+      case Notification.MEDIA_FAILED:
+        messageTitle = 'Failed Request';
+        message += `<b>${title}</b>`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n<b>Requested By</b>\n${username}`;
+        message += `\n\n<b>Status</b>\nFailed`;
+        priority = 1;
         break;
       case Notification.TEST_NOTIFICATION:
         messageTitle = 'Test Notification';
-        message += `${plot}\n\n`;
-        message += `<b>Requested By</b>\n${username}\n`;
+        message += `${plot}`;
+        message += `\n\n<b>Requested By</b>\n${username}`;
         break;
     }
 
     if (settings.main.applicationUrl && payload.media) {
-      const actionUrl = `${settings.main.applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`;
-      message += `<a href="${actionUrl}">Open in ${settings.main.applicationTitle}</a>`;
+      url = `${settings.main.applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`;
+      url_title = `Open in ${settings.main.applicationTitle}`;
     }
 
-    return { title: messageTitle, message };
+    return {
+      title: messageTitle,
+      message,
+      url,
+      url_title,
+      priority,
+    };
   }
 
   public async send(
@@ -104,13 +141,22 @@ class PushoverAgent
 
       const { accessToken, userToken } = this.getSettings().options;
 
-      const { title, message } = this.constructMessageDetails(type, payload);
+      const {
+        title,
+        message,
+        url,
+        url_title,
+        priority,
+      } = this.constructMessageDetails(type, payload);
 
       await axios.post(endpoint, {
         token: accessToken,
         user: userToken,
         title: title,
         message: message,
+        url: url,
+        url_title: url_title,
+        priority: priority,
         html: 1,
       } as PushoverPayload);
 

--- a/server/lib/notifications/agents/pushover.ts
+++ b/server/lib/notifications/agents/pushover.ts
@@ -113,7 +113,6 @@ class PushoverAgent
       case Notification.TEST_NOTIFICATION:
         messageTitle = 'Test Notification';
         message += `${plot}`;
-        message += `\n\n<b>Requested By</b>\n${username}`;
         break;
     }
 

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -63,10 +63,12 @@ class SlackAgent
 
     const fields: EmbedField[] = [];
 
-    fields.push({
-      type: 'mrkdwn',
-      text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
-    });
+    if (payload.request) {
+      fields.push({
+        type: 'mrkdwn',
+        text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
+      });
+    }
 
     switch (type) {
       case Notification.MEDIA_PENDING:

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -58,77 +58,59 @@ class SlackAgent
     payload: NotificationPayload
   ): SlackBlockEmbed {
     const settings = getSettings();
-    let header = settings.main.applicationTitle;
+    let header = '';
     let actionUrl: string | undefined;
 
     const fields: EmbedField[] = [];
 
+    fields.push({
+      type: 'mrkdwn',
+      text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
+    });
+
     switch (type) {
       case Notification.MEDIA_PENDING:
         header = 'New Request';
-        fields.push(
-          {
-            type: 'mrkdwn',
-            text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
-          },
-          {
-            type: 'mrkdwn',
-            text: '*Status*\nPending Approval',
-          }
-        );
-        if (settings.main.applicationUrl) {
-          actionUrl = `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`;
-        }
+        fields.push({
+          type: 'mrkdwn',
+          text: '*Status*\nPending Approval',
+        });
         break;
       case Notification.MEDIA_APPROVED:
         header = 'Request Approved';
-        fields.push(
-          {
-            type: 'mrkdwn',
-            text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
-          },
-          {
-            type: 'mrkdwn',
-            text: '*Status*\nProcessing Request',
-          }
-        );
-        if (settings.main.applicationUrl) {
-          actionUrl = `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`;
-        }
+        fields.push({
+          type: 'mrkdwn',
+          text: '*Status*\nProcessing',
+        });
+        break;
+      case Notification.MEDIA_AVAILABLE:
+        header = 'Now Available';
+        fields.push({
+          type: 'mrkdwn',
+          text: '*Status*\nAvailable',
+        });
         break;
       case Notification.MEDIA_DECLINED:
         header = 'Request Declined';
-        fields.push(
-          {
-            type: 'mrkdwn',
-            text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
-          },
-          {
-            type: 'mrkdwn',
-            text: '*Status*\nDeclined',
-          }
-        );
-        if (settings.main.applicationUrl) {
-          actionUrl = `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`;
-        }
+        fields.push({
+          type: 'mrkdwn',
+          text: '*Status*\nDeclined',
+        });
         break;
-      case Notification.MEDIA_AVAILABLE:
-        header = 'Now available!';
-        fields.push(
-          {
-            type: 'mrkdwn',
-            text: `*Requested By*\n${payload.notifyUser.displayName ?? ''}`,
-          },
-          {
-            type: 'mrkdwn',
-            text: '*Status*\nAvailable',
-          }
-        );
+      case Notification.MEDIA_FAILED:
+        header = 'Failed Request';
+        fields.push({
+          type: 'mrkdwn',
+          text: '*Status*\nFailed',
+        });
+        break;
+      case Notification.TEST_NOTIFICATION:
+        header = 'Test Notification';
+        break;
+    }
 
-        if (settings.main.applicationUrl) {
-          actionUrl = `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`;
-        }
-        break;
+    if (settings.main.applicationUrl && payload.media) {
+      actionUrl = `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`;
     }
 
     const blocks: EmbedBlock[] = [
@@ -139,14 +121,17 @@ class SlackAgent
           text: header,
         },
       },
-      {
+    ];
+
+    if (type !== Notification.TEST_NOTIFICATION) {
+      blocks.push({
         type: 'section',
         text: {
           type: 'mrkdwn',
           text: `*${payload.subject}*`,
         },
-      },
-    ];
+      });
+    }
 
     if (payload.message) {
       blocks.push({
@@ -191,7 +176,7 @@ class SlackAgent
             value: 'open_overseerr',
             text: {
               type: 'plain_text',
-              text: `Open ${settings.main.applicationTitle}`,
+              text: `Open in ${settings.main.applicationTitle}`,
             },
           },
         ],

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -103,8 +103,7 @@ class TelegramAgent
         break;
       case Notification.TEST_NOTIFICATION:
         message += `\*Test Notification\*`;
-        message += `\n\n${plot}\n\n`;
-        message += `\n\n\*Requested By\*\n${user}`;
+        message += `\n\n${plot}`;
         break;
     }
 

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -8,6 +8,7 @@ interface TelegramPayload {
   text: string;
   parse_mode: string;
   chat_id: string;
+  disable_notification: boolean;
 }
 
 class TelegramAgent
@@ -56,49 +57,60 @@ class TelegramAgent
     /* eslint-disable no-useless-escape */
     switch (type) {
       case Notification.MEDIA_PENDING:
-        message += `\*New Request\*\n`;
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `\*Requested By\*\n${user}\n\n`;
-        message += `\*Status\*\nPending Approval\n`;
-
+        message += `\*New Request\*`;
+        message += `\n\n\*${title}\*`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n\*Requested By\*\n${user}`;
+        message += `\n\n\*Status\*\nPending Approval`;
         break;
       case Notification.MEDIA_APPROVED:
-        message += `\*Request Approved\*\n`;
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `\*Requested By\*\n${user}\n\n`;
-        message += `\*Status\*\nProcessing Request\n`;
-
-        break;
-      case Notification.MEDIA_DECLINED:
-        message += `\*Request Declined\*\n`;
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `\*Requested By\*\n${user}\n\n`;
-        message += `\*Status\*\nDeclined\n`;
-
+        message += `\*Request Approved\*`;
+        message += `\n\n\*${title}\*`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n\*Requested By\*\n${user}`;
+        message += `\n\n\*Status\*\nProcessing`;
         break;
       case Notification.MEDIA_AVAILABLE:
-        message += `\*Now available\\!\*\n`;
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `\*Requested By\*\n${user}\n\n`;
-        message += `\*Status\*\nAvailable\n`;
-
+        message += `\*Now Available\*`;
+        message += `\n\n\*${title}\*`;
+        if (plot) {
+          message += `\n${plot}\n\n`;
+        }
+        message += `\n\n\*Requested By\*\n${user}`;
+        message += `\n\n\*Status\*\nAvailable`;
+        break;
+      case Notification.MEDIA_DECLINED:
+        message += `\*Request Declined\*`;
+        message += `\n\n\*${title}\*`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n\*Requested By\*\n${user}`;
+        message += `\n\n\*Status\*\nDeclined`;
+        break;
+      case Notification.MEDIA_FAILED:
+        message += `\*Failed Request\*`;
+        message += `\n\n\*${title}\*`;
+        if (plot) {
+          message += `\n${plot}`;
+        }
+        message += `\n\n\*Requested By\*\n${user}`;
+        message += `\n\n\*Status\*\nFailed`;
         break;
       case Notification.TEST_NOTIFICATION:
-        message += `\*Test Notification\*\n`;
-        message += `${title}\n\n`;
-        message += `${plot}\n\n`;
-        message += `\*Requested By\*\n${user}\n`;
-
+        message += `\*Test Notification\*`;
+        message += `\n\n${plot}\n\n`;
+        message += `\n\n\*Requested By\*\n${user}`;
         break;
     }
 
     if (settings.main.applicationUrl && payload.media) {
       const actionUrl = `${settings.main.applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`;
-      message += `\[Open in ${settings.main.applicationTitle}\]\(${actionUrl}\)`;
+      message += `\n\n\[Open in ${settings.main.applicationTitle}\]\(${actionUrl}\)`;
     }
     /* eslint-enable */
 
@@ -119,6 +131,7 @@ class TelegramAgent
         text: this.buildMessage(type, payload),
         parse_mode: 'MarkdownV2',
         chat_id: `${this.getSettings().options.chatId}`,
+        disable_notification: this.getSettings().options.sendSilently,
       } as TelegramPayload);
 
       return true;

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -27,6 +27,7 @@ const KeyMap: Record<string, string | KeyMapFunction> = {
     payload.media?.status ? MediaStatus[payload.media?.status] : '',
   media_status4k: (payload) =>
     payload.media?.status ? MediaStatus[payload.media?.status4k] : '',
+  request_id: 'requestId',
 };
 
 class WebhookAgent

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -27,7 +27,7 @@ const KeyMap: Record<string, string | KeyMapFunction> = {
     payload.media?.status ? MediaStatus[payload.media?.status] : '',
   media_status4k: (payload) =>
     payload.media?.status ? MediaStatus[payload.media?.status4k] : '',
-  request_id: 'requestId',
+  request_id: 'request.id',
 };
 
 class WebhookAgent
@@ -61,6 +61,14 @@ class WebhookAgent
         }
         delete finalPayload[key];
         key = 'media';
+      } else if (key === '{{request}}') {
+        if (payload.request) {
+          finalPayload.request = finalPayload[key];
+        } else {
+          finalPayload.request = null;
+        }
+        delete finalPayload[key];
+        key = 'request';
       }
 
       if (typeof finalPayload[key] === 'string') {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -107,6 +107,7 @@ export interface NotificationAgentTelegram extends NotificationAgentConfig {
   options: {
     botAPI: string;
     chatId: string;
+    sendSilently: boolean;
   };
 }
 
@@ -220,6 +221,7 @@ class Settings {
             options: {
               botAPI: '',
               chatId: '',
+              sendSilently: false,
             },
           },
           pushover: {

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -35,7 +35,7 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               message: movie.overview,
               media: entity,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
-              requestId: request.id,
+              request: request,
             });
           });
         }
@@ -97,7 +97,7 @@ export class MediaSubscriber implements EntitySubscriberInterface {
                   .join(', '),
               },
             ],
-            requestId: request.id,
+            request: request,
           });
         }
       }

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -35,6 +35,7 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               message: movie.overview,
               media: entity,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
+              requestId: request.id,
             });
           });
         }
@@ -96,6 +97,7 @@ export class MediaSubscriber implements EntitySubscriberInterface {
                   .join(', '),
               },
             ],
+            requestId: request.id,
           });
         }
       }

--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -204,12 +204,10 @@ const NotificationsEmail: React.FC = () => {
             </div>
             <div className="form-row">
               <label htmlFor="secure" className="checkbox-label">
-                <div className="flex flex-col">
-                  <span>{intl.formatMessage(messages.enableSsl)}</span>
-                  <span className="text-gray-500">
-                    {intl.formatMessage(messages.ssldisabletip)}
-                  </span>
-                </div>
+                <span>{intl.formatMessage(messages.enableSsl)}</span>
+                <span className="label-tip">
+                  {intl.formatMessage(messages.ssldisabletip)}
+                </span>
               </label>
               <div className="form-input">
                 <Field type="checkbox" id="secure" name="secure" />

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -28,6 +28,8 @@ const messages = defineMessages({
     Additionally, you need the chat ID for the chat you want the bot to send notifications to.\
     You can do this by adding <GetIdBotLink>@get_id_bot</GetIdBotLink> to the chat or group chat.',
   notificationtypes: 'Notification Types',
+  sendSilently: 'Send Silently',
+  sendSilentlyTip: 'Send notifications with no sound',
 });
 
 const NotificationsTelegram: React.FC = () => {
@@ -57,6 +59,7 @@ const NotificationsTelegram: React.FC = () => {
         types: data?.types,
         botAPI: data?.options.botAPI,
         chatId: data?.options.chatId,
+        sendSilently: data?.options.sendSilently,
       }}
       validationSchema={NotificationsTelegramSchema}
       onSubmit={async (values) => {
@@ -67,6 +70,7 @@ const NotificationsTelegram: React.FC = () => {
             options: {
               botAPI: values.botAPI,
               chatId: values.chatId,
+              sendSilently: values.sendSilently,
             },
           });
           addToast(intl.formatMessage(messages.telegramsettingssaved), {
@@ -91,6 +95,7 @@ const NotificationsTelegram: React.FC = () => {
             options: {
               botAPI: values.botAPI,
               chatId: values.chatId,
+              sendSilently: values.sendSilently,
             },
           });
 
@@ -176,6 +181,21 @@ const NotificationsTelegram: React.FC = () => {
                   {errors.chatId && touched.chatId && (
                     <div className="error">{errors.chatId}</div>
                   )}
+                </div>
+              </div>
+              <div className="form-row">
+                <label htmlFor="sendSilently" className="checkbox-label">
+                  <span>{intl.formatMessage(messages.sendSilently)}</span>
+                  <span className="label-tip">
+                    {intl.formatMessage(messages.sendSilentlyTip)}
+                  </span>
+                </label>
+                <div className="form-input">
+                  <Field
+                    type="checkbox"
+                    id="sendSilently"
+                    name="sendSilently"
+                  />
                 </div>
               </div>
               <div

--- a/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
@@ -29,6 +29,7 @@ const defaultPayload = {
     status4k: '{{media_status4k}}',
   },
   '{{extra}}': [],
+  request_id: '{{request_id}}',
 };
 
 const messages = defineMessages({

--- a/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
@@ -29,7 +29,9 @@ const defaultPayload = {
     status4k: '{{media_status4k}}',
   },
   '{{extra}}': [],
-  request_id: '{{request_id}}',
+  '{{request}}': {
+    request_id: '{{request_id}}',
+  },
 };
 
 const messages = defineMessages({

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -287,6 +287,8 @@
   "components.Settings.Notifications.notificationtypes": "Notification Types",
   "components.Settings.Notifications.save": "Save Changes",
   "components.Settings.Notifications.saving": "Saving…",
+  "components.Settings.Notifications.sendSilently": "Send Silently",
+  "components.Settings.Notifications.sendSilentlyTip": "Send notifications with no sound",
   "components.Settings.Notifications.senderName": "Sender Name",
   "components.Settings.Notifications.settinguptelegram": "Setting Up Telegram Notifications",
   "components.Settings.Notifications.settinguptelegramDescription": "To set up Telegram, you need to <CreateBotLink>create a bot</CreateBotLink> and get the bot API key. Additionally, you need the chat ID for the chat you want the bot to send notifications to. You can do this by adding <GetIdBotLink>@get_id_bot</GetIdBotLink> to the chat or group chat.",


### PR DESCRIPTION
#### Description

- Added handling of `MEDIA_FAILED` notifications to the Pushover, Slack, and Telegram agents.
- Refactored construction of notification messages/payloads to reduce the amount of duplicated code.
- Fixed formatting of notification messages for Pushover and Telegram agents for consistency.
- Added appropriate priorities to Pushover notifications.
- Send action URL using the `url` and `url_title` parameters instead of as part of the message body for Pushover notifications.
- Added option to send Telegram notifications silently.
- Added request ID to default webhook JSON payload (existing users will need to click the "Reset to Default" button or add it manually).

#### Todos

- [x] Successful build
- [x] Translation keys

#### Issues Fixed or Closed by this PR

- Fixes #623
- Fixes #761
- Fixes #795