### PR TITLE
fix(frontend): include language parameter in TMDb links

### DIFF
--- a/src/components/ExternalLinkBlock/index.tsx
+++ b/src/components/ExternalLinkBlock/index.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { MediaType } from '../../../server/constants/media';
+import ImdbLogo from '../../assets/services/imdb.svg';
+import PlexLogo from '../../assets/services/plex.svg';
+import RTLogo from '../../assets/services/rt.svg';
 import TmdbLogo from '../../assets/services/tmdb.svg';
 import TvdbLogo from '../../assets/services/tvdb.svg';
-import ImdbLogo from '../../assets/services/imdb.svg';
-import RTLogo from '../../assets/services/rt.svg';
-import PlexLogo from '../../assets/services/plex.svg';
-import { MediaType } from '../../../server/constants/media';
+import { LanguageContext } from '../../context/LanguageContext';
 
 interface ExternalLinkBlockProps {
   mediaType: 'movie' | 'tv';
@@ -23,6 +24,8 @@ const ExternalLinkBlock: React.FC<ExternalLinkBlockProps> = ({
   rtUrl,
   plexUrl,
 }) => {
+  const { locale } = useContext(LanguageContext);
+
   return (
     <div className="flex items-center justify-center w-full space-x-5">
       {plexUrl && (
@@ -37,7 +40,7 @@ const ExternalLinkBlock: React.FC<ExternalLinkBlockProps> = ({
       )}
       {tmdbId && (
         <a
-          href={`https://www.themoviedb.org/${mediaType}/${tmdbId}`}
+          href={`https://www.themoviedb.org/${mediaType}/${tmdbId}?language=${locale}`}
           className="w-8 transition duration-300 opacity-50 hover:opacity-100"
           target="_blank"
           rel="noreferrer"


### PR DESCRIPTION
#### Description

Include the `language` query parameter in TMDb external links, so that the user is directed to the appropriately localized page.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A