### PR TITLE
fix(ui): link request card status badge to Plex media URL

### DIFF
--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -192,6 +192,8 @@ const RequestCard: React.FC<RequestCardProps> = ({ request, onTitleData }) => {
                 ).length > 0
               }
               is4k={requestData.is4k}
+              plexUrl={requestData.media.plexUrl}
+              plexUrl4k={requestData.media.plexUrl4k}
             />
           )}
         </div>


### PR DESCRIPTION
#### Description

Plex URLs aren't being passed to the `StatusBadge` component for `RequestCard`s currently.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A