### PR TITLE
docs(proxy): add nginx subfolder reverse proxy (#1114) [skip ci]

### DIFF
--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -4,9 +4,9 @@
 Base URLs cannot be configured in Overseerr. With this limitation, only subdomain configurations are supported. However, a Nginx subfolder workaround configuration is provided below to use at your own risk.
 {% endhint %}
 
-## [SWAG (Secure Web Application Gateway, formerly known as `letsencrypt`)](https://github.com/linuxserver/docker-swag)
+## SWAG
 
-A sample proxy configuration is included in SWAG. However, this page is still the only source of truth, so the SWAG sample configuration is not guaranteed to be up-to-date. If you find an inconsistency, please [report it to the LinuxServer team](https://github.com/linuxserver/reverse-proxy-confs/issues/new) or [submit a pull request to update it](https://github.com/linuxserver/reverse-proxy-confs/pulls).
+A sample proxy configuration is included in [SWAG](https://github.com/linuxserver/docker-swag). However, this page is still the only source of truth, so the SWAG sample configuration is not guaranteed to be up-to-date. If you find an inconsistency, please [report it to the LinuxServer team](https://github.com/linuxserver/reverse-proxy-confs/issues/new) or [submit a pull request to update it](https://github.com/linuxserver/reverse-proxy-confs/pulls).
 
 To use the bundled configuration file, simply rename `overseerr.subdomain.conf.sample` in the `proxy-confs` folder to `overseerr.subdomain.conf`. Alternatively, create a new file `overseerr.subdomain.conf` in `proxy-confs` with the following configuration:
 
@@ -53,7 +53,9 @@ labels:
 
 For more information, see the Traefik documentation for a [basic example](https://doc.traefik.io/traefik/user-guides/docker-compose/basic-example/).
 
-## `nginx` (subdomain)
+## Nginx
+
+### Subdomain
 
 Add the following configuration to a new file `/etc/nginx/sites-available/overseerr.example.com.conf`:
 
@@ -124,7 +126,7 @@ Finally, reload `nginx` for the new configuration to take effect:
 sudo systemctl reload nginx
 ```
 
-## `nginx` (subfolder)
+### Subfolder
 
 {% hint style="warning" %}
 Nginx subfolder reverse proxy is unsupported. The sub filters may stop working when Overseerr is updated. Use at your own risk!

--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -6,7 +6,7 @@ Base URLs cannot be configured in Overseerr. With this limitation, only subdomai
 
 ## SWAG
 
-A sample proxy configuration is included in [SWAG](https://github.com/linuxserver/docker-swag). However, this page is still the only source of truth, so the SWAG sample configuration is not guaranteed to be up-to-date. If you find an inconsistency, please [report it to the LinuxServer team](https://github.com/linuxserver/reverse-proxy-confs/issues/new) or [submit a pull request to update it](https://github.com/linuxserver/reverse-proxy-confs/pulls).
+A sample proxy configuration is included in [SWAG (Secure Web Application Gateway)](https://github.com/linuxserver/docker-swag). However, this page is still the only source of truth, so the SWAG sample configuration is not guaranteed to be up-to-date. If you find an inconsistency, please [report it to the LinuxServer team](https://github.com/linuxserver/reverse-proxy-confs/issues/new) or [submit a pull request to update it](https://github.com/linuxserver/reverse-proxy-confs/pulls).
 
 To use the bundled configuration file, simply rename `overseerr.subdomain.conf.sample` in the `proxy-confs` folder to `overseerr.subdomain.conf`. Alternatively, create a new file `overseerr.subdomain.conf` in `proxy-confs` with the following configuration:
 

--- a/docs/extending-overseerr/reverse-proxy-examples.md
+++ b/docs/extending-overseerr/reverse-proxy-examples.md
@@ -55,7 +55,8 @@ For more information, see the Traefik documentation for a [basic example](https:
 
 ## Nginx
 
-### Subdomain
+{% tabs %}
+{% tab title="Subdomain" %}
 
 Add the following configuration to a new file `/etc/nginx/sites-available/overseerr.example.com.conf`:
 
@@ -113,20 +114,9 @@ Then, create a symlink to `/etc/nginx/sites-enabled`:
 ```bash
 sudo ln -s /etc/nginx/sites-available/overseerr.example.com.conf /etc/nginx/sites-enabled/overseerr.example.com.conf
 ```
+{% endtab %}
 
-Next, test the configuration:
-
-```bash
-sudo nginx -t
-```
-
-Finally, reload `nginx` for the new configuration to take effect:
-
-```bash
-sudo systemctl reload nginx
-```
-
-### Subfolder
+{% tab title="Subfolder" %}
 
 {% hint style="warning" %}
 Nginx subfolder reverse proxy is unsupported. The sub filters may stop working when Overseerr is updated. Use at your own risk!
@@ -162,6 +152,8 @@ location ^~ /overseerr {
     sub_filter '/site.webmanifest' '/$app/site.webmanifest';
 }
 ```
+{% endtab %}
+{% endtabs %}
 
 Next, test the configuration:
 


### PR DESCRIPTION
#### Description

Add a workaround `nginx` subfolder reverse proxy configuration to the documentation.

This method is super hacky and is prone to break if Overseerr updates any of the paths rendering the `sub_filter`s invalid.

#### Issues Fixed or Closed

- Workaround for #274