### PR TITLE
fix(lang): use localized genre names

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4427,6 +4427,12 @@ paths:
       description: Returns a list of genres in a JSON array.
       tags:
         - tmdb
+      parameters:
+        - in: query
+          name: language
+          schema:
+            type: string
+            example: en
       responses:
         '200':
           description: Results
@@ -4449,6 +4455,12 @@ paths:
       description: Returns a list of genres in a JSON array.
       tags:
         - tmdb
+      parameters:
+        - in: query
+          name: language
+          schema:
+            type: string
+            example: en
       responses:
         '200':
           description: Results

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -695,11 +695,15 @@ class TheMovieDb extends ExternalAPI {
     }
   }
 
-  public async getMovieGenres(): Promise<TmdbGenre[]> {
+  public async getMovieGenres(language = 'en'): Promise<TmdbGenre[]> {
     try {
       const data = await this.get<TmdbGenresResult>(
         '/genre/movie/list',
-        {},
+        {
+          params: {
+            language,
+          },
+        },
         86400 // 24 hours
       );
 
@@ -711,11 +715,15 @@ class TheMovieDb extends ExternalAPI {
     }
   }
 
-  public async getTvGenres(): Promise<TmdbGenre[]> {
+  public async getTvGenres(language = 'en'): Promise<TmdbGenre[]> {
     try {
       const data = await this.get<TmdbGenresResult>(
         '/genre/tv/list',
-        {},
+        {
+          params: {
+            language,
+          },
+        },
         86400 // 24 hours
       );
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -93,7 +93,7 @@ router.get<{ id: string }>('/network/:id', async (req, res) => {
 router.get('/genres/movie', isAuthenticated(), async (req, res) => {
   const tmdb = new TheMovieDb();
 
-  const genres = await tmdb.getMovieGenres();
+  const genres = await tmdb.getMovieGenres(req.query.language as string);
 
   return res.status(200).json(genres);
 });
@@ -101,7 +101,7 @@ router.get('/genres/movie', isAuthenticated(), async (req, res) => {
 router.get('/genres/tv', isAuthenticated(), async (req, res) => {
   const tmdb = new TheMovieDb();
 
-  const genres = await tmdb.getTvGenres();
+  const genres = await tmdb.getTvGenres(req.query.language as string);
 
   return res.status(200).json(genres);
 });

--- a/src/components/Discover/DiscoverMovies.tsx
+++ b/src/components/Discover/DiscoverMovies.tsx
@@ -33,7 +33,9 @@ const DiscoverMovies: React.FC = () => {
   const settings = useSettings();
   const { locale } = useContext(LanguageContext);
 
-  const { data: genres } = useSWR<TmdbGenre[]>('/api/v1/genres/movie');
+  const { data: genres } = useSWR<TmdbGenre[]>(
+    `/api/v1/genres/movie?language=${locale}`
+  );
   const genre = genres?.find((g) => g.id === Number(router.query.genreId));
 
   const { data: studio } = useSWR<TmdbStudio>(

--- a/src/components/Discover/DiscoverTv.tsx
+++ b/src/components/Discover/DiscoverTv.tsx
@@ -33,7 +33,9 @@ const DiscoverTv: React.FC = () => {
   const settings = useSettings();
   const { locale } = useContext(LanguageContext);
 
-  const { data: genres } = useSWR<TmdbGenre[]>('/api/v1/genres/tv');
+  const { data: genres } = useSWR<TmdbGenre[]>(
+    `/api/v1/genres/tv?language=${locale}`
+  );
   const genre = genres?.find((g) => g.id === Number(router.query.genreId));
 
   const { data: network } = useSWR<TmdbNetwork>(


### PR DESCRIPTION
#### Description

TMDb supports the `language` parameter on their genres endpoints, so we should pass it to get localized genre names on the new genre-filtered Discover pages.  (The companies and networks endpoints unfortunately do not support this.)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A