### PR TITLE
fix(ui): Automatically disable and uncheck user permissions with unmet requirements

### DIFF
--- a/src/components/PermissionEdit/index.tsx
+++ b/src/components/PermissionEdit/index.tsx
@@ -115,18 +115,21 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
       name: intl.formatMessage(messages.request4k),
       description: intl.formatMessage(messages.request4kDescription),
       permission: Permission.REQUEST_4K,
+      requires: [{ permissions: [Permission.REQUEST] }],
       children: [
         {
           id: 'request4k-movies',
           name: intl.formatMessage(messages.request4kMovies),
           description: intl.formatMessage(messages.request4kMoviesDescription),
           permission: Permission.REQUEST_4K_MOVIE,
+          requires: [{ permissions: [Permission.REQUEST] }],
         },
         {
           id: 'request4k-tv',
           name: intl.formatMessage(messages.request4kTv),
           description: intl.formatMessage(messages.request4kTvDescription),
           permission: Permission.REQUEST_4K_TV,
+          requires: [{ permissions: [Permission.REQUEST] }],
         },
       ],
     },
@@ -135,6 +138,7 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
       name: intl.formatMessage(messages.autoapprove),
       description: intl.formatMessage(messages.autoapproveDescription),
       permission: Permission.AUTO_APPROVE,
+      requires: [{ permissions: [Permission.REQUEST] }],
       children: [
         {
           id: 'autoapprovemovies',
@@ -143,6 +147,7 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
             messages.autoapproveMoviesDescription
           ),
           permission: Permission.AUTO_APPROVE_MOVIE,
+          requires: [{ permissions: [Permission.REQUEST] }],
         },
         {
           id: 'autoapprovetv',
@@ -151,6 +156,7 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
             messages.autoapproveSeriesDescription
           ),
           permission: Permission.AUTO_APPROVE_TV,
+          requires: [{ permissions: [Permission.REQUEST] }],
         },
       ],
     },
@@ -159,6 +165,12 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
       name: intl.formatMessage(messages.autoapprove4k),
       description: intl.formatMessage(messages.autoapprove4kDescription),
       permission: Permission.AUTO_APPROVE_4K,
+      requires: [
+        {
+          permissions: [Permission.REQUEST, Permission.REQUEST_4K],
+          type: 'and',
+        },
+      ],
       children: [
         {
           id: 'autoapprove4k-movies',
@@ -167,6 +179,15 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
             messages.autoapprove4kMoviesDescription
           ),
           permission: Permission.AUTO_APPROVE_4K_MOVIE,
+          requires: [
+            {
+              permissions: [Permission.REQUEST],
+            },
+            {
+              permissions: [Permission.REQUEST_4K, Permission.REQUEST_4K_MOVIE],
+              type: 'or',
+            },
+          ],
         },
         {
           id: 'autoapprove4k-tv',
@@ -175,6 +196,15 @@ export const PermissionEdit: React.FC<PermissionEditProps> = ({
             messages.autoapprove4kSeriesDescription
           ),
           permission: Permission.AUTO_APPROVE_4K_TV,
+          requires: [
+            {
+              permissions: [Permission.REQUEST],
+            },
+            {
+              permissions: [Permission.REQUEST_4K, Permission.REQUEST_4K_TV],
+              type: 'or',
+            },
+          ],
         },
       ],
     },

--- a/src/components/PermissionOption/index.tsx
+++ b/src/components/PermissionOption/index.tsx
@@ -20,16 +20,9 @@ const hasRequirement = (
   requirement: PermissionRequirement,
   currentPermission: number
 ): boolean => {
-  switch (requirement.type) {
-    case 'or':
-      return requirement.permissions.some(
-        (permission) => !!(permission & currentPermission)
-      );
-    default:
-      return requirement.permissions.every(
-        (permission) => !!(permission & currentPermission)
-      );
-  }
+  return hasPermission(requirement.permissions, currentPermission, {
+    type: requirement.type ?? 'and',
+  });
 };
 
 interface PermissionOptionProps {

--- a/src/components/PermissionOption/index.tsx
+++ b/src/components/PermissionOption/index.tsx
@@ -16,15 +16,6 @@ interface PermissionRequirement {
   type?: 'and' | 'or';
 }
 
-const hasRequirement = (
-  requirement: PermissionRequirement,
-  currentPermission: number
-): boolean => {
-  return hasPermission(requirement.permissions, currentPermission, {
-    type: requirement.type ?? 'and',
-  });
-};
-
 interface PermissionOptionProps {
   option: PermissionItem;
   currentPermission: number;
@@ -65,7 +56,9 @@ const PermissionOption: React.FC<PermissionOptionProps> = ({
             option.permission === Permission.MANAGE_SETTINGS) ||
           (option.requires &&
             !option.requires.every((requirement) =>
-              hasRequirement(requirement, currentPermission)
+              hasPermission(requirement.permissions, currentPermission, {
+                type: requirement.type ?? 'and',
+              })
             ))
             ? 'opacity-50'
             : ''
@@ -91,7 +84,9 @@ const PermissionOption: React.FC<PermissionOptionProps> = ({
                 option.permission === Permission.MANAGE_SETTINGS) ||
               (option.requires &&
                 !option.requires.every((requirement) =>
-                  hasRequirement(requirement, currentPermission)
+                  hasPermission(requirement.permissions, currentPermission, {
+                    type: requirement.type ?? 'and',
+                  })
                 ))
             }
             onChange={() => {
@@ -112,7 +107,9 @@ const PermissionOption: React.FC<PermissionOptionProps> = ({
                   ))) &&
               (!option.requires ||
                 option.requires.every((requirement) =>
-                  hasRequirement(requirement, currentPermission)
+                  hasPermission(requirement.permissions, currentPermission, {
+                    type: requirement.type ?? 'and',
+                  })
                 ))
             }
           />


### PR DESCRIPTION
#### Description

Some permissions are dependent on other, non-parent permissions.  For example, "Auto-Approve 4K" is dependent on both "Request" (general request permission) and "Request 4K" (4K content request permission).  This PR adds a check for requirements for a particular permission, and disables and unchecks a permission if that condition is not satisfied.

#### Todos

- [x] Successful build