### PR TITLE
feat: Remove media items that no longer exist in Plex

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -583,7 +583,7 @@ class TheMovieDb extends ExternalAPI {
       }
 
       throw new Error(
-        '[TMDb] Failed to find a title with the provided IMDB id'
+        `[TMDb] Failed to find a title with the provided IMDB id ${imdbId}`
       );
     } catch (e) {
       throw new Error(


### PR DESCRIPTION
#### Description

On a full scan, if there are orphaned media items we should remove them any likely anything else relating to that item to ensure we're in sync with the source (plex). 

This is related to #377 but I'm likely missing quite a bit of context for the fix so would appreciate any direction as to how to do this properly. I'm not a huge fan of using the class with a property bag for processed items.

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
