### PR TITLE
build(snap): Revert QEMU version to fix arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
 
       - name: Build Snap Package
         uses: diddlesnaps/snapcraft-multiarch-action@v1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
 
       - name: Build Snap Package
         uses: diddlesnaps/snapcraft-multiarch-action@v1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         architecture:
           - amd64
-          #- arm64 Disable until there is a workaround or fix.
+          - arm64
           - armhf
     steps:
       - name: Checkout Code


### PR DESCRIPTION
#### Description

The issue with the snap packages and `arm64` appear to be related to the latest QEMU version. This change reverts QEMU to a known working version. We will have to park QEMU for snap build until there is a fix. 

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A
