### PR TITLE
fix(overseerr-api.yml): Fixed Pushbullet & webhook API definition refs and descriptions

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -2502,8 +2502,8 @@ paths:
                 $ref: '#/components/schemas/PushbulletSettings'
   /settings/notifications/pushbullet/test:
     post:
-      summary: Test Pushover settings
-      description: Sends a test notification to the Pushover agent.
+      summary: Test Pushbullet settings
+      description: Sends a test notification to the Pushbullet agent.
       tags:
         - settings
       requestBody:
@@ -2511,7 +2511,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PushoverSettings'
+              $ref: '#/components/schemas/PushbulletSettings'
       responses:
         '204':
           description: Test notification attempted
@@ -2649,7 +2649,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SlackSettings'
+              $ref: '#/components/schemas/WebhookSettings'
       responses:
         '204':
           description: Test notification attempted


### PR DESCRIPTION
#### Description

Quick fix for the API definitions where Pushbullet was referencing the wrong schema and had an incorrect summary & description.

Similar fix for webhook, which referenced the wrong schema.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- No open issues regarding this fix.
