### PR TITLE
ci(docker): don't cache first build stage, and add temp fix for growing cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: yarn lint
       - name: build
         run: yarn build
+
   build_and_push:
     name: Build & Publish to Docker Hub
     needs: test
@@ -77,6 +78,7 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
   discord:
     name: Send Discord Notification
     needs: build_and_push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,14 @@ jobs:
             ghcr.io/sct/overseerr:develop
             ghcr.io/sct/overseerr:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - # Temporary fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   discord:
     name: Send Discord Notification
     needs: build_and_push
@@ -78,7 +85,6 @@ jobs:
     steps:
       - name: Get Build Job Status
         uses: technote-space/workflow-conclusion-action@v2.1.2
-
       - name: Combine Job Status
         id: status
         run: |
@@ -88,7 +94,6 @@ jobs:
           else
             echo ::set-output name=status::$WORKFLOW_CONCLUSION
           fi
-
       - name: Post Status to Discord
         uses: sarisia/actions-status-discord@v1
         with:


### PR DESCRIPTION
#### Description

Nothing is getting cached during the first build stage, so we should stop writing it to the cache.

Also, "[at] the moment caches are copied over the existing cache so it keeps growing. The Move cache step is used as a temporary fix..." (https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache).

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A