### PR TITLE
fix(ui): fix regex matching when parsing label from logs

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -270,7 +270,7 @@ settingsRoutes.get(
 
           const timestamp = line.match(new RegExp(/^.{24}/)) || [];
           const level = line.match(new RegExp(/\s\[\w+\]/)) || [];
-          const label = line.match(new RegExp(/\]\[.+\]/)) || [];
+          const label = line.match(new RegExp(/\]\[.+?\]/)) || [];
           const message = line.match(new RegExp(/:\s([^{}]+)({.*})?/)) || [];
 
           if (level.length && filter.includes(level[0].slice(2, -1))) {


### PR DESCRIPTION
#### Description
Properly parse labels for log messages that have json in them

#### Screenshot (if UI-related)
None

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
