### PR TITLE
feat(notif): add setting for Discord bot username

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1102,6 +1102,8 @@ components:
         options:
           type: object
           properties:
+            botUsername:
+              type: string
             webhookUrl:
               type: string
     SlackSettings:
@@ -1146,10 +1148,14 @@ components:
         options:
           type: object
           properties:
+            botUsername:
+              type: string
             botAPI:
               type: string
             chatId:
               type: string
+            sendSilently:
+              type: boolean
     PushbulletSettings:
       type: object
       properties:

--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -203,8 +203,7 @@ class DiscordAgent
   ): Promise<boolean> {
     logger.debug('Sending discord notification', { label: 'Notifications' });
     try {
-      const settings = getSettings();
-      const webhookUrl = this.getSettings().options.webhookUrl;
+      const { botUsername, webhookUrl } = this.getSettings().options;
 
       if (!webhookUrl) {
         return false;
@@ -222,7 +221,7 @@ class DiscordAgent
       }
 
       await axios.post(webhookUrl, {
-        username: settings.main.applicationTitle,
+        username: botUsername,
         embeds: [this.buildEmbed(type, payload)],
         content,
         allowed_mentions: {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -95,6 +95,7 @@ export interface NotificationAgentConfig {
 }
 export interface NotificationAgentDiscord extends NotificationAgentConfig {
   options: {
+    botUsername?: string;
     webhookUrl: string;
   };
 }
@@ -120,7 +121,7 @@ export interface NotificationAgentEmail extends NotificationAgentConfig {
 
 export interface NotificationAgentTelegram extends NotificationAgentConfig {
   options: {
-    botUsername: string;
+    botUsername?: string;
     botAPI: string;
     chatId: string;
     sendSilently: boolean;
@@ -229,6 +230,7 @@ class Settings {
             enabled: false,
             types: 0,
             options: {
+              botUsername: '',
               webhookUrl: '',
             },
           },

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -13,6 +13,7 @@ const messages = defineMessages({
   save: 'Save Changes',
   saving: 'Saving…',
   agentenabled: 'Enable Agent',
+  botUsername: 'Bot Username',
   webhookUrl: 'Webhook URL',
   webhookUrlPlaceholder: 'Server Settings → Integrations → Webhooks',
   discordsettingssaved: 'Discord notification settings saved successfully!',
@@ -45,6 +46,7 @@ const NotificationsDiscord: React.FC = () => {
       initialValues={{
         enabled: data.enabled,
         types: data.types,
+        botUsername: data?.options.botUsername,
         webhookUrl: data.options.webhookUrl,
       }}
       validationSchema={NotificationsDiscordSchema}
@@ -54,6 +56,7 @@ const NotificationsDiscord: React.FC = () => {
             enabled: values.enabled,
             types: values.types,
             options: {
+              botUsername: values.botUsername,
               webhookUrl: values.webhookUrl,
             },
           });
@@ -77,6 +80,7 @@ const NotificationsDiscord: React.FC = () => {
             enabled: true,
             types: values.types,
             options: {
+              botUsername: values.botUsername,
               webhookUrl: values.webhookUrl,
             },
           });
@@ -95,6 +99,24 @@ const NotificationsDiscord: React.FC = () => {
               </label>
               <div className="form-input">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="botUsername" className="text-label">
+                {intl.formatMessage(messages.botUsername)}
+              </label>
+              <div className="form-input">
+                <div className="flex max-w-lg rounded-md shadow-sm">
+                  <Field
+                    id="botUsername"
+                    name="botUsername"
+                    type="text"
+                    placeholder={intl.formatMessage(messages.botUsername)}
+                  />
+                </div>
+                {errors.botUsername && touched.botUsername && (
+                  <div className="error">{errors.botUsername}</div>
+                )}
               </div>
             </div>
             <div className="form-row">


### PR DESCRIPTION
#### Description

Add a setting to allow for customization of the Discord bot username.

#### Screenshot (if UI-related)

![image](https://user-images.githubusercontent.com/52870424/110257194-a8c9f200-7f6a-11eb-8cbf-2ef4e2dcd252.png)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A