### PR TITLE
fix(user.ts): Time value of a quota was being ignored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -236,11 +236,9 @@ export class User {
     const movieDate = new Date();
     if (movieQuotaDays) {
       movieDate.setDate(movieDate.getDate() - movieQuotaDays);
-    } else {
-      movieDate.setDate(0);
     }
-    // YYYY-MM-DD format
-    const movieQuotaStartDate = movieDate.toJSON().split('T')[0];
+    const movieQuotaStartDate = movieDate.toJSON();
+
     const movieQuotaUsed = movieQuotaLimit
       ? await requestRepository.count({
           where: {
@@ -261,11 +259,8 @@ export class User {
     const tvDate = new Date();
     if (tvQuotaDays) {
       tvDate.setDate(tvDate.getDate() - tvQuotaDays);
-    } else {
-      tvDate.setDate(0);
     }
-    // YYYY-MM-DD format
-    const tvQuotaStartDate = tvDate.toJSON().split('T')[0];
+    const tvQuotaStartDate = tvDate.toJSON();
     const tvQuotaUsed = tvQuotaLimit
       ? (
           await requestRepository


### PR DESCRIPTION
re #1358

#### Description
This would cause inaccurate quota rules applied to new requests, as it may or may not artificially
extend the actual cooldown period.

Also added .gitattributes for the pesky windows users that have different line endings than the repo

- Request limit hit at 3PM.
- Day one of the cooldown is the next day (3PM -> 3PM then cut off time time value so we're just at the next day)
- Day two of the cooldown period is the next after that (3PM -> 3PM again then cut of the time again)
- Day 3 at 12:01AM they are able to request again.

This means that 48 hours + 9 hours (3PM -> 11:59PM on the first day) have passed since requesting = 57 hours.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1358
