### PR TITLE
build(snap): Disable arm64 snap build.

### DIFF
--- a/.github/workflows/invalid_template.yml
+++ b/.github/workflows/invalid_template.yml
@@ -14,6 +14,6 @@ jobs:
           support-label: 'invalid:template-incomplete'
           issue-comment: >
             :wave: @{issue-author}, please edit your issue and follow the template provided.
-          close-issue: false
-          lock-issue: false
+          close-issue: true
+          lock-issue: true
           issue-lock-reason: 'resolved'

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         architecture:
           - amd64
-          - arm64
+          #- arm64 Disable until there is a workaround or fix.
           - armhf
     steps:
       - name: Checkout Code

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -8,6 +8,7 @@ jobs:
   jobs:
     name: Job Check
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -17,7 +18,6 @@ jobs:
     name: Lint & Test Build
     needs: jobs
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container: node:12.18-alpine
     steps:
       - name: checkout

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -5,8 +5,17 @@ on:
     branches: [develop]
 
 jobs:
+  jobs:
+    name: Job Check
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
   test:
     name: Lint & Test Build
+    needs: jobs
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container: node:12.18-alpine


### PR DESCRIPTION
#### Description
1) This change disables `arm64` until we find a fix or workaround. Waiting on a response [here](https://forum.snapcraft.io/t/snapcraft-4-5-1-cannot-pack-data-prime-mksquashfs-call-failed-signal-segmentation-fault-core-dumped/22749).

2) Updated the snap workflow to include a job check. 

3) Changed invalid template workflow to close and lock and invalid issue. 

#### Screenshot (if UI related)

N/A

#### Todos

None

#### Issues Fixed or Closed by this PR

N/A
