### PR TITLE
fix: fall back to English genre names

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -715,7 +715,10 @@ class TheMovieDb extends ExternalAPI {
         86400 // 24 hours
       );
 
-      if (language !== 'en' && data.genres.some((genre) => !genre.name)) {
+      if (
+        !language.startsWith('en') &&
+        data.genres.some((genre) => !genre.name)
+      ) {
         const englishData = await this.get<TmdbGenresResult>(
           '/genre/movie/list',
           {
@@ -763,7 +766,10 @@ class TheMovieDb extends ExternalAPI {
         86400 // 24 hours
       );
 
-      if (language !== 'en' && data.genres.some((genre) => !genre.name)) {
+      if (
+        !language.startsWith('en') &&
+        data.genres.some((genre) => !genre.name)
+      ) {
         const englishData = await this.get<TmdbGenresResult>(
           '/genre/tv/list',
           {

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -715,7 +715,31 @@ class TheMovieDb extends ExternalAPI {
         86400 // 24 hours
       );
 
-      const movieGenres = sortBy(data.genres, 'name');
+      if (language !== 'en' && data.genres.some((genre) => !genre.name)) {
+        const englishData = await this.get<TmdbGenresResult>(
+          '/genre/movie/list',
+          {
+            params: {
+              language: 'en',
+            },
+          },
+          86400 // 24 hours
+        );
+
+        data.genres
+          .filter((genre) => !genre.name)
+          .forEach((genre) => {
+            genre.name =
+              englishData.genres.find(
+                (englishGenre) => englishGenre.id === genre.id
+              )?.name ?? '';
+          });
+      }
+
+      const movieGenres = sortBy(
+        data.genres.filter((genre) => genre.name),
+        'name'
+      );
 
       return movieGenres;
     } catch (e) {
@@ -739,7 +763,31 @@ class TheMovieDb extends ExternalAPI {
         86400 // 24 hours
       );
 
-      const tvGenres = sortBy(data.genres, 'name');
+      if (language !== 'en' && data.genres.some((genre) => !genre.name)) {
+        const englishData = await this.get<TmdbGenresResult>(
+          '/genre/tv/list',
+          {
+            params: {
+              language: 'en',
+            },
+          },
+          86400 // 24 hours
+        );
+
+        data.genres
+          .filter((genre) => !genre.name)
+          .forEach((genre) => {
+            genre.name =
+              englishData.genres.find(
+                (englishGenre) => englishGenre.id === genre.id
+              )?.name ?? '';
+          });
+      }
+
+      const tvGenres = sortBy(
+        data.genres.filter((genre) => genre.name),
+        'name'
+      );
 
       return tvGenres;
     } catch (e) {


### PR DESCRIPTION
#### Description

TMDb returns `null` for genre names in some languages (e.g., Catalan), which results in odd behavior for those locales (genre cards with no text and genre pages with no genre name).

This PR adds a fall back to English genre names when a localized name is not provided by TMDb.

**Note:** TMDb _is_ falling back to English genre names in the `genres` object returned by their `/movie/{movie_id}` and `/tv/{tv_id}` API endpoints (used by movie/series detail pages).  They simply aren't falling back to English on their `/genre/movie/list` and `/genre/tv/list` endpoints. 🤦🏻‍♀️

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #1349