### PR TITLE
fix(ui): use correct colspan for 'No results.' message in Settings > Logs

### DIFF
--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -418,7 +418,7 @@ const SettingsLogs: React.FC = () => {
               </tr>
             )}
             <tr className="bg-gray-700">
-              <Table.TD colSpan={6} noPadding>
+              <Table.TD colSpan={5} noPadding>
                 <nav
                   className="flex flex-col items-center w-screen px-6 py-3 space-x-4 space-y-3 sm:space-y-0 sm:flex-row lg:w-full"
                   aria-label="Pagination"

--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -397,7 +397,7 @@ const SettingsLogs: React.FC = () => {
 
             {data.results.length === 0 && (
               <tr className="relative h-24 p-2 text-white">
-                <Table.TD colSpan={4} noPadding>
+                <Table.TD colSpan={5} noPadding>
                   <div className="flex flex-col items-center justify-center w-screen p-6 lg:w-full">
                     <span className="text-base">
                       {intl.formatMessage(globalMessages.noresults)}


### PR DESCRIPTION
#### Description

When the buttons for each log line were added, the colspan wasn't updated.

PR fixes this issue:
![image](https://user-images.githubusercontent.com/52870424/112933562-18587a80-90ee-11eb-9d50-7ac2b0dc1ff4.png)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A