### PR TITLE
fix(plex): use server 'address' returned by Plex API

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -200,9 +200,6 @@ components:
         message:
           type: string
           example: 'OK'
-        host:
-          type: string
-          example: '127-0-0-1.2ab6ce1a093d465e910def96cf4e4799.plex.direct'
       required:
         - protocol
         - address


### PR DESCRIPTION
#### Description

This PR updates the `/plex/devices/servers` API endpoint to try to connect to Plex using the returned `address` property, rather than trying to parse the hostname out of the `uri` property.

This resolves an issue with automatic server configuration reported by the folks over at LSIO 🐱

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A