### PR TITLE
fix(backend): fix getShowByTvdbId() error message

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -11,6 +11,7 @@ import {
   TmdbNetwork,
   TmdbPersonCombinedCredits,
   TmdbPersonDetail,
+  TmdbProductionCompany,
   TmdbRegion,
   TmdbSearchMovieResponse,
   TmdbSearchMultiResponse,
@@ -18,7 +19,6 @@ import {
   TmdbSeasonWithEpisodes,
   TmdbTvDetails,
   TmdbUpcomingMoviesResponse,
-  TmdbProductionCompany,
 } from './interfaces';
 
 interface SearchOptions {
@@ -613,15 +613,15 @@ class TheMovieDb extends ExternalAPI {
 
         return tvshow;
       }
-
-      throw new Error(
-        `[TMDb] Failed to find a TV show with the provided TVDB ID: ${tvdbId}`
-      );
     } catch (e) {
       throw new Error(
         `[TMDb] Failed to get TV show using the external TVDB ID: ${e.message}`
       );
     }
+
+    throw new Error(
+      `[TMDb] Failed to find a TV show with the provided TVDB ID: ${tvdbId}`
+    );
   }
 
   public async getCollection({

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -613,15 +613,13 @@ class TheMovieDb extends ExternalAPI {
 
         return tvshow;
       }
+
+      throw new Error(`No show returned from API for ID ${tvdbId}`);
     } catch (e) {
       throw new Error(
         `[TMDb] Failed to get TV show using the external TVDB ID: ${e.message}`
       );
     }
-
-    throw new Error(
-      `[TMDb] Failed to find a TV show with the provided TVDB ID: ${tvdbId}`
-    );
   }
 
   public async getCollection({


### PR DESCRIPTION
#### Description

Currently, we are logging messages such as the following:
```
2021-03-29T08:30:25.985Z [error][Sonarr Scan]: Failed to process Sonarr media {"errorMessage":"[TMDb] Failed to get TV show using the external TVDB ID: [TMDb] Failed to find a TV show with the provided TVDB ID: 309496","title":"Rock Records In Love"}
```

This is because we are throwing an error in `getShowByTvdbId()` which gets caught by a `try`/`catch` block which then re-throws and adds to the message.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A