### PR TITLE
build(docker): bump node from 14.15 to 14.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15-alpine AS BUILD_IMAGE
+FROM node:14.16-alpine AS BUILD_IMAGE
 
 ARG COMMIT_TAG
 ENV COMMIT_TAG=${COMMIT_TAG}
@@ -20,7 +20,7 @@ RUN touch config/DOCKER
 RUN echo "{\"commitTag\": \"${COMMIT_TAG}\"}" > committag.json
 
 
-FROM node:14.15-alpine
+FROM node:14.16-alpine
 
 RUN apk add --no-cache tzdata
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine
+FROM node:14.16-alpine
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
#### Description

Node v14.x (LTS) update from 2021-02-23 (includes vulnerability fixes)
https://nodejs.org/en/blog/release/v14.16.0/

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `docker build`

#### Issues Fixed or Closed

N/A