### PR TITLE
fix(ui): Fix settings navigation horizontal scroll issues

### DIFF
--- a/src/components/Settings/SettingsLayout.tsx
+++ b/src/components/Settings/SettingsLayout.tsx
@@ -122,20 +122,18 @@ const SettingsLayout: React.FC = ({ children }) => {
             ))}
           </select>
         </div>
-        <div className="hidden sm:block">
-          <div className="border-b border-gray-600">
-            <nav className="flex -mb-px">
-              {settingsRoutes.map((route, index) => (
-                <SettingsLink
-                  route={route.route}
-                  regex={route.regex}
-                  key={`standard-settings-link-${index}`}
-                >
-                  {route.text}
-                </SettingsLink>
-              ))}
-            </nav>
-          </div>
+        <div className="hidden overflow-x-scroll overflow-y-hidden border-b border-gray-600 sm:block hide-scrollbar">
+          <nav className="flex -mb-px">
+            {settingsRoutes.map((route, index) => (
+              <SettingsLink
+                route={route.route}
+                regex={route.regex}
+                key={`standard-settings-link-${index}`}
+              >
+                {route.text}
+              </SettingsLink>
+            ))}
+          </nav>
         </div>
       </div>
       <div className="mt-10 text-white">{children}</div>

--- a/src/components/Settings/SettingsNotifications.tsx
+++ b/src/components/Settings/SettingsNotifications.tsx
@@ -311,7 +311,7 @@ const SettingsNotifications: React.FC = ({ children }) => {
             ))}
           </select>
         </div>
-        <div className="hidden sm:block">
+        <div className="hidden overflow-x-scroll overflow-y-hidden sm:block hide-scrollbar">
           <nav className="flex space-x-4" aria-label="Tabs">
             {settingsRoutes.map((route, index) => (
               <SettingsLink


### PR DESCRIPTION
#### Description

Fix navigation display issue in Settings in cases where the window/viewport is not wide enough to display all options/tabs without scrolling.

#### Screenshot (if UI-related)

- Before:
   ![image](https://user-images.githubusercontent.com/52870424/108635148-b2703780-744b-11eb-8c32-50dd6fa5a131.png)
- After:
   ![image](https://user-images.githubusercontent.com/52870424/108635150-be5bf980-744b-11eb-93de-7b559a0787bf.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A