### PR TITLE
fix(ui): Display 4K download status on 4K status badge

### DIFF
--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -416,7 +416,7 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
                     status={data.mediaInfo?.status4k}
                     is4k
                     inProgress={
-                      (data.mediaInfo?.downloadStatus ?? []).length > 0
+                      (data.mediaInfo?.downloadStatus4k ?? []).length > 0
                     }
                     plexUrl4k={data.mediaInfo?.plexUrl4k}
                   />


### PR DESCRIPTION
#### Description

Incorrect download status array is being used for the 4K status badge on TV series detail pages.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A