### PR TITLE
build(snap): bump node to 14.16.0 for snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 parts:
   overseerr:
     plugin: nodejs
-    nodejs-version: "12.18.4"
+    nodejs-version: "14.16.0"
     nodejs-package-manager: "yarn"
     nodejs-yarn-version: v1.22.5
     build-packages:


### PR DESCRIPTION
#### Description
Bump node version for sanp to align with docker builds. 

#### To-Dos

- [X] Successful build `yarn build`

#### Issues Fixed or Closed

N/A
