### PR TITLE
chore(github): lock closed support issues

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -21,5 +21,5 @@ jobs:
             - [Discord](https://discord.gg/PkCWJSeCk7)
             - [GitHub Discussions](https://github.com/sct/overseerr/discussions)
           close-issue: true
-          lock-issue: false
+          lock-issue: true
           issue-lock-reason: 'off-topic'

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -19,6 +19,7 @@ jobs:
             to get help with Overseerr.
 
             - [Discord](https://discord.gg/PkCWJSeCk7)
+
             - [GitHub Discussions](https://github.com/sct/overseerr/discussions)
           close-issue: true
           lock-issue: true


### PR DESCRIPTION
#### Description

When issues are tagged as support, lock conversation in addition to closing them.

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A