### PR TITLE
feat(ui): store sort order and page size of userlist in localstorage

### DIFF
--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -77,7 +77,7 @@ const SettingsLogs: React.FC = () => {
   const { data: appData } = useSWR('/api/v1/status/appdata');
 
   useEffect(() => {
-    const filterString = window.localStorage.getItem('logs-filter-settings');
+    const filterString = window.localStorage.getItem('logs-display-settings');
 
     if (filterString) {
       const filterSettings = JSON.parse(filterString);
@@ -89,7 +89,7 @@ const SettingsLogs: React.FC = () => {
 
   useEffect(() => {
     window.localStorage.setItem(
-      'logs-filter-settings',
+      'logs-display-settings',
       JSON.stringify({
         currentFilter,
         currentPageSize,

--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -77,19 +77,19 @@ const SettingsLogs: React.FC = () => {
   const { data: appData } = useSWR('/api/v1/status/appdata');
 
   useEffect(() => {
-    const displayString = window.localStorage.getItem('logs-display-settings');
+    const filterString = window.localStorage.getItem('logs-filter-settings');
 
-    if (displayString) {
-      const displaySettings = JSON.parse(displayString);
+    if (filterString) {
+      const filterSettings = JSON.parse(filterString);
 
-      setCurrentFilter(displaySettings.currentFilter);
-      setCurrentPageSize(displaySettings.currentPageSize);
+      setCurrentFilter(filterSettings.currentFilter);
+      setCurrentPageSize(filterSettings.currentPageSize);
     }
   }, []);
 
   useEffect(() => {
     window.localStorage.setItem(
-      'logs-display-settings',
+      'logs-filter-settings',
       JSON.stringify({
         currentFilter,
         currentPageSize,

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -111,21 +111,19 @@ const UserList: React.FC = () => {
   const { user: currentUser } = useUser();
 
   useEffect(() => {
-    const displayString = window.localStorage.getItem(
-      'userlist-display-settings'
-    );
+    const filterString = window.localStorage.getItem('ul-filter-settings');
 
-    if (displayString) {
-      const displaySettings = JSON.parse(displayString);
+    if (filterString) {
+      const filterSettings = JSON.parse(filterString);
 
-      setCurrentSort(displaySettings.currentSort);
-      setCurrentPageSize(displaySettings.currentPageSize);
+      setCurrentSort(filterSettings.currentSort);
+      setCurrentPageSize(filterSettings.currentPageSize);
     }
   }, []);
 
   useEffect(() => {
     window.localStorage.setItem(
-      'userlist-display-settings',
+      'ul-filter-settings',
       JSON.stringify({
         currentSort,
         currentPageSize,

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
@@ -109,6 +109,29 @@ const UserList: React.FC = () => {
   const [showBulkEditModal, setShowBulkEditModal] = useState(false);
   const [selectedUsers, setSelectedUsers] = useState<number[]>([]);
   const { user: currentUser } = useUser();
+
+  useEffect(() => {
+    const displayString = window.localStorage.getItem(
+      'userlist-display-settings'
+    );
+
+    if (displayString) {
+      const displaySettings = JSON.parse(displayString);
+
+      setCurrentSort(displaySettings.currentSort);
+      setCurrentPageSize(displaySettings.currentPageSize);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      'userlist-display-settings',
+      JSON.stringify({
+        currentSort,
+        currentPageSize,
+      })
+    );
+  }, [currentSort, currentPageSize]);
 
   const isUserPermsEditable = (userId: number) =>
     userId !== 1 && userId !== currentUser?.id;


### PR DESCRIPTION
#### Description

Use localStorage to remember the sort order and page size of the user list just like it's done for the requests list and logs.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
