### PR TITLE
ci: use actions/cache@v2.1.0 instead of v2.1.5 for Next.js build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Use Next.js cache
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2.1.0
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Use Next.js cache
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2.1.0
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache Next.js build
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2.1.0
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
#### Description

`actions/cache@v2.1.5` does not support BusyBox `tar`, so we need to use `v2.1.0` for this action to work in the Alpine container environment.

More info: https://github.com/actions/cache/issues/425#issuecomment-703114994

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A