### PR TITLE
fix(ui): restore saved states of quota override checkboxes

### DIFF
--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import { useRouter } from 'next/router';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
@@ -56,6 +56,11 @@ const UserGeneralSettings: React.FC = () => {
   const { data, error, revalidate } = useSWR<UserSettingsGeneralResponse>(
     user ? `/api/v1/user/${user?.id}/settings/main` : null
   );
+
+  useEffect(() => {
+    setMovieQuotaEnabled(!!data?.movieQuotaLimit && !!data?.movieQuotaDays);
+    setTvQuotaEnabled(!!data?.tvQuotaLimit && !!data?.tvQuotaDays);
+  }, [data]);
 
   const { data: languages, error: languagesError } = useSWR<Language[]>(
     '/api/v1/languages'

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -58,8 +58,12 @@ const UserGeneralSettings: React.FC = () => {
   );
 
   useEffect(() => {
-    setMovieQuotaEnabled(!!data?.movieQuotaLimit && !!data?.movieQuotaDays);
-    setTvQuotaEnabled(!!data?.tvQuotaLimit && !!data?.tvQuotaDays);
+    setMovieQuotaEnabled(
+      data?.movieQuotaLimit != undefined && data?.movieQuotaDays != undefined
+    );
+    setTvQuotaEnabled(
+      data?.tvQuotaLimit != undefined && data?.tvQuotaDays != undefined
+    );
   }, [data]);
 
   const { data: languages, error: languagesError } = useSWR<Language[]>(


### PR DESCRIPTION
#### Description

Currently, the "Enable Override" checkboxes reset to unchecked when you return to the user settings page after  saving.  (This is just a visual bug, the values are saved properly to the DB.)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A