### PR TITLE
fix: remove language/region filtering on studio/network results

### DIFF
--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -107,7 +107,7 @@ discoverRoutes.get<{ genreId: string }>(
 discoverRoutes.get<{ studioId: string }>(
   '/movies/studio/:studioId',
   async (req, res) => {
-    const tmdb = createTmdbWithRegionLanaguage(req.user);
+    const tmdb = new TheMovieDb();
 
     const studio = await tmdb.getStudio(Number(req.params.studioId));
 
@@ -245,7 +245,7 @@ discoverRoutes.get<{ genreId: string }>(
 discoverRoutes.get<{ networkId: string }>(
   '/tv/network/:networkId',
   async (req, res) => {
-    const tmdb = createTmdbWithRegionLanaguage(req.user);
+    const tmdb = new TheMovieDb();
 
     const network = await tmdb.getNetwork(Number(req.params.networkId));
 


### PR DESCRIPTION
#### Description

Networks/studios tend to produce content only in certain languages/regions, so it does not make sense to filter these results.  (Currently, if there is global/user language/region filtering, results for some studios/networks will be empty.)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A