### PR TITLE
fix(ui): do not require numeric value in FormattedRelativeTime

### DIFF
--- a/src/components/DownloadBlock/index.tsx
+++ b/src/components/DownloadBlock/index.tsx
@@ -64,6 +64,7 @@ const DownloadBlock: React.FC<DownloadBlockProps> = ({
                   1000
               )}
               updateIntervalInSeconds={1}
+              numeric="auto"
             />
           ) : (
             'N/A'

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -292,6 +292,7 @@ const RequestItem: React.FC<RequestItemProps> = ({
                               1000
                           )}
                           updateIntervalInSeconds={1}
+                          numeric="auto"
                         />
                       ),
                       user: (

--- a/src/components/Settings/SettingsAbout/Releases/index.tsx
+++ b/src/components/Settings/SettingsAbout/Releases/index.tsx
@@ -107,7 +107,7 @@ const Release: React.FC<ReleaseProps> = ({
               (new Date(release.created_at).getTime() - Date.now()) / 1000
             )}
             updateIntervalInSeconds={1}
-            numeric="always"
+            numeric="auto"
           />
         </span>
         <span className="text-lg">{release.name}</span>

--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -175,6 +175,7 @@ const SettingsJobs: React.FC = () => {
                           1000
                       )}
                       updateIntervalInSeconds={1}
+                      numeric="auto"
                     />
                   </div>
                 </Table.TD>


### PR DESCRIPTION
#### Description

Sets `numeric` attribute of `FormattedRelativeTime` elements to `auto`. This fixes cases where a string like "in 0 seconds" will be displayed to the user, instead of a more readable string like "now."

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A