### PR TITLE
fix(ui): filter out server options that do not match request type (non-4K or 4K)

### DIFF
--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -276,15 +276,20 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                   onBlur={(e) => setSelectedServer(Number(e.target.value))}
                   className="block w-full py-2 pl-3 pr-10 mt-1 text-base leading-6 text-white transition duration-150 ease-in-out bg-gray-800 border-gray-700 rounded-md form-select focus:outline-none focus:ring-blue focus:border-blue-300 sm:text-sm sm:leading-5"
                 >
-                  {data.map((server) => (
-                    <option key={`server-list-${server.id}`} value={server.id}>
-                      {server.isDefault && server.is4k === is4k
-                        ? intl.formatMessage(messages.default, {
-                            name: server.name,
-                          })
-                        : server.name}
-                    </option>
-                  ))}
+                  {data
+                    .filter((server) => server.is4k === is4k)
+                    .map((server) => (
+                      <option
+                        key={`server-list-${server.id}`}
+                        value={server.id}
+                      >
+                        {server.isDefault
+                          ? intl.formatMessage(messages.default, {
+                              name: server.name,
+                            })
+                          : server.name}
+                      </option>
+                    ))}
                 </select>
               </div>
               <div className="flex-grow flex-shrink-0 w-full mb-2 md:w-1/4 md:pr-4 md:mb-0">


### PR DESCRIPTION
#### Description

Request overrides should not allow user to select 4K servers for non-4K requests, or non-4K servers for 4K requests.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A