### PR TITLE
build(deps): bump openpgp from 5.0.0-1 to 5.0.0-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node-cache": "^5.1.2",
     "node-schedule": "^2.0.0",
     "nodemailer": "^6.6.0",
-    "openpgp": "^5.0.0-1",
+    "openpgp": "^5.0.0-2",
     "plex-api": "^5.3.1",
     "pug": "^3.0.2",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10114,10 +10114,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-openpgp@^5.0.0-1:
-  version "5.0.0-1"
-  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-5.0.0-1.tgz#28456d930895483770f099e373045e3ce9dbf9f9"
-  integrity sha512-yfmRStdmOQPZbNbvwyQrqjLOTGW4QO0/aok/Vt08Zhf4UB9w0tGA5c6zBxDefxq+SmXlqEsmdNu+AtYx5G8D6A==
+openpgp@^5.0.0-2:
+  version "5.0.0-2"
+  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-5.0.0-2.tgz#da54385eb9298c259bc6aa76ab556532298897d4"
+  integrity sha512-es+5A50Y+4JbtV+eugLPW9v/UkUIOufeOUyTcjbG8SMILNaLY9nEwUSJKDjQOadY+16w7Uqt0FDQ3Z1Vq7/F9g==
   dependencies:
     asn1.js "^5.0.0"
 


### PR DESCRIPTION
#### Description

Resolves build failure in Dependabot PR #1517 from breaking changes in `openpgp` 🐱

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A