### PR TITLE
fix(notif): Do not HTML-escape email subjects

### DIFF
--- a/server/templates/email/generatedpassword/subject.pug
+++ b/server/templates/email/generatedpassword/subject.pug
@@ -1,1 +1,1 @@
-= `Account Information - ${applicationTitle}`
+!= `Account Information [${applicationTitle}]`

--- a/server/templates/email/media-request/subject.pug
+++ b/server/templates/email/media-request/subject.pug
@@ -1,1 +1,1 @@
-= `${requestType}: ${mediaName} - ${applicationTitle}`
+!= `${requestType} - ${mediaName} [${applicationTitle}]`

--- a/server/templates/email/resetpassword/subject.pug
+++ b/server/templates/email/resetpassword/subject.pug
@@ -1,1 +1,1 @@
-= `Password Reset - ${applicationTitle}`
+!= `Password Reset [${applicationTitle}]`

--- a/server/templates/email/test-email/subject.pug
+++ b/server/templates/email/test-email/subject.pug
@@ -1,1 +1,1 @@
-= `Test Notification - ${applicationTitle}`
+!= `Test Notification [${applicationTitle}]`


### PR DESCRIPTION
#### Description
Do not HTML-escape email subjects, to prevent unwanted character sequences like `&amp;`.

More info: https://pugjs.org/language/code.html#unescaped-buffered-code

#### Screenshot (if UI related)
N/A

#### Todos

- [x] Successful build

#### Issues Fixed or Closed by this PR

- Fixes #927