### PR TITLE
build(docker): refactor Dockerfile to enable caching of node_modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install GNU tar
+        run: apk add --no-cache tar
       - name: Use Next.js cache
-        uses: actions/cache@v2.1.0
+        uses: actions/cache@v2.1.5
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install GNU tar
-        run: apk add --no-cache tar
-      - name: Use Next.js cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}
       - name: Install dependencies
         env:
           HUSKY_SKIP_INSTALL: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
             ghcr.io/sct/overseerr:develop
             ghcr.io/sct/overseerr:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       - # Temporary fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,13 +19,6 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -49,12 +42,3 @@ jobs:
           tags: |
             sctx/overseerr:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/sct/overseerr:${{ steps.get_version.outputs.VERSION }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      - # Temporary fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install GNU tar
+        run: apk add --no-cache tar
       - name: Use Next.js cache
-        uses: actions/cache@v2.1.0
+        uses: actions/cache@v2.1.5
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install GNU tar
-        run: apk add --no-cache tar
-      - name: Use Next.js cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}
       - name: Install dependencies
         env:
           HUSKY_SKIP_INSTALL: 1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -24,8 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache Next.js build
-        uses: actions/cache@v2.1.0
+      - name: Install GNU tar
+        run: apk add --no-cache tar
+      - name: Use Next.js cache
+        uses: actions/cache@v2.1.5
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -24,13 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install GNU tar
-        run: apk add --no-cache tar
-      - name: Use Next.js cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}
       - name: Install dependencies
         env:
           HUSKY_SKIP_INSTALL: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM node:14.16-alpine AS BUILD_IMAGE
 
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --network-timeout 1000000
+
+COPY . ./
+
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
-
-ARG COMMIT_TAG
-ENV COMMIT_TAG=${COMMIT_TAG}
-
-COPY . /app
-WORKDIR /app
 
 RUN \
   case "${TARGETPLATFORM}" in \
@@ -15,14 +16,15 @@ RUN \
     'linux/arm/v7') apk add --no-cache python make g++ ;; \
   esac
 
-RUN yarn --frozen-lockfile --network-timeout 1000000 && \
-  yarn build
+ARG COMMIT_TAG
+ENV COMMIT_TAG=${COMMIT_TAG}
+
+RUN yarn build
 
 # remove development dependencies
 RUN yarn install --production --ignore-scripts --prefer-offline
 
-RUN rm -rf src && \
-  rm -rf server
+RUN rm -rf src server
 
 RUN touch config/DOCKER
 
@@ -31,11 +33,12 @@ RUN echo "{\"commitTag\": \"${COMMIT_TAG}\"}" > committag.json
 
 FROM node:14.16-alpine
 
+WORKDIR /app
+
 RUN apk add --no-cache tzdata tini
 
 # copy from build image
-COPY --from=BUILD_IMAGE /app /app
-WORKDIR /app
+COPY --from=BUILD_IMAGE /app ./
 
 ENTRYPOINT [ "/sbin/tini", "--" ]
 CMD [ "yarn", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,6 @@ FROM node:14.16-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --network-timeout 1000000
-
-COPY . ./
-
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 
@@ -15,6 +10,11 @@ RUN \
     'linux/arm64') apk add --no-cache python make g++ ;; \
     'linux/arm/v7') apk add --no-cache python make g++ ;; \
   esac
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --network-timeout 1000000
+
+COPY . ./
 
 ARG COMMIT_TAG
 ENV COMMIT_TAG=${COMMIT_TAG}


### PR DESCRIPTION
#### Description

Refactors the `Dockerfile` to enable caching of `node_modules`, by copying `package.json` & `yarn.lock` first and doing the initial `yarn install` before copying in the remainder of the source files and building.

During local testing with `buildx`, this resulted in a 45% reduction in total build time 👀  (See screenshots below!)

Also:
- Removed Next.js caching as it requires GNU `tar` and it isn't worth it to install additional packages
- Removed `actions/cache` from preview build workflow.

#### Screenshot (if UI-related)

- **Initial build:**
  ![image](https://user-images.githubusercontent.com/52870424/116795534-c1a2df80-aaa3-11eb-817f-9556087635a3.png)

- **Second build (with different `COMMIT_TAG` and no changes to `package.json` or `yarn.lock`):**
  ![image](https://user-images.githubusercontent.com/52870424/116795542-cebfce80-aaa3-11eb-8fbc-c136c2b28355.png)

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A