### PR TITLE
chore(github): Edit templates for consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,45 +1,45 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Submit a report to help us improve
 title: ''
 labels: 'awaiting-triage, type:bug'
 assignees: ''
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+#### Description
 
-**What version of Overseerr are you running?**
-Please fill in the version you are currently running.
+Please provide a clear and concise description of the bug or issue.
 
-You can find it under: Settings -> About -> Version
+#### Version
 
-**To Reproduce**
-Steps to reproduce the behavior:
+What version of Overseerr are you running? (You can find this in Settings → About → Version.)
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+#### Steps to Reproduce
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+Please tell us how we can reproduce the undesired behavior.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+1. Go to [...]
+2. Click on [...]
+3. Scroll down to [...]
+4. See error in [...]
 
-**Desktop (please complete the following information):**
+#### Expected Behavior
 
-- OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
+Please provide a clear and concise description of what you expected to happen.
 
-**Smartphone (please complete the following information):**
+#### Screenshots
 
-- Device: [e.g. iPhone6]
-- OS: [e.g. iOS8.1]
-- Browser [e.g. stock browser, safari]
-- Version [e.g. 22]
+If applicable, please provide screenshots depicting the problem.
 
-**Additional context**
-Add any other context about the problem here.
+#### Device
+
+What device were you using when you encountered this issue? Please provide this information to help us reproduce and investigate the bug.
+
+- **Platform:** [e.g., desktop, smartphone, tablet]
+- **Device:** [e.g., iPhone X, Surface Pro, Samsung Galaxy Tab]
+- **OS:** [e.g., iOS 8.1, Windows 10, Android 11]
+- **Browser:** [e.g., Chrome, Safari, Edge, Firefox]
+
+#### Additional Context
+
+Please provide any additional information that may be relevant or helpful.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,11 +6,14 @@ labels: 'awaiting-triage, type:enhancement'
 assignees: ''
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+#### Description
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+Is your feature request related to a problem? If so, please provide a clear and concise description of the problem. E.g., "I'm always frustrated when [...]."
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+#### Desired Behavior
+
+Provide a clear and concise description of what you want to happen.
+
+#### Additional Context
+
+Provide any additional information or screenshots that may be relevant or helpful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
 #### Description
 
-#### Screenshot (if UI related)
+#### Screenshot (if UI-related)
 
-#### Todos
+#### To-Dos
 
-- [ ] Sucessfully builds `yarn build`
-- [ ] Translation Keys `yarn i18n:extract`
-- [ ] Database migration created (if required)
+- [ ] Successful build `yarn build`
+- [ ] Translation keys `yarn i18n:extract`
+- [ ] Database migration (if required)
 
-#### Issues Fixed or Closed by this PR
+#### Issues Fixed
 
 - Fixes #XXXX

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@
 - [ ] Translation keys `yarn i18n:extract`
 - [ ] Database migration (if required)
 
-#### Issues Fixed
+#### Issues Fixed or Closed
 
 - Fixes #XXXX

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ exemptLabels:
   - security
   - dependencies
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
#### Description

@sct This PR is just my suggestions/opinions for improvement, and I understand if you don't want to change certain things.

It really bothers me that the PR template uses headings, whereas the issue templates use bolded text.  Changing this would enable us to use an action such as [lucasbento/auto-close-issues](https://github.com/lucasbento/auto-close-issues) to automatically label and close issues that do not follow the template.  It also has the advantage of automatically re-opening issues if a user fixes the template! 😉  I think that this would help greatly with issue management, especially as Overseerr grows and becomes more popular.

I also corrected the spelling error in the PR template and edited heading names, etc. for consistency/clarity.

#### Screenshots

N/A

#### To-Dos

N/A

#### Issues Fixed

N/A