### PR TITLE
fix(notif): Remove extra newlines from Telegram notifications

### DIFF
--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -78,7 +78,7 @@ class TelegramAgent
         message += `\*Now Available\*`;
         message += `\n\n\*${title}\*`;
         if (plot) {
-          message += `\n${plot}\n\n`;
+          message += `\n${plot}`;
         }
         message += `\n\n\*Requested By\*\n${user}`;
         message += `\n\n\*Status\*\nAvailable`;


### PR DESCRIPTION
#### Description

Removes extra newlines from "Now Available" Telegram notifications.

#### Todos

- [x] Successful build