### PR TITLE
fix(plex): do not log error when attempting to import user w/ no server access

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -91,7 +91,7 @@ interface FriendResponse {
         email: string;
         thumb: string;
       };
-      Server: ServerResponse[];
+      Server?: ServerResponse[];
     }[];
   };
 }
@@ -232,7 +232,7 @@ class PlexTvAPI {
         );
       }
 
-      return !!user.Server.find(
+      return !!user.Server?.find(
         (server) => server.$.machineIdentifier === settings.plex.machineId
       );
     } catch (e) {


### PR DESCRIPTION
#### Description

Fixes `Error checking user access: Cannot read properly ‘find’ of undefined` error when importing users and a user does not have access to any servers.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A