### PR TITLE
fix(frontend): redirect from /setup if already initialized

### DIFF
--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -63,7 +63,11 @@ const Setup: React.FC = () => {
         <LanguagePicker />
       </div>
       <div className="relative z-40 px-4 sm:mx-auto sm:w-full sm:max-w-4xl">
-        <img src="/logo.png" className="max-w-full sm:max-w-md" alt="Logo" />
+        <img
+          src="/logo.png"
+          className="max-w-full sm:max-w-md sm:mx-auto"
+          alt="Logo"
+        />
         <AppDataWarning />
         <nav className="relative z-50">
           <ul

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -180,7 +180,7 @@ CoreApp.getInitialProps = async (initialProps) => {
         );
         user = response.data;
 
-        if (router.pathname.match(/login/)) {
+        if (router.pathname.match(/(setup|login)/)) {
           ctx.res.writeHead(307, {
             Location: '/',
           });


### PR DESCRIPTION
#### Description

Redirect users from `/setup` if Overseerr is also initialized.  Also fix positioning of logo on setup pages so that it is centered.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A