### PR TITLE
fix(ui): add alt prop to studio/network logos & fix blinking text cursor

### DIFF
--- a/src/components/Discover/DiscoverNetwork/index.tsx
+++ b/src/components/Discover/DiscoverNetwork/index.tsx
@@ -49,9 +49,9 @@ const DiscoverTvNetwork: React.FC = () => {
           {firstResultData?.network.logoPath ? (
             <div className="flex justify-center mb-6">
               <img
-                src={`//image.tmdb.org/t/p/w780_filter(negate,000,666)/${firstResultData?.network.logoPath}`}
-                alt=""
-                className="text-white max-h-24 sm:max-h-32"
+                src={`//image.tmdb.org/t/p/w780_filter(negate,000,666)/${firstResultData.network.logoPath}`}
+                alt={firstResultData.network.name}
+                className="max-h-24 sm:max-h-32"
               />
             </div>
           ) : (

--- a/src/components/Discover/DiscoverStudio/index.tsx
+++ b/src/components/Discover/DiscoverStudio/index.tsx
@@ -49,9 +49,9 @@ const DiscoverMovieStudio: React.FC = () => {
           {firstResultData?.studio.logoPath ? (
             <div className="flex justify-center mb-6">
               <img
-                src={`//image.tmdb.org/t/p/w780_filter(negate,000,666)/${firstResultData?.studio.logoPath}`}
-                alt=""
-                className="text-white max-h-24 sm:max-h-32"
+                src={`//image.tmdb.org/t/p/w780_filter(negate,000,666)/${firstResultData.studio.logoPath}`}
+                alt={firstResultData.studio.name}
+                className="max-h-24 sm:max-h-32"
               />
             </div>
           ) : (


### PR DESCRIPTION
#### Description

There is no `alt` text for the studio/network logos on the filtered Discover pages, so this PR adds that.

Also noticed that a blinking text cursor would appear either before/after the logos, so fixed that as well.

#### Screenshot (if UI-related)

**Blinking text cursor:**
![image](https://user-images.githubusercontent.com/52870424/110081637-3682c300-7d5a-11eb-98ea-354c20deb30b.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A