### PR TITLE
fix(auth): handle sign-in attempts from emails with no password

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -108,11 +108,11 @@ export class User {
   }
 
   public passwordMatch(password: string): Promise<boolean> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (this.password) {
         resolve(bcrypt.compare(password, this.password));
       } else {
-        return reject(false);
+        return resolve(false);
       }
     });
   }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -176,7 +176,10 @@ authRoutes.post('/local', async (req, res, next) => {
 
     return res.status(200).json(user?.filter() ?? {});
   } catch (e) {
-    logger.error(e.message, { label: 'Auth' });
+    logger.error('Something went wrong when trying to authenticate', {
+      label: 'Auth',
+      error: e.message,
+    });
     return next({
       status: 500,
       message: 'Something went wrong.',


### PR DESCRIPTION
#### Description
No longer logs undefined when trying to login with emails that are connected to a user with no password.

#### Todos
- [x] Sucessfully builds `yarn build`

#### Issues Fixed or Closed by this PR

- Fixes #771 
