### PR TITLE
fix(webpush): only prompt user to allow notifications if enabled in user settings

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -81,10 +81,16 @@ router.get('/status/appdata', (_req, res) => {
 });
 
 router.use('/user', isAuthenticated(), user);
-router.get('/settings/public', async (_req, res) => {
+router.get('/settings/public', async (req, res) => {
   const settings = getSettings();
 
-  return res.status(200).json(settings.fullPublicSettings);
+  if (!req.user?.settings?.notificationTypes.webpush) {
+    return res
+      .status(200)
+      .json({ ...settings.fullPublicSettings, enablePushRegistration: false });
+  } else {
+    return res.status(200).json(settings.fullPublicSettings);
+  }
 });
 router.use(
   '/settings',

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -3,7 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import globalMessages from '../../../../i18n/globalMessages';
 import Button from '../../../Common/Button';
 import LoadingSpinner from '../../../Common/LoadingSpinner';
@@ -44,6 +44,7 @@ const NotificationsWebPush: React.FC = () => {
               types: values.types,
               options: {},
             });
+            mutate('/api/v1/settings/public');
             addToast(intl.formatMessage(messages.webpushsettingssaved), {
               appearance: 'success',
               autoDismiss: true,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import { UserSettingsNotificationsResponse } from '../../../../../server/interfaces/api/userSettingsInterfaces';
 import { useUser } from '../../../../hooks/useUser';
 import globalMessages from '../../../../i18n/globalMessages';
@@ -48,6 +48,7 @@ const UserWebPushSettings: React.FC = () => {
               webpush: values.enableWebPush ? ALL_NOTIFICATIONS : 0,
             },
           });
+          mutate('/api/v1/settings/public');
           addToast(intl.formatMessage(messages.webpushsettingssaved), {
             appearance: 'success',
             autoDismiss: true,


### PR DESCRIPTION
#### Description

Users who opt out of receiving web push notifications should not be prompted to allow notifications in their browser.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A