### PR TITLE
fix: correctly fall back to English name in LanguageSelector

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -14,6 +14,7 @@ export interface Library {
 export interface Region {
   iso_3166_1: string;
   english_name: string;
+  name?: string;
 }
 
 export interface Language {

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -58,12 +58,9 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
     return sortBy(languages, 'name');
   }, [intl, languages]);
 
-  function languageName(langCode: string): string {
-    return (
-      sortedLanguages?.find((language) => language.iso_639_1 === langCode)
-        ?.name ?? langCode
-    );
-  }
+  const languageName = (languageCode: string) =>
+    sortedLanguages?.find((language) => language.iso_639_1 === languageCode)
+      ?.name ?? languageCode;
 
   const options: OptionType[] =
     sortedLanguages?.map((language) => ({

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -2,6 +2,7 @@ import { Listbox, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/solid';
 import { hasFlag } from 'country-flag-icons';
 import 'country-flag-icons/3x2/flags.css';
+import { sortBy } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import useSWR from 'swr';
@@ -39,32 +40,24 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
     []
   );
 
-  const sortedRegions = useMemo(
-    () =>
-      regions?.sort((region1, region2) => {
-        const region1Name =
-          intl.formatDisplayName(region1.iso_3166_1, {
-            type: 'region',
-            fallback: 'none',
-          }) ?? region1.english_name;
-        const region2Name =
-          intl.formatDisplayName(region2.iso_3166_1, {
-            type: 'region',
-            fallback: 'none',
-          }) ?? region2.english_name;
+  const sortedRegions = useMemo(() => {
+    regions?.forEach((region) => {
+      region.name =
+        intl.formatDisplayName(region.iso_3166_1, {
+          type: 'region',
+          fallback: 'none',
+        }) ?? region.english_name;
+    });
 
-        return region1Name === region2Name
-          ? 0
-          : region1Name > region2Name
-          ? 1
-          : -1;
-      }),
-    [intl, regions]
-  );
+    return sortBy(regions, 'name');
+  }, [intl, regions]);
 
-  const defaultRegionNameFallback =
-    regions?.find((region) => region.iso_3166_1 === currentSettings.region)
-      ?.english_name ?? currentSettings.region;
+  function regionName(regionCode: string): string {
+    return (
+      sortedRegions?.find((region) => region.iso_3166_1 === regionCode)?.name ??
+      regionCode
+    );
+  }
 
   useEffect(() => {
     if (regions && value) {
@@ -110,17 +103,11 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
                   )}
                   <span className="block truncate">
                     {selectedRegion && selectedRegion.iso_3166_1 !== 'all'
-                      ? intl.formatDisplayName(selectedRegion.iso_3166_1, {
-                          type: 'region',
-                          fallback: 'none',
-                        }) ?? selectedRegion.english_name
+                      ? regionName(selectedRegion.iso_3166_1)
                       : isUserSetting && selectedRegion?.iso_3166_1 !== 'all'
                       ? intl.formatMessage(messages.regionServerDefault, {
                           region: currentSettings.region
-                            ? intl.formatDisplayName(currentSettings.region, {
-                                type: 'region',
-                                fallback: 'none',
-                              }) ?? defaultRegionNameFallback
+                            ? regionName(currentSettings.region)
                             : intl.formatMessage(messages.regionDefault),
                         })
                       : intl.formatMessage(messages.regionDefault)}
@@ -168,13 +155,7 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
                           >
                             {intl.formatMessage(messages.regionServerDefault, {
                               region: currentSettings.region
-                                ? intl.formatDisplayName(
-                                    currentSettings.region,
-                                    {
-                                      type: 'region',
-                                      fallback: 'none',
-                                    }
-                                  ) ?? defaultRegionNameFallback
+                                ? regionName(currentSettings.region)
                                 : intl.formatMessage(messages.regionDefault),
                             })}
                           </span>
@@ -241,10 +222,7 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
                               selected ? 'font-semibold' : 'font-normal'
                             } block truncate`}
                           >
-                            {intl.formatDisplayName(region.iso_3166_1, {
-                              type: 'region',
-                              fallback: 'none',
-                            }) ?? region.english_name}
+                            {regionName(region.iso_3166_1)}
                           </span>
                           {selected && (
                             <span

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -52,12 +52,9 @@ const RegionSelector: React.FC<RegionSelectorProps> = ({
     return sortBy(regions, 'name');
   }, [intl, regions]);
 
-  function regionName(regionCode: string): string {
-    return (
-      sortedRegions?.find((region) => region.iso_3166_1 === regionCode)?.name ??
-      regionCode
-    );
-  }
+  const regionName = (regionCode: string) =>
+    sortedRegions?.find((region) => region.iso_3166_1 === regionCode)?.name ??
+    regionCode;
 
   useEffect(() => {
     if (regions && value) {

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -1,12 +1,12 @@
 import { RefreshIcon } from '@heroicons/react/solid';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR, { mutate } from 'swr';
 import * as Yup from 'yup';
-import type { Language, MainSettings } from '../../../server/lib/settings';
+import type { MainSettings } from '../../../server/lib/settings';
 import { Permission, useUser } from '../../hooks/useUser';
 import globalMessages from '../../i18n/globalMessages';
 import Badge from '../Common/Badge';
@@ -58,9 +58,7 @@ const SettingsMain: React.FC = () => {
   const { data, error, revalidate } = useSWR<MainSettings>(
     '/api/v1/settings/main'
   );
-  const { data: languages, error: languagesError } = useSWR<Language[]>(
-    '/api/v1/languages'
-  );
+
   const MainSettingsSchema = Yup.object().shape({
     applicationTitle: Yup.string().required(
       intl.formatMessage(messages.validationApplicationTitle)
@@ -96,26 +94,7 @@ const SettingsMain: React.FC = () => {
     }
   };
 
-  const sortedLanguages = useMemo(
-    () =>
-      languages?.sort((lang1, lang2) => {
-        const lang1Name =
-          intl.formatDisplayName(lang1.iso_639_1, {
-            type: 'language',
-            fallback: 'none',
-          }) ?? lang1.english_name;
-        const lang2Name =
-          intl.formatDisplayName(lang2.iso_639_1, {
-            type: 'language',
-            fallback: 'none',
-          }) ?? lang2.english_name;
-
-        return lang1Name === lang2Name ? 0 : lang1Name > lang2Name ? 1 : -1;
-      }),
-    [intl, languages]
-  );
-
-  if (!data && !error && !languages && !languagesError) {
+  if (!data && !error) {
     return <LoadingSpinner />;
   }
 
@@ -316,7 +295,6 @@ const SettingsMain: React.FC = () => {
                   <div className="form-input">
                     <div className="form-input-field">
                       <LanguageSelector
-                        languages={sortedLanguages ?? []}
                         setFieldValue={setFieldValue}
                         value={values.originalLanguage}
                       />

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -1,12 +1,11 @@
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import { useRouter } from 'next/router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
 import { UserSettingsGeneralResponse } from '../../../../../server/interfaces/api/userSettingsInterfaces';
-import { Language } from '../../../../../server/lib/settings';
 import {
   availableLanguages,
   AvailableLocales,
@@ -72,38 +71,11 @@ const UserGeneralSettings: React.FC = () => {
     );
   }, [data]);
 
-  const { data: languages, error: languagesError } = useSWR<Language[]>(
-    '/api/v1/languages'
-  );
-
-  const sortedLanguages = useMemo(
-    () =>
-      languages?.sort((lang1, lang2) => {
-        const lang1Name =
-          intl.formatDisplayName(lang1.iso_639_1, {
-            type: 'language',
-            fallback: 'none',
-          }) ?? lang1.english_name;
-        const lang2Name =
-          intl.formatDisplayName(lang2.iso_639_1, {
-            type: 'language',
-            fallback: 'none',
-          }) ?? lang2.english_name;
-
-        return lang1Name === lang2Name ? 0 : lang1Name > lang2Name ? 1 : -1;
-      }),
-    [intl, languages]
-  );
-
   if (!data && !error) {
     return <LoadingSpinner />;
   }
 
-  if (!languages && !languagesError) {
-    return <LoadingSpinner />;
-  }
-
-  if (!data || !languages) {
+  if (!data) {
     return <Error statusCode={500} />;
   }
 
@@ -263,7 +235,6 @@ const UserGeneralSettings: React.FC = () => {
                 <div className="form-input">
                   <div className="form-input-field">
                     <LanguageSelector
-                      languages={sortedLanguages ?? []}
                       setFieldValue={setFieldValue}
                       serverValue={currentSettings.originalLanguage}
                       value={values.originalLanguage}


### PR DESCRIPTION
#### Description

When multiple languages are selected for the `Discover Language` server setting, the fallback logic does not use the individual language code to determine the TMDb English name, but the entire `|`-delimited string (e.g., `en|zh|ko`).

In addition to fixing that bug, this PR also refactors sorting and name fallback logic for both the `LanguageSelector` and `RegionSelector`, to use `lodash` `sortBy` and remove duplicated code for `intl.formatDisplayName` & TMDb `english_name` fallbacks.

#### Screenshot (if UI-related)

- Before:
  ![Screenshot](https://user-images.githubusercontent.com/52870424/116581524-68d81900-a8e2-11eb-900e-0bd78ae6a30f.png)

- After:
  ![Screenshot](https://user-images.githubusercontent.com/52870424/116581570-755c7180-a8e2-11eb-979a-10964d3d6f31.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A