### PR TITLE
fix(frontend): 'Recent Requests' slider should link to request list w/ same filter

### DIFF
--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -63,7 +63,7 @@ const Discover: React.FC = () => {
         ))}
       />
       <div className="slider-header">
-        <Link href="/requests">
+        <Link href="/requests?filter=unavailable">
           <a className="slider-title">
             <span>{intl.formatMessage(messages.recentrequests)}</span>
             <svg

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -38,7 +38,7 @@ const Discover: React.FC = () => {
     data: requests,
     error: requestError,
   } = useSWR<RequestResultsResponse>(
-    '/api/v1/request?filter=unavailable&take=10&sort=modified&skip=0',
+    '/api/v1/request?filter=all&take=10&sort=modified&skip=0',
     { revalidateOnMount: true }
   );
 
@@ -63,7 +63,7 @@ const Discover: React.FC = () => {
         ))}
       />
       <div className="slider-header">
-        <Link href="/requests?filter=unavailable">
+        <Link href="/requests?filter=all">
           <a className="slider-title">
             <span>{intl.formatMessage(messages.recentrequests)}</span>
             <svg

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -17,19 +17,21 @@ const messages = defineMessages({
   sortModified: 'Last Modified',
 });
 
-type Filter =
-  | 'all'
-  | 'pending'
-  | 'approved'
-  | 'processing'
-  | 'available'
-  | 'unavailable';
+enum Filter {
+  ALL = 'all',
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  PROCESSING = 'processing',
+  AVAILABLE = 'available',
+  UNAVAILABLE = 'unavailable',
+}
+
 type Sort = 'added' | 'modified';
 
 const RequestList: React.FC = () => {
   const router = useRouter();
   const intl = useIntl();
-  const [currentFilter, setCurrentFilter] = useState<Filter>('pending');
+  const [currentFilter, setCurrentFilter] = useState<Filter>(Filter.PENDING);
   const [currentSort, setCurrentSort] = useState<Sort>('added');
   const [currentPageSize, setCurrentPageSize] = useState<number>(10);
 
@@ -55,10 +57,10 @@ const RequestList: React.FC = () => {
     }
 
     // If filter value is provided in query, use that instead
-    if (router.query.filter) {
+    if (Object.values(Filter).includes(router.query.filter as Filter)) {
       setCurrentFilter(router.query.filter as Filter);
     }
-  }, []);
+  }, [router.query.filter]);
 
   // Set filter values to local storage any time they are changed
   useEffect(() => {
@@ -130,7 +132,7 @@ const RequestList: React.FC = () => {
                 {intl.formatMessage(globalMessages.available)}
               </option>
               <option value="unavailable">
-                {intl.formatMessage(messages.filterUnavailable)}
+                {intl.formatMessage(globalMessages.unavailable)}
               </option>
             </select>
           </div>
@@ -181,11 +183,11 @@ const RequestList: React.FC = () => {
           <span className="text-2xl text-gray-400">
             {intl.formatMessage(globalMessages.noresults)}
           </span>
-          {currentFilter !== 'all' && (
+          {currentFilter !== Filter.ALL && (
             <div className="mt-4">
               <Button
                 buttonType="primary"
-                onClick={() => setCurrentFilter('all')}
+                onClick={() => setCurrentFilter(Filter.ALL)}
               >
                 {intl.formatMessage(messages.showallrequests)}
               </Button>

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -17,7 +17,13 @@ const messages = defineMessages({
   sortModified: 'Last Modified',
 });
 
-type Filter = 'all' | 'pending' | 'approved' | 'processing' | 'available';
+type Filter =
+  | 'all'
+  | 'pending'
+  | 'approved'
+  | 'processing'
+  | 'available'
+  | 'unavailable';
 type Sort = 'added' | 'modified';
 
 const RequestList: React.FC = () => {
@@ -46,6 +52,11 @@ const RequestList: React.FC = () => {
       setCurrentFilter(filterSettings.currentFilter);
       setCurrentSort(filterSettings.currentSort);
       setCurrentPageSize(filterSettings.currentPageSize);
+    }
+
+    // If filter value is provided in query, use that instead
+    if (router.query.filter) {
+      setCurrentFilter(router.query.filter as Filter);
     }
   }, []);
 
@@ -117,6 +128,9 @@ const RequestList: React.FC = () => {
               </option>
               <option value="available">
                 {intl.formatMessage(globalMessages.available)}
+              </option>
+              <option value="unavailable">
+                {intl.formatMessage(messages.filterUnavailable)}
               </option>
             </select>
           </div>


### PR DESCRIPTION
#### Description

The "Recent Requests" slider on the Discover page only shows "unavailable" requests -- requests with any request status, but with media status of any value but "available."

This slider should link to a request list view with the same filter, so this PR adds the missing filter type to the request list and updates the slider link to pass a new `filter` query parameter.

**Edit:** Changed "Recent Requests" slider and its link to use the "all" instead of "unavailable" filter.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A