### PR TITLE
fix(ui): default to text input type for SensitiveInputs

### DIFF
--- a/src/components/Common/SensitiveInput/index.tsx
+++ b/src/components/Common/SensitiveInput/index.tsx
@@ -34,7 +34,7 @@ const SensitiveInput: React.FC<SensitiveInputProps> = ({
           isHidden
             ? 'password'
             : props.type !== 'password'
-            ? props.type
+            ? props.type ?? 'text'
             : 'text'
         }
       />


### PR DESCRIPTION
#### Description

Fixes input type being undefined (see screenshots below).  I accidentally introduced this bug in #1563 🙈

#### Screenshot (if UI-related)

**Before:**
![image](https://user-images.githubusercontent.com/52870424/117025278-c5637b80-acc8-11eb-85a1-c5145124b2dd.png)

**After:**
![image](https://user-images.githubusercontent.com/52870424/117025395-df9d5980-acc8-11eb-988b-0a5ee7915edf.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A