### PR TITLE
fix(ui): adjust user list buttons on mobile

### DIFF
--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -436,9 +436,9 @@ const UserList: React.FC = () => {
       <div className="flex flex-col justify-between lg:items-end lg:flex-row">
         <Header>{intl.formatMessage(messages.userlist)}</Header>
         <div className="flex flex-col flex-grow mt-2 lg:flex-row lg:flex-grow-0">
-          <div className="flex flex-row justify-between flex-grow mb-2 lg:mb-0 lg:flex-grow-0">
+          <div className="flex flex-col justify-between flex-grow mb-2 sm:flex-row lg:mb-0 lg:flex-grow-0">
             <Button
-              className="flex-grow mr-2 outline"
+              className="flex-grow mb-2 sm:mb-0 sm:mr-2 outline"
               buttonType="primary"
               onClick={() => setCreateModal({ isOpen: true })}
             >


### PR DESCRIPTION
#### Description

Adjusts user list buttons so that they are on separate lines and do not wrap on mobile.

#### Screenshot (if UI-related)

![Screenshot_20210417-120750.png](https://user-images.githubusercontent.com/52870424/115119285-9c778280-9f75-11eb-879c-865055dd4269.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A