### PR TITLE
fix(radarr): only process Radarr movies which are either monitored or downloaded

### DIFF
--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -55,7 +55,9 @@ class RadarrScanner
             url: RadarrAPI.buildUrl(server, '/api/v3'),
           });
 
-          this.items = await this.radarrApi.getMovies();
+          this.items = (await this.radarrApi.getMovies()).filter(
+            (m) => m.monitored || m.downloaded
+          );
 
           await this.loop(this.processRadarrMovie.bind(this), { sessionId });
         } else {

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -55,9 +55,7 @@ class RadarrScanner
             url: RadarrAPI.buildUrl(server, '/api/v3'),
           });
 
-          this.items = (await this.radarrApi.getMovies()).filter(
-            (m) => m.monitored || m.downloaded
-          );
+          this.items = await this.radarrApi.getMovies();
 
           await this.loop(this.processRadarrMovie.bind(this), { sessionId });
         } else {
@@ -74,6 +72,17 @@ class RadarrScanner
   }
 
   private async processRadarrMovie(radarrMovie: RadarrMovie): Promise<void> {
+    if (!radarrMovie.monitored && !radarrMovie.downloaded) {
+      this.log(
+        'Title is unmonitored and has not been downloaded. Skipping item.',
+        'debug',
+        {
+          title: radarrMovie.title,
+        }
+      );
+      return;
+    }
+
     try {
       const server4k = this.enable4kMovie && this.currentServer.is4k;
       await this.processMovie(radarrMovie.tmdbId, {


### PR DESCRIPTION
#### Description

Changes behavior of Radarr scanner to not mark unmonitored movies as `Requested`.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes https://github.com/sct/overseerr/issues/1286#issuecomment-827582789