### PR TITLE
docs: add Pushbullet, Pushover, Slack, Telegram

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Discord](using-overseerr/notifications/discord.md)
   - [Pushbullet](using-overseerr/notifications/pushbullet.md)
   - [Pushover](using-overseerr/notifications/pushover.md)
+  - [Slack](using-overseerr/notifications/slack.md)
   - [Telegram](using-overseerr/notifications/telegram.md)
   - [Webhook](using-overseerr/notifications/webhooks.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,7 +13,10 @@
 - [Notifications](using-overseerr/notifications/README.md)
   - [Email](using-overseerr/notifications/email.md)
   - [Discord](using-overseerr/notifications/discord.md)
-  - [Webhooks](using-overseerr/notifications/webhooks.md)
+  - [Pushbullet](using-overseerr/notifications/pushbullet.md)
+  - [Pushover](using-overseerr/notifications/pushover.md)
+  - [Telegram](using-overseerr/notifications/telegram.md)
+  - [Webhook](using-overseerr/notifications/webhooks.md)
 
 ## Support
 

--- a/docs/using-overseerr/notifications/README.md
+++ b/docs/using-overseerr/notifications/README.md
@@ -8,7 +8,7 @@ Overseerr currently supports the following notification agents:
 - [Discord](./discord.md)
 - [Pushbullet](./pushbullet.md)
 - [Pushover](./pushover.md)
-- Slack
+- [Slack](./slack.md)
 - [Telegram](./telegram.md)
 - [Webhooks](./webhooks.md)
 

--- a/docs/using-overseerr/notifications/README.md
+++ b/docs/using-overseerr/notifications/README.md
@@ -6,10 +6,10 @@ Overseerr currently supports the following notification agents:
 
 - [Email](./email.md)
 - [Discord](./discord.md)
-- Pushbullet
-- Pushover
+- [Pushbullet](./pushbullet.md)
+- [Pushover](./pushover.md)
 - Slack
-- Telegram
+- [Telegram](./telegram.md)
 - [Webhooks](./webhooks.md)
 
 ## Setting Up Notifications

--- a/docs/using-overseerr/notifications/discord.md
+++ b/docs/using-overseerr/notifications/discord.md
@@ -1,11 +1,25 @@
 # Discord
 
+{% hint style="info" %}
+The following notification types will mention _all_ users with the **Manage Requests** permission, as these notification types are intended for application administrators rather than end users:
+
+- Media Requested
+- Media Automatically Approved
+- Media Failed
+
+On the other hand, the notification types below will only mention the user who submitted the request:
+
+- Media Approved (does not include automatic approvals)
+- Media Declined
+- Media Available
+
+In order for users to be mentioned in Discord notifications, they must have their [Discord user ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) configured and **Enable Mentions** checked in their Discord notification user settings.
+{% endhint %}
+
 ## Configuration
 
 {% hint style="info" %}
-In order to configure Discord notifications, you first need to [create a webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
-
-In order for users to be mentioned in Discord notifications, they must have their [Discord user ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) configured in their user settings.
+To configure Discord notifications, you first need to [create a webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
 {% endhint %}
 
 ### Bot Username (optional)

--- a/docs/using-overseerr/notifications/email.md
+++ b/docs/using-overseerr/notifications/email.md
@@ -9,15 +9,16 @@ The following email notification types are sent to _all_ users with the **Manage
 
 On the other hand, the email notification types below are only sent to the user who submitted the request:
 
-- Media Approved
+- Media Approved (does not include automatic approvals)
 - Media Declined
 - Media Available
 
+In order for users to receive email notifications, they must have **Enable Notifications** checked in their email notification user settings.
 {% endhint %}
 
 ## Configuration
 
-### Sender Address (required)
+### Sender Address
 
 Set this to the email address you would like to appear in the "from" field of the email message.
 

--- a/docs/using-overseerr/notifications/email.md
+++ b/docs/using-overseerr/notifications/email.md
@@ -52,4 +52,6 @@ Configure these values as appropriate to authenticate with your SMTP host.
 
 ### PGP Private Key & Password (optional)
 
-Configure these values to enable encrypting and signing of email messages using [OpenPGP](https://www.openpgp.org/). Note that individual users must also have their PGP public keys enabled in their user settings in order for PGP encryption to be used.
+Configure these values to enable encrypting and signing of email messages using [OpenPGP](https://www.openpgp.org/). Note that individual users must also have their **PGP public keys** configured in their user settings in order for PGP encryption to be used in messages addressed to them.
+
+When configuring the PGP keys, be sure to keep the entire contents of the key intact. For example, private keys always begin with `-----BEGIN PGP PRIVATE KEY BLOCK-----` and end with `-----END PGP PRIVATE KEY BLOCK-----`.

--- a/docs/using-overseerr/notifications/pushbullet.md
+++ b/docs/using-overseerr/notifications/pushbullet.md
@@ -1,0 +1,7 @@
+# Pushbullet
+
+## Configuration
+
+### Access Token
+
+[Create an access token](https://www.pushbullet.com/#settings) and set it here to grant Overseerr access to the Pushbullet API.

--- a/docs/using-overseerr/notifications/pushover.md
+++ b/docs/using-overseerr/notifications/pushover.md
@@ -1,0 +1,19 @@
+# Pushover
+
+## Configuration
+
+{% hint style="info" %}
+To configure Pushover notifications, you first need to [register an application](https://pushover.net/apps/build) for Overseerr. (You can use one of the [official icons in our GitHub repository](https://github.com/sct/overseerr/tree/develop/public) when configuring the application.)
+{% endhint %}
+
+### Application/API Token
+
+Set this to the API token for the application you registered.
+
+For more details on registering applications or the API token, please see the [Pushover API documentation](https://pushover.net/api#registration).
+
+### User Key
+
+Set this to the user key for your Pushover account. Alternatively, you can set this to a group key to deliver notifications to multiple users.
+
+For more details, please see the [Pushover API documentation](https://pushover.net/api#identifiers).

--- a/docs/using-overseerr/notifications/pushover.md
+++ b/docs/using-overseerr/notifications/pushover.md
@@ -2,13 +2,9 @@
 
 ## Configuration
 
-{% hint style="info" %}
-To configure Pushover notifications, you first need to [register an application](https://pushover.net/apps/build) for Overseerr. (You can use one of the [official icons in our GitHub repository](https://github.com/sct/overseerr/tree/develop/public) when configuring the application.)
-{% endhint %}
-
 ### Application/API Token
 
-Set this to the API token for the application you registered.
+[Register an application](https://pushover.net/apps/build) and enter the API token in this field. (You can use one of the [official icons in our GitHub repository](https://github.com/sct/overseerr/tree/develop/public) when configuring the application.)
 
 For more details on registering applications or the API token, please see the [Pushover API documentation](https://pushover.net/api#registration).
 

--- a/docs/using-overseerr/notifications/slack.md
+++ b/docs/using-overseerr/notifications/slack.md
@@ -1,0 +1,7 @@
+# Slack
+
+## Configuration
+
+### Webhook URL
+
+Simply [create a webhook](https://catflixserver.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks) and enter the URL in this field.

--- a/docs/using-overseerr/notifications/telegram.md
+++ b/docs/using-overseerr/notifications/telegram.md
@@ -21,9 +21,9 @@ Bots **cannot** initiate conversations with users, users must have your bot adde
 
 ### Bot Username (optional)
 
-If this value is configured, a link will be displayed in notification user settings to allow users to easily start a conversation with your bot.
+If this value is configured, users will be able to start a chat with your bot and configure their own personal notifications.
 
-This username should end with `_bot`, and the `@` prefix should be omitted.
+The bot username should end with `_bot`, and the `@` prefix should be omitted.
 
 ### Bot Authentication Token
 

--- a/docs/using-overseerr/notifications/telegram.md
+++ b/docs/using-overseerr/notifications/telegram.md
@@ -31,7 +31,7 @@ At the end of the bot creation process, [@BotFather](https://telegram.me/botfath
 
 ### Chat ID
 
-To obtain your chat ID, simply create a new chat, add [@get_id_bot](https://telegram.me/get_id_bot), and issue the `/my_id` command.
+To obtain your chat ID, simply create a new group chat, add [@get_id_bot](https://telegram.me/get_id_bot), and issue the `/my_id` command.
 
 ### Send Silently (optional)
 

--- a/docs/using-overseerr/notifications/telegram.md
+++ b/docs/using-overseerr/notifications/telegram.md
@@ -1,0 +1,38 @@
+# Telegram
+
+{% hint style="info" %}
+All notification types will be sent to the chat ID configured in your Overseerr application settings.
+
+If a user has configured a chat ID and has **Enable Notifications** checked in their Telegram notification user settings as well, they will be sent the following notification types for requests which they submit:
+
+- Media Approved (does not include automatic approvals)
+- Media Declined
+- Media Available
+
+{% endhint %}
+
+## Configuration
+
+{% hint style="info" %}
+In order to configure Telegram notifications, you first need to [create a bot](https://telegram.me/BotFather).
+
+Bots **cannot** initiate conversations with users, users must have your bot added to a conversation in order to receive notifications.
+{% endhint %}
+
+### Bot Username (optional)
+
+If this value is configured, a link will be displayed in notification user settings to allow users to easily start a conversation with your bot.
+
+This username should end with `_bot`, and the `@` prefix should be omitted.
+
+### Bot Authentication Token
+
+At the end of the bot creation process, [@BotFather](https://telegram.me/botfather) will provide an authentication token.
+
+### Chat ID
+
+To obtain your chat ID, simply create a new chat, add [@get_id_bot](https://telegram.me/get_id_bot), and issue the `/my_id` command.
+
+### Send Silently (optional)
+
+Instagram allows you to enable silent notifications. Those will present a pop-up to the user, but will not make any sound. That's a per user configuration.

--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -1,10 +1,10 @@
-# Webhooks
+# Webhook
 
-Webhooks allow you to send a custom JSON payload to any endpoint. You can also set an authorization header for security purposes.
+The webhook notification agent allows you to send a custom JSON payload to any endpoint.
 
 ## Configuration
 
-### Webhook URL (required)
+### Webhook URL
 
 The URL you would like to post notifications to. Your JSON will be sent as the body of the request.
 
@@ -16,7 +16,7 @@ This is typically not needed. Please refer to your webhook provider's documentat
 
 This value will be sent as an `Authorization` HTTP header.
 
-### JSON Payload (required)
+### JSON Payload
 
 Customize the JSON payload to suit your needs. Overseerr provides several [template variables](./webhooks.md#template-variables) for use in the payload, which will be replaced with the relevant data when the notifications are triggered.
 


### PR DESCRIPTION
#### Description

This PR adds documentation for the Pushbullet, Pushover, Slack, and Telegram agents.

It also reflects the changes/fixes implemented in #1172, so it should not be merged until after that PR is in `develop`.

Many thanks to @costaht for helping with the Telegram docs!

#### Screenshot (if UI-related)

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A