### PR TITLE
fix(notif): loosen input validation on Pushover settings

### DIFF
--- a/src/components/Settings/Notifications/NotificationsPushover/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushover/index.tsx
@@ -41,13 +41,13 @@ const NotificationsPushover: React.FC = () => {
     accessToken: Yup.string()
       .required(intl.formatMessage(messages.validationAccessTokenRequired))
       .matches(
-        /^a[A-Za-z0-9]{29}$/,
+        /^[a-z\d]{30}$/i,
         intl.formatMessage(messages.validationAccessTokenRequired)
       ),
     userToken: Yup.string()
       .required(intl.formatMessage(messages.validationUserTokenRequired))
       .matches(
-        /^[ug][A-Za-z0-9]{29}$/,
+        /^[a-z\d]{30}$/i,
         intl.formatMessage(messages.validationUserTokenRequired)
       ),
   });

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -18,7 +18,7 @@ const messages = defineMessages({
   botAPI: 'Bot Authentication Token',
   chatId: 'Chat ID',
   validationBotAPIRequired: 'You must provide a bot authentication token',
-  validationChatIdRequired: 'You must provide a chat ID',
+  validationChatIdRequired: 'You must provide a valid chat ID',
   telegramsettingssaved: 'Telegram notification settings saved successfully!',
   telegramsettingsfailed: 'Telegram notification settings failed to save.',
   testsent: 'Test notification sent!',

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -343,7 +343,7 @@
   "components.Settings.Notifications.test": "Test",
   "components.Settings.Notifications.testsent": "Test notification sent!",
   "components.Settings.Notifications.validationBotAPIRequired": "You must provide a bot authentication token",
-  "components.Settings.Notifications.validationChatIdRequired": "You must provide a chat ID",
+  "components.Settings.Notifications.validationChatIdRequired": "You must provide a valid chat ID",
   "components.Settings.Notifications.validationEmail": "You must provide a valid email address",
   "components.Settings.Notifications.validationSmtpHostRequired": "You must provide an SMTP host",
   "components.Settings.Notifications.validationSmtpPortRequired": "You must provide an SMTP port",


### PR DESCRIPTION
#### Description

Our input validation on Pushover tokens/keys is too strict, so relax the check to only verify that 30-character alphanumeric strings are inputted.

Also fix a string on the Telegram notifications page.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #1165