### PR TITLE
fix(ui): sort regions & languages by their localized names rather than their TMDb English names

### DIFF
--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -38,6 +38,29 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
     []
   );
 
+  const sortedRegions = useMemo(
+    () =>
+      regions?.sort((region1, region2) => {
+        const region1Name =
+          intl.formatDisplayName(region1.iso_3166_1, {
+            type: 'region',
+            fallback: 'none',
+          }) ?? region1.english_name;
+        const region2Name =
+          intl.formatDisplayName(region2.iso_3166_1, {
+            type: 'region',
+            fallback: 'none',
+          }) ?? region2.english_name;
+
+        return region1Name === region2Name
+          ? 0
+          : region1Name > region2Name
+          ? 1
+          : -1;
+      }),
+    [intl, regions]
+  );
+
   const defaultRegionNameFallback =
     regions?.find((region) => region.iso_3166_1 === currentSettings.region)
       ?.english_name ?? currentSettings.region;
@@ -228,78 +251,59 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
                       </div>
                     )}
                   </Listbox.Option>
-                  {regions
-                    ?.sort((region1, region2) => {
-                      const region1Name =
-                        intl.formatDisplayName(region1.iso_3166_1, {
-                          type: 'region',
-                          fallback: 'none',
-                        }) ?? region1.english_name;
-                      const region2Name =
-                        intl.formatDisplayName(region2.iso_3166_1, {
-                          type: 'region',
-                          fallback: 'none',
-                        }) ?? region2.english_name;
-
-                      return region1Name === region2Name
-                        ? 0
-                        : region1Name > region2Name
-                        ? 1
-                        : -1;
-                    })
-                    .map((region) => (
-                      <Listbox.Option key={region.iso_3166_1} value={region}>
-                        {({ selected, active }) => (
-                          <div
+                  {sortedRegions?.map((region) => (
+                    <Listbox.Option key={region.iso_3166_1} value={region}>
+                      {({ selected, active }) => (
+                        <div
+                          className={`${
+                            active
+                              ? 'text-white bg-indigo-600'
+                              : 'text-gray-300'
+                          } cursor-default select-none relative py-2 pl-8 pr-4 flex items-center`}
+                        >
+                          <span className="mr-2 text-base">
+                            <span
+                              className={
+                                hasFlag(region.iso_3166_1)
+                                  ? `flag:${region.iso_3166_1}`
+                                  : 'pr-6'
+                              }
+                            />
+                          </span>
+                          <span
                             className={`${
-                              active
-                                ? 'text-white bg-indigo-600'
-                                : 'text-gray-300'
-                            } cursor-default select-none relative py-2 pl-8 pr-4 flex items-center`}
+                              selected ? 'font-semibold' : 'font-normal'
+                            } block truncate`}
                           >
-                            <span className="mr-2 text-base">
-                              <span
-                                className={
-                                  hasFlag(region.iso_3166_1)
-                                    ? `flag:${region.iso_3166_1}`
-                                    : 'pr-6'
-                                }
-                              />
-                            </span>
+                            {intl.formatDisplayName(region.iso_3166_1, {
+                              type: 'region',
+                              fallback: 'none',
+                            }) ?? region.english_name}
+                          </span>
+                          {selected && (
                             <span
                               className={`${
-                                selected ? 'font-semibold' : 'font-normal'
-                              } block truncate`}
+                                active ? 'text-white' : 'text-indigo-600'
+                              } absolute inset-y-0 left-0 flex items-center pl-1.5`}
                             >
-                              {intl.formatDisplayName(region.iso_3166_1, {
-                                type: 'region',
-                                fallback: 'none',
-                              }) ?? region.english_name}
-                            </span>
-                            {selected && (
-                              <span
-                                className={`${
-                                  active ? 'text-white' : 'text-indigo-600'
-                                } absolute inset-y-0 left-0 flex items-center pl-1.5`}
+                              <svg
+                                className="w-5 h-5"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 20 20"
+                                fill="currentColor"
                               >
-                                <svg
-                                  className="w-5 h-5"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  viewBox="0 0 20 20"
-                                  fill="currentColor"
-                                >
-                                  <path
-                                    fillRule="evenodd"
-                                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                    clipRule="evenodd"
-                                  />
-                                </svg>
-                              </span>
-                            )}
-                          </div>
-                        )}
-                      </Listbox.Option>
-                    ))}
+                                <path
+                                  fillRule="evenodd"
+                                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </Listbox.Option>
+                  ))}
                 </Listbox.Options>
               </Transition>
             </div>

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -241,15 +241,11 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
                           fallback: 'none',
                         }) ?? region2.english_name;
 
-                      if (region1Name > region2Name) {
-                        return 1;
-                      }
-
-                      if (region1Name < region2Name) {
-                        return -1;
-                      }
-
-                      return 0;
+                      return region1Name === region2Name
+                        ? 0
+                        : region1Name > region2Name
+                        ? 1
+                        : -1;
                     })
                     .map((region) => (
                       <Listbox.Option key={region.iso_3166_1} value={region}>

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -228,59 +228,82 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
                       </div>
                     )}
                   </Listbox.Option>
-                  {regions?.map((region) => (
-                    <Listbox.Option key={region.iso_3166_1} value={region}>
-                      {({ selected, active }) => (
-                        <div
-                          className={`${
-                            active
-                              ? 'text-white bg-indigo-600'
-                              : 'text-gray-300'
-                          } cursor-default select-none relative py-2 pl-8 pr-4 flex items-center`}
-                        >
-                          <span className="mr-2 text-base">
-                            <span
-                              className={
-                                hasFlag(region.iso_3166_1)
-                                  ? `flag:${region.iso_3166_1}`
-                                  : 'pr-6'
-                              }
-                            />
-                          </span>
-                          <span
+                  {regions
+                    ?.sort((region1, region2) => {
+                      const region1Name =
+                        intl.formatDisplayName(region1.iso_3166_1, {
+                          type: 'region',
+                          fallback: 'none',
+                        }) ?? region1.english_name;
+                      const region2Name =
+                        intl.formatDisplayName(region2.iso_3166_1, {
+                          type: 'region',
+                          fallback: 'none',
+                        }) ?? region2.english_name;
+
+                      if (region1Name > region2Name) {
+                        return 1;
+                      }
+
+                      if (region1Name < region2Name) {
+                        return -1;
+                      }
+
+                      return 0;
+                    })
+                    .map((region) => (
+                      <Listbox.Option key={region.iso_3166_1} value={region}>
+                        {({ selected, active }) => (
+                          <div
                             className={`${
-                              selected ? 'font-semibold' : 'font-normal'
-                            } block truncate`}
+                              active
+                                ? 'text-white bg-indigo-600'
+                                : 'text-gray-300'
+                            } cursor-default select-none relative py-2 pl-8 pr-4 flex items-center`}
                           >
-                            {intl.formatDisplayName(region.iso_3166_1, {
-                              type: 'region',
-                              fallback: 'none',
-                            }) ?? region.english_name}
-                          </span>
-                          {selected && (
+                            <span className="mr-2 text-base">
+                              <span
+                                className={
+                                  hasFlag(region.iso_3166_1)
+                                    ? `flag:${region.iso_3166_1}`
+                                    : 'pr-6'
+                                }
+                              />
+                            </span>
                             <span
                               className={`${
-                                active ? 'text-white' : 'text-indigo-600'
-                              } absolute inset-y-0 left-0 flex items-center pl-1.5`}
+                                selected ? 'font-semibold' : 'font-normal'
+                              } block truncate`}
                             >
-                              <svg
-                                className="w-5 h-5"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 20 20"
-                                fill="currentColor"
-                              >
-                                <path
-                                  fillRule="evenodd"
-                                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                  clipRule="evenodd"
-                                />
-                              </svg>
+                              {intl.formatDisplayName(region.iso_3166_1, {
+                                type: 'region',
+                                fallback: 'none',
+                              }) ?? region.english_name}
                             </span>
-                          )}
-                        </div>
-                      )}
-                    </Listbox.Option>
-                  ))}
+                            {selected && (
+                              <span
+                                className={`${
+                                  active ? 'text-white' : 'text-indigo-600'
+                                } absolute inset-y-0 left-0 flex items-center pl-1.5`}
+                              >
+                                <svg
+                                  className="w-5 h-5"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  viewBox="0 0 20 20"
+                                  fill="currentColor"
+                                >
+                                  <path
+                                    fillRule="evenodd"
+                                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                    clipRule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </Listbox.Option>
+                    ))}
                 </Listbox.Options>
               </Transition>
             </div>

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import useSWR from 'swr';
 import LoadingSpinner from '../Common/LoadingSpinner';
 import type { MainSettings, Language } from '../../../server/lib/settings';
@@ -93,6 +93,25 @@ const SettingsMain: React.FC = () => {
       });
     }
   };
+
+  const sortedLanguages = useMemo(
+    () =>
+      languages?.sort((lang1, lang2) => {
+        const lang1Name =
+          intl.formatDisplayName(lang1.iso_639_1, {
+            type: 'language',
+            fallback: 'none',
+          }) ?? lang1.english_name;
+        const lang2Name =
+          intl.formatDisplayName(lang2.iso_639_1, {
+            type: 'language',
+            fallback: 'none',
+          }) ?? lang2.english_name;
+
+        return lang1Name === lang2Name ? 0 : lang1Name > lang2Name ? 1 : -1;
+      }),
+    [intl, languages]
+  );
 
   if (!data && !error && !languages && !languagesError) {
     return <LoadingSpinner />;
@@ -306,36 +325,17 @@ const SettingsMain: React.FC = () => {
                         <option value="">
                           {intl.formatMessage(messages.originalLanguageDefault)}
                         </option>
-                        {languages
-                          ?.sort((lang1, lang2) => {
-                            const lang1Name =
-                              intl.formatDisplayName(lang1.iso_639_1, {
-                                type: 'language',
-                                fallback: 'none',
-                              }) ?? lang1.english_name;
-                            const lang2Name =
-                              intl.formatDisplayName(lang2.iso_639_1, {
-                                type: 'language',
-                                fallback: 'none',
-                              }) ?? lang2.english_name;
-
-                            return lang1Name === lang2Name
-                              ? 0
-                              : lang1Name > lang2Name
-                              ? 1
-                              : -1;
-                          })
-                          .map((language) => (
-                            <option
-                              key={`language-key-${language.iso_639_1}`}
-                              value={language.iso_639_1}
-                            >
-                              {intl.formatDisplayName(language.iso_639_1, {
-                                type: 'language',
-                                fallback: 'none',
-                              }) ?? language.english_name}
-                            </option>
-                          ))}
+                        {sortedLanguages?.map((language) => (
+                          <option
+                            key={`language-key-${language.iso_639_1}`}
+                            value={language.iso_639_1}
+                          >
+                            {intl.formatDisplayName(language.iso_639_1, {
+                              type: 'language',
+                              fallback: 'none',
+                            }) ?? language.english_name}
+                          </option>
+                        ))}
                       </Field>
                     </div>
                   </div>

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -306,17 +306,40 @@ const SettingsMain: React.FC = () => {
                         <option value="">
                           {intl.formatMessage(messages.originalLanguageDefault)}
                         </option>
-                        {languages?.map((language) => (
-                          <option
-                            key={`language-key-${language.iso_639_1}`}
-                            value={language.iso_639_1}
-                          >
-                            {intl.formatDisplayName(language.iso_639_1, {
-                              type: 'language',
-                              fallback: 'none',
-                            }) ?? language.english_name}
-                          </option>
-                        ))}
+                        {languages
+                          ?.sort((lang1, lang2) => {
+                            const lang1Name =
+                              intl.formatDisplayName(lang1.iso_639_1, {
+                                type: 'language',
+                                fallback: 'none',
+                              }) ?? lang1.english_name;
+                            const lang2Name =
+                              intl.formatDisplayName(lang2.iso_639_1, {
+                                type: 'language',
+                                fallback: 'none',
+                              }) ?? lang2.english_name;
+
+                            if (lang1Name > lang2Name) {
+                              return 1;
+                            }
+
+                            if (lang1Name < lang2Name) {
+                              return -1;
+                            }
+
+                            return 0;
+                          })
+                          .map((language) => (
+                            <option
+                              key={`language-key-${language.iso_639_1}`}
+                              value={language.iso_639_1}
+                            >
+                              {intl.formatDisplayName(language.iso_639_1, {
+                                type: 'language',
+                                fallback: 'none',
+                              }) ?? language.english_name}
+                            </option>
+                          ))}
                       </Field>
                     </div>
                   </div>

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -319,15 +319,11 @@ const SettingsMain: React.FC = () => {
                                 fallback: 'none',
                               }) ?? lang2.english_name;
 
-                            if (lang1Name > lang2Name) {
-                              return 1;
-                            }
-
-                            if (lang1Name < lang2Name) {
-                              return -1;
-                            }
-
-                            return 0;
+                            return lang1Name === lang2Name
+                              ? 0
+                              : lang1Name > lang2Name
+                              ? 1
+                              : -1;
                           })
                           .map((language) => (
                             <option

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -224,15 +224,11 @@ const UserGeneralSettings: React.FC = () => {
                               fallback: 'none',
                             }) ?? lang2.english_name;
 
-                          if (lang1Name > lang2Name) {
-                            return 1;
-                          }
-
-                          if (lang1Name < lang2Name) {
-                            return -1;
-                          }
-
-                          return 0;
+                          return lang1Name === lang2Name
+                            ? 0
+                            : lang1Name > lang2Name
+                            ? 1
+                            : -1;
                         })
                         .map((language) => (
                           <option

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -211,17 +211,40 @@ const UserGeneralSettings: React.FC = () => {
                       <option value="all">
                         {intl.formatMessage(messages.originalLanguageDefault)}
                       </option>
-                      {languages?.map((language) => (
-                        <option
-                          key={`language-key-${language.iso_639_1}`}
-                          value={language.iso_639_1}
-                        >
-                          {intl.formatDisplayName(language.iso_639_1, {
-                            type: 'language',
-                            fallback: 'none',
-                          }) ?? language.english_name}
-                        </option>
-                      ))}
+                      {languages
+                        ?.sort((lang1, lang2) => {
+                          const lang1Name =
+                            intl.formatDisplayName(lang1.iso_639_1, {
+                              type: 'language',
+                              fallback: 'none',
+                            }) ?? lang1.english_name;
+                          const lang2Name =
+                            intl.formatDisplayName(lang2.iso_639_1, {
+                              type: 'language',
+                              fallback: 'none',
+                            }) ?? lang2.english_name;
+
+                          if (lang1Name > lang2Name) {
+                            return 1;
+                          }
+
+                          if (lang1Name < lang2Name) {
+                            return -1;
+                          }
+
+                          return 0;
+                        })
+                        .map((language) => (
+                          <option
+                            key={`language-key-${language.iso_639_1}`}
+                            value={language.iso_639_1}
+                          >
+                            {intl.formatDisplayName(language.iso_639_1, {
+                              type: 'language',
+                              fallback: 'none',
+                            }) ?? language.english_name}
+                          </option>
+                        ))}
                     </Field>
                   </div>
                 </div>

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
@@ -54,6 +54,25 @@ const UserGeneralSettings: React.FC = () => {
 
   const { data: languages, error: languagesError } = useSWR<Language[]>(
     '/api/v1/languages'
+  );
+
+  const sortedLanguages = useMemo(
+    () =>
+      languages?.sort((lang1, lang2) => {
+        const lang1Name =
+          intl.formatDisplayName(lang1.iso_639_1, {
+            type: 'language',
+            fallback: 'none',
+          }) ?? lang1.english_name;
+        const lang2Name =
+          intl.formatDisplayName(lang2.iso_639_1, {
+            type: 'language',
+            fallback: 'none',
+          }) ?? lang2.english_name;
+
+        return lang1Name === lang2Name ? 0 : lang1Name > lang2Name ? 1 : -1;
+      }),
+    [intl, languages]
   );
 
   if (!data && !error) {
@@ -211,36 +230,17 @@ const UserGeneralSettings: React.FC = () => {
                       <option value="all">
                         {intl.formatMessage(messages.originalLanguageDefault)}
                       </option>
-                      {languages
-                        ?.sort((lang1, lang2) => {
-                          const lang1Name =
-                            intl.formatDisplayName(lang1.iso_639_1, {
-                              type: 'language',
-                              fallback: 'none',
-                            }) ?? lang1.english_name;
-                          const lang2Name =
-                            intl.formatDisplayName(lang2.iso_639_1, {
-                              type: 'language',
-                              fallback: 'none',
-                            }) ?? lang2.english_name;
-
-                          return lang1Name === lang2Name
-                            ? 0
-                            : lang1Name > lang2Name
-                            ? 1
-                            : -1;
-                        })
-                        .map((language) => (
-                          <option
-                            key={`language-key-${language.iso_639_1}`}
-                            value={language.iso_639_1}
-                          >
-                            {intl.formatDisplayName(language.iso_639_1, {
-                              type: 'language',
-                              fallback: 'none',
-                            }) ?? language.english_name}
-                          </option>
-                        ))}
+                      {sortedLanguages?.map((language) => (
+                        <option
+                          key={`language-key-${language.iso_639_1}`}
+                          value={language.iso_639_1}
+                        >
+                          {intl.formatDisplayName(language.iso_639_1, {
+                            type: 'language',
+                            fallback: 'none',
+                          }) ?? language.english_name}
+                        </option>
+                      ))}
                     </Field>
                   </div>
                 </div>


### PR DESCRIPTION
#### Description

Currently, items in the dropdowns are not actually alphabetized by the strings displayed to the user, but by the English names returned from TMDb.

Not only does this result in the list not being alphabetized in non-English languages, but it actually causes some entries to appear out of order in English as well.

One example is the "zh" language code, for which TMDb returns an English name of "Mandarin" but is usually localized to "Chinese."

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A