### PR TITLE
fix: remove requestedBy user param from existing movie request check

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -256,7 +256,6 @@ requestRoutes.post('/', async (req, res, next) => {
           media: {
             tmdbId: tmdbMedia.id,
           },
-          requestedBy: req.user,
           is4k: req.body.is4k,
         },
       });
@@ -265,6 +264,7 @@ requestRoutes.post('/', async (req, res, next) => {
         logger.warn('Duplicate request for media blocked', {
           tmdbId: tmdbMedia.id,
           mediaType: req.body.mediaType,
+          is4k: req.body.is4k,
         });
         return next({
           status: 409,


### PR DESCRIPTION
#### Description

When checking for an existing movie request, we shouldn't filter out requests made by other users, since there can be only one "regular" request and one 4K request for any given movie.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A