### PR TITLE
fix(notif): set URL for Discord embeds rather than adding a field for the link

### DIFF
--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -156,15 +156,14 @@ class DiscordAgent
         break;
     }
 
-    if (settings.main.applicationUrl && payload.media) {
-      fields.push({
-        name: `Open in ${settings.main.applicationTitle}`,
-        value: `${settings.main.applicationUrl}/${payload.media?.mediaType}/${payload.media?.tmdbId}`,
-      });
-    }
+    const url =
+      settings.main.applicationUrl && payload.media
+        ? `${settings.main.applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`
+        : undefined;
 
     return {
       title: payload.subject,
+      url,
       description: payload.message,
       color,
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
#### Description

#### Screenshot (if UI-related)

- **Before:**
    ![image](https://user-images.githubusercontent.com/52870424/111040450-f7f7a300-8400-11eb-92d6-73ab996e11df.png)
- **After:**
    ![image](https://user-images.githubusercontent.com/52870424/111040455-01810b00-8401-11eb-88a0-630475c906d9.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A