### PR TITLE
fix(frontend): use region settings instead of hardcoded 'US' value for movie/TV ratings

### DIFF
--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -12,6 +12,7 @@ export interface PublicSettingsResponse {
   localLogin: boolean;
   movie4kEnabled: boolean;
   series4kEnabled: boolean;
+  region: string;
 }
 
 export interface CacheItem {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -84,6 +84,7 @@ interface FullPublicSettings extends PublicSettings {
   localLogin: boolean;
   movie4kEnabled: boolean;
   series4kEnabled: boolean;
+  region: string;
 }
 
 export interface NotificationAgentConfig {
@@ -335,6 +336,7 @@ class Settings {
       series4kEnabled: this.data.sonarr.some(
         (sonarr) => sonarr.is4k && sonarr.isDefault
       ),
+      region: this.data.main.region,
     };
   }
 

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -82,20 +82,28 @@ interface MovieDetailsProps {
 
 const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
   const settings = useSettings();
-  const { hasPermission } = useUser();
+  const { user, hasPermission } = useUser();
   const router = useRouter();
   const intl = useIntl();
   const { locale } = useContext(LanguageContext);
   const [showManager, setShowManager] = useState(false);
+
   const { data, error, revalidate } = useSWR<MovieDetailsType>(
     `/api/v1/movie/${router.query.movieId}?language=${locale}`,
     {
       initialData: movie,
     }
   );
+
   const { data: ratingData } = useSWR<RTRating>(
     `/api/v1/movie/${router.query.movieId}/ratings`
   );
+
+  const { data: userSettings } = useSWR<{
+    username?: string;
+    region?: string;
+    originalLanguage?: string;
+  }>(user ? `/api/v1/user/${user?.id}/settings/main` : null);
 
   const sortedCrew = useMemo(() => sortCrewPriority(data?.credits.crew ?? []), [
     data,
@@ -156,17 +164,22 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
     revalidate();
   };
 
+  const region = userSettings?.region
+    ? userSettings.region
+    : settings.currentSettings.region
+    ? settings.currentSettings.region
+    : 'US';
   const movieAttributes: React.ReactNode[] = [];
 
   if (
     data.releases.results.length &&
-    (data.releases.results.find((r) => r.iso_3166_1 === 'US')?.release_dates[0]
-      .certification ||
+    (data.releases.results.find((r) => r.iso_3166_1 === region)
+      ?.release_dates[0].certification ||
       data.releases.results[0].release_dates[0].certification)
   ) {
     movieAttributes.push(
       <span className="p-0.5 py-0 border rounded-md">
-        {data.releases.results.find((r) => r.iso_3166_1 === 'US')
+        {data.releases.results.find((r) => r.iso_3166_1 === region)
           ?.release_dates[0].certification ||
           data.releases.results[0].release_dates[0].certification}
       </span>

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -99,12 +99,6 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
     `/api/v1/movie/${router.query.movieId}/ratings`
   );
 
-  const { data: userSettings } = useSWR<{
-    username?: string;
-    region?: string;
-    originalLanguage?: string;
-  }>(user ? `/api/v1/user/${user?.id}/settings/main` : null);
-
   const sortedCrew = useMemo(() => sortCrewPriority(data?.credits.crew ?? []), [
     data,
   ]);
@@ -164,8 +158,8 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
     revalidate();
   };
 
-  const region = userSettings?.region
-    ? userSettings.region
+  const region = user?.settings?.region
+    ? user.settings.region
     : settings.currentSettings.region
     ? settings.currentSettings.region
     : 'US';

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -98,12 +98,6 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
     `/api/v1/tv/${router.query.tvId}/ratings`
   );
 
-  const { data: userSettings } = useSWR<{
-    username?: string;
-    region?: string;
-    originalLanguage?: string;
-  }>(user ? `/api/v1/user/${user?.id}/settings/main` : null);
-
   const sortedCrew = useMemo(() => sortCrewPriority(data?.credits.crew ?? []), [
     data,
   ]);
@@ -163,8 +157,8 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
     revalidate();
   };
 
-  const region = userSettings?.region
-    ? userSettings.region
+  const region = user?.settings?.region
+    ? user.settings.region
     : settings.currentSettings.region
     ? settings.currentSettings.region
     : 'US';

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -13,6 +13,7 @@ const defaultSettings = {
   localLogin: false,
   movie4kEnabled: false,
   series4kEnabled: false,
+  region: '',
 };
 
 export const SettingsContext = React.createContext<SettingsContextProps>({

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -6,6 +6,7 @@ import {
 } from '../../server/lib/permissions';
 import { UserType } from '../../server/constants/user';
 import { mutateCallback } from 'swr/dist/types';
+import { UserSettings } from '../../server/entity/UserSettings';
 
 export { Permission, UserType };
 
@@ -21,6 +22,7 @@ export interface User {
   createdAt: Date;
   updatedAt: Date;
   requestCount: number;
+  settings?: UserSettings;
 }
 
 interface UserHookResponse {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -6,7 +6,6 @@ import {
 } from '../../server/lib/permissions';
 import { UserType } from '../../server/constants/user';
 import { mutateCallback } from 'swr/dist/types';
-import { UserSettings } from '../../server/entity/UserSettings';
 
 export { Permission, UserType };
 
@@ -23,6 +22,13 @@ export interface User {
   updatedAt: Date;
   requestCount: number;
   settings?: UserSettings;
+}
+
+export interface UserSettings {
+  enableNotifications: boolean;
+  discordId?: string;
+  region?: string;
+  originalLanguage?: string;
 }
 
 interface UserHookResponse {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -144,6 +144,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     movie4kEnabled: false,
     series4kEnabled: false,
     localLogin: true,
+    region: '',
   };
 
   let locale = 'en';


### PR DESCRIPTION
#### Description

Movie/TV ratings are associated with releases, and we currently return the rating associated with a US release if one exists.

This changes the behavior to use the global or user region setting, and to fall back to the US region only if those are both set to "All Regions."

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A