### PR TITLE
fix(notif): escape application title in Telegram notifications

### DIFF
--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -53,6 +53,7 @@ class TelegramAgent
     const title = this.escapeText(payload.subject);
     const plot = this.escapeText(payload.message);
     const user = this.escapeText(payload.notifyUser.displayName);
+    const applicationTitle = this.escapeText(settings.main.applicationTitle);
 
     /* eslint-disable no-useless-escape */
     switch (type) {
@@ -109,7 +110,7 @@ class TelegramAgent
 
     if (settings.main.applicationUrl && payload.media) {
       const actionUrl = `${settings.main.applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`;
-      message += `\n\n\[Open in ${settings.main.applicationTitle}\]\(${actionUrl}\)`;
+      message += `\n\n\[Open in ${applicationTitle}\]\(${actionUrl}\)`;
     }
     /* eslint-enable */
 

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -17,7 +17,7 @@ const messages = defineMessages({
   botAPI: 'Bot Authentication Token',
   chatId: 'Chat ID',
   validationBotAPIRequired: 'You must provide a bot authentication token',
-  validationChatIdRequired: 'You must provide a valid chat ID',
+  validationChatIdRequired: 'You must provide a chat ID',
   telegramsettingssaved: 'Telegram notification settings saved successfully!',
   telegramsettingsfailed: 'Telegram notification settings failed to save.',
   testsent: 'Test notification sent!',
@@ -43,9 +43,9 @@ const NotificationsTelegram: React.FC = () => {
     botAPI: Yup.string().required(
       intl.formatMessage(messages.validationBotAPIRequired)
     ),
-    chatId: Yup.string()
-      .required(intl.formatMessage(messages.validationChatIdRequired))
-      .matches(/^\d+$/, intl.formatMessage(messages.validationChatIdRequired)),
+    chatId: Yup.string().required(
+      intl.formatMessage(messages.validationChatIdRequired)
+    ),
   });
 
   if (!data && !error) {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -326,7 +326,7 @@
   "components.Settings.Notifications.test": "Test",
   "components.Settings.Notifications.testsent": "Test notification sent!",
   "components.Settings.Notifications.validationBotAPIRequired": "You must provide a bot authentication token",
-  "components.Settings.Notifications.validationChatIdRequired": "You must provide a valid chat ID",
+  "components.Settings.Notifications.validationChatIdRequired": "You must provide a chat ID",
   "components.Settings.Notifications.validationEmail": "You must provide a valid email address",
   "components.Settings.Notifications.validationSmtpHostRequired": "You must provide an SMTP host",
   "components.Settings.Notifications.validationSmtpPortRequired": "You must provide an SMTP port",


### PR DESCRIPTION
#### Description

When the custom application title contained certain special characters, Telegram notifications would fail to send.

Also, removed the validation on the chat ID field since it does not account for some chat IDs which begin with a special character.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #1010