### PR TITLE
fix(ui): correctly set autocomplete attribute for password fields

### DIFF
--- a/src/components/Login/LocalLogin.tsx
+++ b/src/components/Login/LocalLogin.tsx
@@ -84,6 +84,7 @@ const LocalLogin: React.FC<LocalLoginProps> = ({ revalidate }) => {
                       id="password"
                       name="password"
                       type="password"
+                      autoComplete="current-password"
                       placeholder={intl.formatMessage(messages.password)}
                     />
                   </div>

--- a/src/components/ResetPassword/index.tsx
+++ b/src/components/ResetPassword/index.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
-import ImageFader from '../Common/ImageFader';
-import { defineMessages, useIntl } from 'react-intl';
-import LanguagePicker from '../Layout/LanguagePicker';
-import Button from '../Common/Button';
-import { Field, Form, Formik } from 'formik';
-import * as Yup from 'yup';
 import axios from 'axios';
-import { useRouter } from 'next/router';
+import { Field, Form, Formik } from 'formik';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React, { useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import * as Yup from 'yup';
+import Button from '../Common/Button';
+import ImageFader from '../Common/ImageFader';
+import LanguagePicker from '../Layout/LanguagePicker';
 
 const messages = defineMessages({
   passwordreset: 'Password Reset',
@@ -120,9 +120,7 @@ const ResetPassword: React.FC = () => {
                               id="password"
                               name="password"
                               type="password"
-                              placeholder={intl.formatMessage(
-                                messages.password
-                              )}
+                              autoComplete="new-password"
                               className="flex-1 block w-full min-w-0 text-white transition duration-150 ease-in-out bg-gray-700 border border-gray-500 rounded-md form-input sm:text-sm sm:leading-5"
                             />
                           </div>
@@ -141,8 +139,8 @@ const ResetPassword: React.FC = () => {
                             <Field
                               id="confirmPassword"
                               name="confirmPassword"
-                              placeholder="Confirm Password"
                               type="password"
+                              autoComplete="new-password"
                               className="flex-1 block w-full min-w-0 text-white transition duration-150 ease-in-out bg-gray-700 border border-gray-500 rounded-md form-input sm:text-sm sm:leading-5"
                             />
                           </div>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -62,6 +62,7 @@ const messages = defineMessages({
   passwordinfodescription:
     'Enable email notifications to allow automatic password generation.',
   autogeneratepassword: 'Automatically Generate Password',
+  autogeneratepasswordTip: 'Email a server-generated password to the user',
   validationEmail: 'You must provide a valid email address',
   sortCreated: 'Creation Date',
   sortUpdated: 'Last Updated',
@@ -377,6 +378,9 @@ const UserList: React.FC = () => {
                   >
                     <label htmlFor="genpassword" className="checkbox-label">
                       {intl.formatMessage(messages.autogeneratepassword)}
+                      <span className="label-tip">
+                        {intl.formatMessage(messages.autogeneratepasswordTip)}
+                      </span>
                     </label>
                     <div className="form-input">
                       <Field
@@ -402,8 +406,8 @@ const UserList: React.FC = () => {
                           id="password"
                           name="password"
                           type="password"
+                          autoComplete="new-password"
                           disabled={values.genpassword}
-                          placeholder={intl.formatMessage(messages.password)}
                         />
                       </div>
                       {errors.password && touched.password && (

--- a/src/components/UserProfile/UserSettings/UserPasswordChange/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserPasswordChange/index.tsx
@@ -165,7 +165,8 @@ const UserPasswordChange: React.FC = () => {
                       <Field
                         id="currentPassword"
                         name="currentPassword"
-                        type="text"
+                        type="password"
+                        autoComplete="current-password"
                       />
                     </div>
                     {errors.currentPassword && touched.currentPassword && (
@@ -180,7 +181,12 @@ const UserPasswordChange: React.FC = () => {
                 </label>
                 <div className="form-input">
                   <div className="form-input-field">
-                    <Field id="newPassword" name="newPassword" type="text" />
+                    <Field
+                      id="newPassword"
+                      name="newPassword"
+                      type="password"
+                      autoComplete="new-password"
+                    />
                   </div>
                   {errors.newPassword && touched.newPassword && (
                     <div className="error">{errors.newPassword}</div>
@@ -196,7 +202,8 @@ const UserPasswordChange: React.FC = () => {
                     <Field
                       id="confirmPassword"
                       name="confirmPassword"
-                      type="text"
+                      type="password"
+                      autoComplete="new-password"
                     />
                   </div>
                   {errors.confirmPassword && touched.confirmPassword && (

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -646,6 +646,7 @@
   "components.UserList.accounttype": "Account Type",
   "components.UserList.admin": "Admin",
   "components.UserList.autogeneratepassword": "Automatically Generate Password",
+  "components.UserList.autogeneratepasswordTip": "Email a server-generated password to the user",
   "components.UserList.bulkedit": "Bulk Edit",
   "components.UserList.create": "Create",
   "components.UserList.created": "Created",


### PR DESCRIPTION
#### Description

Sets `autocomplete` attribute for passwords to `new-password` or `current-password` as appropriate.  (This also fixes the undesired behavior of the `Create Local User` modal trying to autofill with saved emails/passwords.)

Also adds a tip for the `Automatically Generate Password` option to clarify that the generated password will be emailed to the user.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A