### PR TITLE
fix(plex): do not use SSL for local servers

### DIFF
--- a/server/interfaces/api/plexInterfaces.ts
+++ b/server/interfaces/api/plexInterfaces.ts
@@ -14,7 +14,6 @@ export interface PlexConnection {
   local: boolean;
   status?: number;
   message?: string;
-  host?: string;
 }
 
 export interface PlexDevice {

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -135,7 +135,7 @@ settingsRoutes.get('/plex/devices/servers', async (req, res, next) => {
                 ...settings.plex,
                 ip: connection.address,
                 port: connection.port,
-                useSsl: connection.protocol === 'https' ? true : false,
+                useSsl: !connection.local && connection.protocol === 'https',
               };
               const plexClient = new PlexAPI({
                 plexToken: admin.plexToken,

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -134,13 +134,12 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
       dev.connection.forEach((conn) =>
         finalPresets.push({
           name: dev.name,
-          ssl: conn.protocol === 'https' ? true : false,
+          ssl: !conn.local && conn.protocol === 'https',
           uri: conn.uri,
           address: conn.address,
           port: conn.port,
           local: conn.local,
-          host: conn.host,
-          status: conn.status === 200 ? true : false,
+          status: conn.status === 200,
           message: conn.message,
         })
       );


### PR DESCRIPTION
#### Description

Plex returns `https` as the protocol even for local IPs, which causes a `Hostname/IP does not match certificate's altnames` error when we test the connection using that particular config.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A