### PR TITLE
feat(webpush): add warning to web push settings re: HTTPS requirement

### DIFF
--- a/server/routes/settings/notifications.ts
+++ b/server/routes/settings/notifications.ts
@@ -259,12 +259,10 @@ notificationRoutes.post('/email/test', async (req, res, next) => {
   }
 });
 
-notificationRoutes.get('/webpush', (req, res) => {
+notificationRoutes.get('/webpush', (_req, res) => {
   const settings = getSettings();
 
-  res
-    .status(200)
-    .json({ ...settings.notifications.agents.webpush, https: req.secure });
+  res.status(200).json(settings.notifications.agents.webpush);
 });
 
 notificationRoutes.post('/webpush', (req, res) => {
@@ -273,9 +271,7 @@ notificationRoutes.post('/webpush', (req, res) => {
   settings.notifications.agents.webpush = req.body;
   settings.save();
 
-  res
-    .status(200)
-    .json({ ...settings.notifications.agents.webpush, https: req.secure });
+  res.status(200).json(settings.notifications.agents.webpush);
 });
 
 notificationRoutes.post('/webpush/test', async (req, res, next) => {

--- a/server/routes/settings/notifications.ts
+++ b/server/routes/settings/notifications.ts
@@ -259,10 +259,12 @@ notificationRoutes.post('/email/test', async (req, res, next) => {
   }
 });
 
-notificationRoutes.get('/webpush', (_req, res) => {
+notificationRoutes.get('/webpush', (req, res) => {
   const settings = getSettings();
 
-  res.status(200).json(settings.notifications.agents.webpush);
+  res
+    .status(200)
+    .json({ ...settings.notifications.agents.webpush, https: req.secure });
 });
 
 notificationRoutes.post('/webpush', (req, res) => {
@@ -271,7 +273,9 @@ notificationRoutes.post('/webpush', (req, res) => {
   settings.notifications.agents.webpush = req.body;
   settings.save();
 
-  res.status(200).json(settings.notifications.agents.webpush);
+  res
+    .status(200)
+    .json({ ...settings.notifications.agents.webpush, https: req.secure });
 });
 
 notificationRoutes.post('/webpush/test', async (req, res, next) => {

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -5,6 +5,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR, { mutate } from 'swr';
 import globalMessages from '../../../../i18n/globalMessages';
+import Alert from '../../../Common/Alert';
 import Button from '../../../Common/Button';
 import LoadingSpinner from '../../../Common/LoadingSpinner';
 import NotificationTypeSelector from '../../../NotificationTypeSelector';
@@ -16,6 +17,8 @@ const messages = defineMessages({
   toastWebPushTestSending: 'Sending web push test notification…',
   toastWebPushTestSuccess: 'Web push test notification sent!',
   toastWebPushTestFailed: 'Web push test notification failed to send.',
+  httpsRequirement:
+    'In order to receive web push notifications, Overseerr must be served over HTTPS.',
 });
 
 const NotificationsWebPush: React.FC = () => {
@@ -32,6 +35,12 @@ const NotificationsWebPush: React.FC = () => {
 
   return (
     <>
+      {!data?.https && (
+        <Alert
+          title={intl.formatMessage(messages.httpsRequirement)}
+          type="warning"
+        />
+      )}
       <Formik
         initialValues={{
           enabled: data.enabled,

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR, { mutate } from 'swr';
@@ -25,9 +25,14 @@ const NotificationsWebPush: React.FC = () => {
   const intl = useIntl();
   const { addToast, removeToast } = useToasts();
   const [isTesting, setIsTesting] = useState(false);
+  const [isHttps, setIsHttps] = useState(false);
   const { data, error, revalidate } = useSWR(
     '/api/v1/settings/notifications/webpush'
   );
+
+  useEffect(() => {
+    setIsHttps(window.location.protocol.startsWith('https'));
+  }, []);
 
   if (!data && !error) {
     return <LoadingSpinner />;
@@ -35,7 +40,7 @@ const NotificationsWebPush: React.FC = () => {
 
   return (
     <>
-      {!window.location.protocol.startsWith('https') && (
+      {!isHttps && (
         <Alert
           title={intl.formatMessage(messages.httpsRequirement)}
           type="warning"

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -35,7 +35,7 @@ const NotificationsWebPush: React.FC = () => {
 
   return (
     <>
-      {!data?.https && (
+      {!window.location.protocol.startsWith('https') && (
         <Alert
           title={intl.formatMessage(messages.httpsRequirement)}
           type="warning"

--- a/src/components/Settings/SettingsNotifications.tsx
+++ b/src/components/Settings/SettingsNotifications.tsx
@@ -38,6 +38,17 @@ const SettingsNotifications: React.FC = ({ children }) => {
       regex: /^\/settings\/notifications\/email/,
     },
     {
+      text: intl.formatMessage(messages.webpush),
+      content: (
+        <span className="flex items-center">
+          <CloudIcon className="h-4 mr-2" />
+          {intl.formatMessage(messages.webpush)}
+        </span>
+      ),
+      route: '/settings/notifications/webpush',
+      regex: /^\/settings\/notifications\/webpush/,
+    },
+    {
       text: 'Discord',
       content: (
         <span className="flex items-center">
@@ -102,17 +113,6 @@ const SettingsNotifications: React.FC = ({ children }) => {
       ),
       route: '/settings/notifications/telegram',
       regex: /^\/settings\/notifications\/telegram/,
-    },
-    {
-      text: intl.formatMessage(messages.webpush),
-      content: (
-        <span className="flex items-center">
-          <CloudIcon className="h-4 mr-2" />
-          {intl.formatMessage(messages.webpush)}
-        </span>
-      ),
-      route: '/settings/notifications/webpush',
-      regex: /^\/settings\/notifications\/webpush/,
     },
     {
       text: intl.formatMessage(messages.webhook),

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -290,6 +290,7 @@
   "components.Settings.Notifications.NotificationsSlack.webhookUrl": "Webhook URL",
   "components.Settings.Notifications.NotificationsSlack.webhookUrlTip": "Create an <WebhookLink>Incoming Webhook</WebhookLink> integration",
   "components.Settings.Notifications.NotificationsWebPush.agentenabled": "Enable Agent",
+  "components.Settings.Notifications.NotificationsWebPush.httpsRequirement": "In order to receive web push notifications, Overseerr must be served over HTTPS.",
   "components.Settings.Notifications.NotificationsWebPush.toastWebPushTestFailed": "Web push test notification failed to send.",
   "components.Settings.Notifications.NotificationsWebPush.toastWebPushTestSending": "Sending web push test notification…",
   "components.Settings.Notifications.NotificationsWebPush.toastWebPushTestSuccess": "Web push test notification sent!",


### PR DESCRIPTION
#### Description

Web push notifications only work when Overseerr is being served over HTTPS, so we should warn users about the requirement.

This PR adds a warning to the web push settings page that only appears when accessed over HTTP.

#### Screenshot (if UI-related)

**Accessed via HTTP:**
![image](https://user-images.githubusercontent.com/52870424/117511024-14c0da80-af5b-11eb-94cb-37efe3cb9600.png)

**Accessed via HTTPS:**
![image](https://user-images.githubusercontent.com/52870424/117511102-31f5a900-af5b-11eb-8da6-7931dfa6a304.png)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A