### PR TITLE
fix(frontend): check for ID instead of email after initial setup Plex login

### DIFF
--- a/src/components/Setup/LoginWithPlex.tsx
+++ b/src/components/Setup/LoginWithPlex.tsx
@@ -25,7 +25,7 @@ const LoginWithPlex: React.FC<LoginWithPlexProps> = ({ onComplete }) => {
     const login = async () => {
       const response = await axios.post('/api/v1/auth/plex', { authToken });
 
-      if (response.data?.email) {
+      if (response.data?.id) {
         revalidate();
       }
     };


### PR DESCRIPTION
#### Description

Apply the fix from c4af4c42ab00f1a63a2f5326c9cd8b26c19f4f14 to the setup flow as well.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A