### PR TITLE
fix(ui): dim password field when password generation option is selected

### DIFF
--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -388,7 +388,9 @@ const UserList: React.FC = () => {
                       />
                     </div>
                   </div>
-                  <div className="form-row">
+                  <div
+                    className={`form-row ${values.genpassword && 'opacity-50'}`}
+                  >
                     <label htmlFor="password" className="text-label">
                       {intl.formatMessage(messages.password)}
                     </label>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -372,7 +372,7 @@ const UserList: React.FC = () => {
                   </div>
                   <div
                     className={`form-row ${
-                      !notificationSettings?.emailEnabled && 'opacity-50'
+                      notificationSettings?.emailEnabled ? '' : 'opacity-50'
                     }`}
                   >
                     <label htmlFor="genpassword" className="checkbox-label">
@@ -389,7 +389,9 @@ const UserList: React.FC = () => {
                     </div>
                   </div>
                   <div
-                    className={`form-row ${values.genpassword && 'opacity-50'}`}
+                    className={`form-row ${
+                      values.genpassword ? 'opacity-50' : ''
+                    }`}
                   >
                     <label htmlFor="password" className="text-label">
                       {intl.formatMessage(messages.password)}


### PR DESCRIPTION
#### Description

Dims password field in `Create Local User` modal when `Automatically Generate Password` is checked, so that it is clearer that the password field is disabled.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A