### PR TITLE
fix(lang): fix overwritten/shared string

### DIFF
--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -843,7 +843,7 @@
   "i18n.tvshows": "Series",
   "i18n.unavailable": "Unavailable",
   "i18n.usersettings": "User Settings",
-  "pages.errormessagewithcode": "404 - {error}",
+  "pages.errormessagewithcode": "{statusCode} - {error}",
   "pages.internalservererror": "Internal Server Error",
   "pages.oops": "Oops",
   "pages.pagenotfound": "Page Not Found",

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -4,7 +4,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import PageTitle from '../components/Common/PageTitle';
 
 const messages = defineMessages({
-  errormessagewithcode: '404 - {error}',
+  errormessagewithcode: '{statusCode} - {error}',
   pagenotfound: 'Page Not Found',
   returnHome: 'Return Home',
 });
@@ -17,6 +17,7 @@ const Custom404: React.FC = () => {
       <PageTitle title={intl.formatMessage(messages.pagenotfound)} />
       <div className="text-4xl">
         {intl.formatMessage(messages.errormessagewithcode, {
+          statusCode: 404,
           error: intl.formatMessage(messages.pagenotfound),
         })}
       </div>


### PR DESCRIPTION
#### Description

I missed the fact that the error message w/ code string was being shared in two files (#1202).  Currently, the status code will always appear as 404. 😅 

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A