### PR TITLE
fix(ui): show translated string on sonarr sucesss/failure toast messages

### DIFF
--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -185,7 +185,7 @@ const SonarrModal: React.FC<SonarrModalProps> = ({
         setIsValidated(true);
         setTestResponse(response.data);
         if (initialLoad.current) {
-          addToast('Sonarr connection established!', {
+          addToast(intl.formatMessage(messages.toastSonarrTestSuccess), {
             appearance: 'success',
             autoDismiss: true,
           });
@@ -193,7 +193,7 @@ const SonarrModal: React.FC<SonarrModalProps> = ({
       } catch (e) {
         setIsValidated(false);
         if (initialLoad.current) {
-          addToast('Failed to connect to Sonarr server', {
+          addToast(intl.formatMessage(messages.toastSonarrTestFailure), {
             appearance: 'error',
             autoDismiss: true,
           });


### PR DESCRIPTION
#### Description
The toast showed a shows string instead of the internationalized one. This fixes that.

#### Screenshot (if UI-related)
![image](https://user-images.githubusercontent.com/20923978/109303405-2fd4e700-7854-11eb-8813-37501460c0c3.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
