### PR TITLE
fix(frontend): call mutate after changing public settings

### DIFF
--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -3,7 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import React, { useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import * as Yup from 'yup';
 import type { Language, MainSettings } from '../../../server/lib/settings';
 import { Permission, useUser } from '../../hooks/useUser';
@@ -162,6 +162,7 @@ const SettingsMain: React.FC = () => {
                 trustProxy: values.trustProxy,
                 cacheImages: values.cacheImages,
               });
+              mutate('/api/v1/settings/public');
 
               addToast(intl.formatMessage(messages.toastSettingsSuccess), {
                 autoDismiss: true,

--- a/src/components/Settings/SettingsServices.tsx
+++ b/src/components/Settings/SettingsServices.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import type {
   RadarrSettings,
   SonarrSettings,
@@ -213,6 +213,7 @@ const SettingsServices: React.FC = () => {
     setDeleteServerModal({ open: false, serverId: null, type: 'radarr' });
     revalidateRadarr();
     revalidateSonarr();
+    mutate('/api/v1/settings/public');
   };
 
   return (
@@ -237,6 +238,7 @@ const SettingsServices: React.FC = () => {
           onClose={() => setEditRadarrModal({ open: false, radarr: null })}
           onSave={() => {
             revalidateRadarr();
+            mutate('/api/v1/settings/public');
             setEditRadarrModal({ open: false, radarr: null });
           }}
         />
@@ -247,6 +249,7 @@ const SettingsServices: React.FC = () => {
           onClose={() => setEditSonarrModal({ open: false, sonarr: null })}
           onSave={() => {
             revalidateSonarr();
+            mutate('/api/v1/settings/public');
             setEditSonarrModal({ open: false, sonarr: null });
           }}
         />


### PR DESCRIPTION
#### Description

Call mutate to `/api/v1/settings/public` after changing public settings to force refresh/update of settings.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A