### PR TITLE
docs: add email & Discord notification info

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,7 +10,9 @@
 
 - [Settings](using-overseerr/settings/README.md)
 - [Notifications](using-overseerr/notifications/README.md)
-  - [Custom Webhooks](using-overseerr/notifications/webhooks.md)
+  - [Email](using-overseerr/notifications/email.md)
+  - [Discord](using-overseerr/notifications/discord.md)
+  - [Webhooks](using-overseerr/notifications/webhooks.md)
 
 ## Support
 

--- a/docs/using-overseerr/notifications/README.md
+++ b/docs/using-overseerr/notifications/README.md
@@ -4,8 +4,8 @@ Overseerr already supports a good number of notification agents, such as **Disco
 
 ## Currently Supported Notification Agents
 
-- Discord
-- Email
+- [Email](./email.md)
+- [Discord](./discord.md)
 - Pushbullet
 - Pushover
 - Slack
@@ -14,15 +14,11 @@ Overseerr already supports a good number of notification agents, such as **Disco
 
 ## Setting Up Notifications
 
-Configuring your notifications is _very simple_. First, you will need to visit the **Settings** page and click **Notifications** in the menu. This will present you with all of the currently available notification agents. Click on each one individually to configure them.
+Configuring your notifications is quite simple. First, you will need to visit the **Settings** page and click **Notifications** in the menu. This will present you with all of the currently available notification agents. Click on each one individually to configure them.
 
 You must configure which type of notifications you want to send _per agent_. If no types are selected, you will not receive notifications!
 
-Some agents may have specific configuration "gotchas" covered in their documentation pages.
-
-{% hint style="danger" %}
-You will **not receive notifications** for any automatically approved requests unless the "Enable Notifications for Automatic Approvals" setting is enabled.
-{% endhint %}
+Note that some notifications are intended for the user who submitted the relevant request, while others are for administrators. For details, please see the documentation for the specific agent you would like to use.
 
 ## Requesting New Notification Agents
 

--- a/docs/using-overseerr/notifications/README.md
+++ b/docs/using-overseerr/notifications/README.md
@@ -2,7 +2,7 @@
 
 Overseerr already supports a good number of notification agents, such as **Discord**, **Slack** and **Pushover**. New agents are always considered for development, if there is enough demand for it.
 
-## Currently Supported Notification Agents
+## Supported Notification Agents
 
 - [Email](./email.md)
 - [Discord](./discord.md)

--- a/docs/using-overseerr/notifications/discord.md
+++ b/docs/using-overseerr/notifications/discord.md
@@ -1,0 +1,21 @@
+# Discord
+
+## Configuration
+
+{% hint style="info" %}
+In order to configure Discord notifications, you first need to [create a webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
+
+In order for users to be mentioned in Discord notifications, they must have their [Discord user ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) configured in their user settings.
+{% endhint %}
+
+### Bot Username (optional)
+
+If you would like to override the name you configured for your bot in Discord, you may set this value to whatever you like!
+
+### Bot Avatar URL (optional)
+
+Similar to the bot username, you can override the avatar for your bot.
+
+### Webhook URL
+
+You can find the webhook URL in the Discord application, at **Server Settings &rarr; Integrations &rarr; Webhooks**.

--- a/docs/using-overseerr/notifications/email.md
+++ b/docs/using-overseerr/notifications/email.md
@@ -1,9 +1,18 @@
 # Email
 
 {% hint style="info" %}
-**Media Requested**, **Media Automatically Approved**, and **Media Failed** email notifications are sent to _all_ users with the **Manage Requests** permission, as these notification types are intended for application administrators rather than end users.
+The following email notification types are sent to _all_ users with the **Manage Requests** permission, as these notification types are intended for application administrators rather than end users:
 
-**Media Approved**, **Media Declined**, and **Media Available** email notifications are sent to the user who submitted the request.
+- Media Requested
+- Media Automatically Approved
+- Media Failed
+
+On the other hand, the email notification types below are only sent to the user who submitted the request:
+
+- Media Approved
+- Media Declined
+- Media Available
+
 {% endhint %}
 
 ## Configuration
@@ -11,6 +20,8 @@
 ## Sender Address (required)
 
 Set this to the email address you would like to appear in the "from" field of the email message.
+
+Depending on your email provider, this may need to be an address you own. For example, Gmail requires this to be your actual email address.
 
 ## Sender Name (optional)
 
@@ -26,11 +37,15 @@ Set this to a supported port number for your SMTP host. `465` and `587` are comm
 
 ## Enable SSL (optional)
 
-If using an SMTP serves which supports [STARTTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS), this should **not** be enabled. If you configured the SMTP port as `587`, you should leave this unchecked in most cases.
+This setting should only be enabled for ports that use [implicit SSL/TLS](https://tools.ietf.org/html/rfc8314) (e.g., port `465` in most cases).
 
-This setting should only be enabled to establish secure connections for hosts which do not support STARTTLS.
+For servers that support [opportunistic TLS/STARTTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS) (typically via port `587`), this setting should **not** be enabled.
 
 ## SMTP Username & Password
+
+{% hint style="info" %}
+If your account has two-factor authentication enabled, you may need to create an application password instead of using your account password.
+{% endhint %}
 
 Configure these values as appropriate to authenticate with your SMTP host.
 

--- a/docs/using-overseerr/notifications/email.md
+++ b/docs/using-overseerr/notifications/email.md
@@ -1,0 +1,39 @@
+# Email
+
+{% hint style="info" %}
+**Media Requested**, **Media Automatically Approved**, and **Media Failed** email notifications are sent to _all_ users with the **Manage Requests** permission, as these notification types are intended for application administrators rather than end users.
+
+**Media Approved**, **Media Declined**, and **Media Available** email notifications are sent to the user who submitted the request.
+{% endhint %}
+
+## Configuration
+
+## Sender Address (required)
+
+Set this to the email address you would like to appear in the "from" field of the email message.
+
+## Sender Name (optional)
+
+Configure a friendly name for the email sender.
+
+## SMTP Host
+
+Set this to the hostname or IP address of your SMTP host/server.
+
+## SMTP Port
+
+Set this to a supported port number for your SMTP host. `465` and `587` are commonly used.
+
+## Enable SSL (optional)
+
+If using an SMTP serves which supports [STARTTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS), this should **not** be enabled. If you configured the SMTP port as `587`, you should leave this unchecked in most cases.
+
+This setting should only be enabled to establish secure connections for hosts which do not support STARTTLS.
+
+## SMTP Username & Password
+
+Configure these values as appropriate to authenticate with your SMTP host.
+
+## PGP Private Key & Password (optional)
+
+Configure these values to enable encrypting and signing of email messages using [OpenPGP](https://www.openpgp.org/). Note that individual users must also have their PGP public keys enabled in their user settings in order for PGP encryption to be used.

--- a/docs/using-overseerr/notifications/email.md
+++ b/docs/using-overseerr/notifications/email.md
@@ -17,31 +17,31 @@ On the other hand, the email notification types below are only sent to the user 
 
 ## Configuration
 
-## Sender Address (required)
+### Sender Address (required)
 
 Set this to the email address you would like to appear in the "from" field of the email message.
 
 Depending on your email provider, this may need to be an address you own. For example, Gmail requires this to be your actual email address.
 
-## Sender Name (optional)
+### Sender Name (optional)
 
 Configure a friendly name for the email sender.
 
-## SMTP Host
+### SMTP Host
 
 Set this to the hostname or IP address of your SMTP host/server.
 
-## SMTP Port
+### SMTP Port
 
 Set this to a supported port number for your SMTP host. `465` and `587` are commonly used.
 
-## Enable SSL (optional)
+### Enable SSL (optional)
 
 This setting should only be enabled for ports that use [implicit SSL/TLS](https://tools.ietf.org/html/rfc8314) (e.g., port `465` in most cases).
 
 For servers that support [opportunistic TLS/STARTTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS) (typically via port `587`), this setting should **not** be enabled.
 
-## SMTP Username & Password
+### SMTP Username & Password
 
 {% hint style="info" %}
 If your account has two-factor authentication enabled, you may need to create an application password instead of using your account password.
@@ -49,6 +49,6 @@ If your account has two-factor authentication enabled, you may need to create an
 
 Configure these values as appropriate to authenticate with your SMTP host.
 
-## PGP Private Key & Password (optional)
+### PGP Private Key & Password (optional)
 
 Configure these values to enable encrypting and signing of email messages using [OpenPGP](https://www.openpgp.org/). Note that individual users must also have their PGP public keys enabled in their user settings in order for PGP encryption to be used.

--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -10,7 +10,11 @@ The URL you would like to post notifications to. Your JSON will be sent as the b
 
 ### Authorization Header (optional)
 
-Custom authorization header. Anything entered for this will be sent as an `Authorization` header.
+{% hint style="info" %}
+This is typically not needed. Please refer to your webhook provider's documentation for details.
+{% endhint %}
+
+This value will be sent as an `Authorization` HTTP header.
 
 ### JSON Payload (required)
 

--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -1,16 +1,14 @@
 # Webhooks
 
-Webhooks let you post a custom JSON payload to any endpoint you like. You can also set an authorization header for security purposes.
+Webhooks allow you to send a custom JSON payload to any endpoint. You can also set an authorization header for security purposes.
 
 ## Configuration
-
-The following configuration options are available:
 
 ### Webhook URL (required)
 
 The URL you would like to post notifications to. Your JSON will be sent as the body of the request.
 
-### Authorization Header
+### Authorization Header (optional)
 
 Custom authorization header. Anything entered for this will be sent as an `Authorization` header.
 


### PR DESCRIPTION
#### Description

Adds email & Discord info to documentation. (Documentation for other notification agents is not included in this PR.)

#### Screenshot (if UI-related)

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A