### PR TITLE
fix(lang): change 'Extra Data' string to 'Additional Data'

### DIFF
--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -42,7 +42,7 @@ const messages = defineMessages({
   viewDetails: 'View Details',
   copyToClipboard: 'Copy to Clipboard',
   logDetails: 'Log Details',
-  extraData: 'Extra Data',
+  extraData: 'Additional Data',
   copiedLogMessage: 'Copied log message to clipboard.',
 });
 

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -453,7 +453,7 @@
   "components.Settings.SettingsJobsCache.unknownJob": "Unknown Job",
   "components.Settings.SettingsLogs.copiedLogMessage": "Copied log message to clipboard.",
   "components.Settings.SettingsLogs.copyToClipboard": "Copy to Clipboard",
-  "components.Settings.SettingsLogs.extraData": "Extra Data",
+  "components.Settings.SettingsLogs.extraData": "Additional Data",
   "components.Settings.SettingsLogs.filterDebug": "Debug",
   "components.Settings.SettingsLogs.filterError": "Error",
   "components.Settings.SettingsLogs.filterInfo": "Info",


### PR DESCRIPTION
#### Description

"Extra Data" implies that the data is unnecessary/superfluous, but this data is really just additional details about the specific log event.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A