### PR TITLE
fix(email): specify Nodemailer SMTP transport 'name' option

### DIFF
--- a/server/lib/email/index.ts
+++ b/server/lib/email/index.ts
@@ -1,11 +1,15 @@
 import Email from 'email-templates';
 import nodemailer from 'nodemailer';
-import { NotificationAgentEmail } from '../settings';
+import { URL } from 'url';
+import { getSettings, NotificationAgentEmail } from '../settings';
 import { openpgpEncrypt } from './openpgpEncrypt';
 
 class PreparedEmail extends Email {
   public constructor(settings: NotificationAgentEmail, pgpKey?: string) {
+    const { applicationUrl } = getSettings().main;
+
     const transport = nodemailer.createTransport({
+      name: applicationUrl ? new URL(applicationUrl).hostname : undefined,
       host: settings.options.smtpHost,
       port: settings.options.smtpPort,
       secure: settings.options.secure,


### PR DESCRIPTION
#### Description

Parses the hostname from the `Application URL` setting and explicitly sets that value as the Nodemailer SMTP transport `name` option.

Default Nodemailer behavior is unchanged when `Application URL` is not set.

More info: https://nodemailer.com/smtp/#connection-options

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #1515