### PR TITLE
fix(css): fix cog icon size on media detail pages

### DIFF
--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -445,7 +445,7 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
               className="ml-2 first:ml-0"
               onClick={() => setShowManager(true)}
             >
-              <CogIcon className="w-5" />
+              <CogIcon />
             </Button>
           )}
         </div>

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -101,7 +101,7 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                   onClick={() => updateRequest('approve')}
                   disabled={isUpdating}
                 >
-                  <CheckIcon />
+                  <CheckIcon className="icon-sm" />
                 </Button>
                 <Button
                   buttonType="danger"
@@ -116,7 +116,7 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                   onClick={() => setShowEditModal(true)}
                   disabled={isUpdating}
                 >
-                  <PencilIcon />
+                  <PencilIcon className="icon-sm" />
                 </Button>
               </>
             )}
@@ -126,7 +126,7 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                 onClick={() => deleteRequest()}
                 disabled={isUpdating}
               >
-                <TrashIcon />
+                <TrashIcon className="icon-sm" />
               </Button>
             )}
           </div>

--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -329,7 +329,7 @@ const SettingsLogs: React.FC = () => {
                         onClick={() => setActiveLog(row)}
                         className="mr-2"
                       >
-                        <DocumentSearchIcon />
+                        <DocumentSearchIcon className="icon-md" />
                       </Button>
                     )}
                     <Button
@@ -337,7 +337,7 @@ const SettingsLogs: React.FC = () => {
                       buttonSize="sm"
                       onClick={() => copyLogString(row)}
                     >
-                      <ClipboardCopyIcon />
+                      <ClipboardCopyIcon className="icon-md" />
                     </Button>
                   </Table.TD>
                 </tr>

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -478,7 +478,7 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
               className="ml-2 first:ml-0"
               onClick={() => setShowManager(true)}
             >
-              <CogIcon className="w-5" />
+              <CogIcon />
             </Button>
           )}
         </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -295,12 +295,8 @@ button.input-action svg,
   @apply w-5 h-5 mr-2 last:mr-0;
 }
 
-.button-md svg {
-  @apply last:w-4 last:h-4;
-}
-
 .button-sm svg {
-  @apply w-4 h-4 mr-1.5 last:w-5 last:h-5 last:mr-0;
+  @apply w-4 h-4 mr-1.5 last:mr-0;
 }
 
 .modal-icon {
@@ -309,6 +305,14 @@ button.input-action svg,
 
 .modal-icon svg {
   @apply w-6 h-6;
+}
+
+svg.icon-md {
+  @apply w-5 h-5;
+}
+
+svg.icon-sm {
+  @apply w-4 h-4;
 }
 
 .protocol {


### PR DESCRIPTION
#### Description

Removes button icon styling using the `last:` variant in favor of new `icon-md` and `icon-sm` classes, as not all buttons conformed to same pattern.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A