### PR TITLE
fix(ui): add missing margins on button SVGs on Plex Settings page

### DIFF
--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -530,9 +530,11 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
             className={isSyncing ? 'animate-spin' : ''}
             style={{ animationDirection: 'reverse' }}
           />
-          {isSyncing
-            ? intl.formatMessage(messages.scanning)
-            : intl.formatMessage(messages.scan)}
+          <span>
+            {isSyncing
+              ? intl.formatMessage(messages.scanning)
+              : intl.formatMessage(messages.scan)}
+          </span>
         </Button>
         <ul className="grid grid-cols-1 gap-5 mt-6 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {data?.libraries.map((library) => (
@@ -601,17 +603,15 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
               </>
             )}
             <div className="flex-1 text-right">
-              {!dataSync?.running && (
+              {!dataSync?.running ? (
                 <Button buttonType="warning" onClick={() => startScan()}>
                   <SearchIcon />
-                  {intl.formatMessage(messages.startscan)}
+                  <span>{intl.formatMessage(messages.startscan)}</span>
                 </Button>
-              )}
-
-              {dataSync?.running && (
+              ) : (
                 <Button buttonType="danger" onClick={() => cancelScan()}>
                   <XIcon />
-                  {intl.formatMessage(messages.cancelscan)}
+                  <span>{intl.formatMessage(messages.cancelscan)}</span>
                 </Button>
               )}
             </div>


### PR DESCRIPTION
#### Description

Button text needs to be wrapped in a `span` element in order for the SVG icon to not be the "last" element.

#### Screenshot (if UI-related)

- Before:
  ![image](https://user-images.githubusercontent.com/52870424/116643335-d6199780-a93e-11eb-93cf-f2695ee6e50f.png)

- After:
  ![image](https://user-images.githubusercontent.com/52870424/116643359-e762a400-a93e-11eb-8cee-923d00c6a49f.png)


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A