### PR TITLE
fix(frontend): use correct path to user profile in request modal quota dropdown

### DIFF
--- a/src/components/RequestModal/QuotaDisplay/index.tsx
+++ b/src/components/RequestModal/QuotaDisplay/index.tsx
@@ -162,7 +162,9 @@ const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
                 ProfileLink: function ProfileLink(msg) {
                   return (
                     <Link
-                      href={userOverride ? `/user/${userOverride}` : '/profile'}
+                      href={
+                        userOverride ? `/users/${userOverride}` : '/profile'
+                      }
                     >
                       <a className="text-white hover:underline">{msg}</a>
                     </Link>

--- a/src/components/RequestModal/QuotaDisplay/index.tsx
+++ b/src/components/RequestModal/QuotaDisplay/index.tsx
@@ -166,7 +166,9 @@ const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
                         userOverride ? `/users/${userOverride}` : '/profile'
                       }
                     >
-                      <a className="text-white hover:underline">{msg}</a>
+                      <a className="text-white transition duration-300 hover:underline">
+                        {msg}
+                      </a>
                     </Link>
                   );
                 },


### PR DESCRIPTION
#### Description

When submitting a request on behalf of another user, the user profile page link is currently broken (links to `/user/[userId]` instead of `/users/[userId]`).

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A