### PR TITLE
fix(ui): remove 'Upcoming Series' slider

### DIFF
--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -19,7 +19,6 @@ const messages = defineMessages({
   recentrequests: 'Recent Requests',
   popularmovies: 'Popular Movies',
   populartv: 'Popular Series',
-  upcomingtv: 'Upcoming Series',
   recentlyAdded: 'Recently Added',
   noRequests: 'No requests.',
   upcoming: 'Upcoming Movies',
@@ -123,12 +122,6 @@ const Discover: React.FC = () => {
         linkUrl="/discover/tv"
       />
       <TvGenreSlider />
-      <MediaSlider
-        sliderKey="upcoming-tv"
-        title={intl.formatMessage(messages.upcomingtv)}
-        url="/api/v1/discover/tv/upcoming"
-        linkUrl="/discover/tv/upcoming"
-      />
       <NetworkSlider />
     </>
   );


### PR DESCRIPTION
#### Description

The results returned by TMDb for `Upcoming Series` slider honestly leave much to be desired, and the slider often surfaces new entries that people have added to TMDb but not necessarily tagged correctly.

The slider problematically frequently returns adult content high in the list of results, even with region and/or language filtering in place.  (TMDb does not support filtering out adult results for TV series the way it does for movies, but that is a whole other issue.)

This PR simply removes the slider from the `Discover` page. The API endpoint and `Upcoming Series` page (`/discover/tv/upcoming`) are left intact, since we will hopefully be able to reinstate this slider in the future once we have added support for filtering by age ratings.  Users will still be able to navigate to and view this page, but there will no longer be any links to it from the UI.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract` (**Note:** The removed string is also shared/used by another component, so there are no changes to `en.json`.)

#### Issues Fixed or Closed

N/A