### PR TITLE
fix(lang): edit search placeholder to reflect that it also returns person results

### DIFF
--- a/src/components/Layout/SearchInput/index.tsx
+++ b/src/components/Layout/SearchInput/index.tsx
@@ -4,7 +4,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import ClearButton from '../../../assets/xcircle.svg';
 
 const messages = defineMessages({
-  searchPlaceholder: 'Search Movies & TV',
+  searchPlaceholder: 'Search for Movies, Series, or People…',
 });
 
 const SearchInput: React.FC = () => {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -39,7 +39,7 @@
   "components.Discover.upcomingmovies": "Upcoming Movies",
   "components.Discover.upcomingtv": "Upcoming Series",
   "components.Layout.LanguagePicker.changelanguage": "Change Language",
-  "components.Layout.SearchInput.searchPlaceholder": "Search Movies & TV",
+  "components.Layout.SearchInput.searchPlaceholder": "Search for Movies, Series, or People…",
   "components.Layout.Sidebar.dashboard": "Discover",
   "components.Layout.Sidebar.requests": "Requests",
   "components.Layout.Sidebar.settings": "Settings",


### PR DESCRIPTION
#### Description

"Search Movies & TV" isn't 100% accurate, given that the search also returns person results.  Also, we don't use "TV" anywhere else in the UI, instead opting for the term "Series," so it would be better to use that same language here.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A