### PR TITLE
fix(ui): use appropriate cursor type for readonly input fields

### DIFF
--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -181,7 +181,7 @@ const SettingsMain: React.FC = () => {
                         <input
                           type="text"
                           id="apiKey"
-                          className="rounded-l-only"
+                          className="cursor-not-allowed rounded-l-only"
                           value={data?.apiKey}
                           readOnly
                         />

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -181,7 +181,7 @@ const SettingsMain: React.FC = () => {
                         <input
                           type="text"
                           id="apiKey"
-                          className="cursor-not-allowed rounded-l-only"
+                          className="rounded-l-only"
                           value={data?.apiKey}
                           readOnly
                         />

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -360,6 +360,7 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
                       type="text"
                       id="name"
                       name="name"
+                      className="cursor-not-allowed"
                       placeholder={intl.formatMessage(
                         messages.servernamePlaceholder
                       )}


### PR DESCRIPTION
#### Description

Makes it clearer that `readonly` input fields cannot be interacted with, since otherwise they appear like regular text boxes.  (Currently, there are only two such fields... the API key in General Settings, and the server name in Plex Settings.)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A