### PR TITLE
fix(ui): hide Plex alert after setup & add warning to create user modal when local sign-in is disabled

### DIFF
--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -262,25 +262,27 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
         <p className="description">
           {intl.formatMessage(messages.plexsettingsDescription)}
         </p>
-        <div className="section">
-          <Alert
-            title={intl.formatMessage(messages.settingUpPlexDescription, {
-              RegisterPlexTVLink: function RegisterPlexTVLink(msg) {
-                return (
-                  <a
-                    href="https://plex.tv"
-                    className="text-white transition duration-300 hover:underline"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {msg}
-                  </a>
-                );
-              },
-            })}
-            type="info"
-          />
-        </div>
+        {!!onComplete && (
+          <div className="section">
+            <Alert
+              title={intl.formatMessage(messages.settingUpPlexDescription, {
+                RegisterPlexTVLink: function RegisterPlexTVLink(msg) {
+                  return (
+                    <a
+                      href="https://plex.tv"
+                      className="text-white transition duration-300 hover:underline"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {msg}
+                    </a>
+                  );
+                },
+              })}
+              type="info"
+            />
+          </div>
+        )}
       </div>
       <Formik
         initialValues={{

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -17,6 +17,7 @@ import * as Yup from 'yup';
 import type { UserResultsResponse } from '../../../server/interfaces/api/userInterfaces';
 import { UserSettingsNotificationsResponse } from '../../../server/interfaces/api/userSettingsInterfaces';
 import { hasPermission } from '../../../server/lib/permissions';
+import useSettings from '../../hooks/useSettings';
 import { useUpdateQueryParams } from '../../hooks/useUpdateQueryParams';
 import { Permission, User, UserType, useUser } from '../../hooks/useUser';
 import globalMessages from '../../i18n/globalMessages';
@@ -77,6 +78,8 @@ const messages = defineMessages({
   sortUpdated: 'Last Updated',
   sortDisplayName: 'Display Name',
   sortRequests: 'Request Count',
+  localLoginDisabled:
+    'The <strong>Enable Local Sign-In</strong> setting is currently disabled.',
 });
 
 type Sort = 'created' | 'updated' | 'requests' | 'displayname';
@@ -84,6 +87,7 @@ type Sort = 'created' | 'updated' | 'requests' | 'displayname';
 const UserList: React.FC = () => {
   const intl = useIntl();
   const router = useRouter();
+  const settings = useSettings();
   const { addToast } = useToasts();
   const { user: currentUser, hasPermission: currentHasPermission } = useUser();
   const [currentSort, setCurrentSort] = useState<Sort>('created');
@@ -347,6 +351,20 @@ const UserList: React.FC = () => {
                 okButtonType="primary"
                 onCancel={() => setCreateModal({ isOpen: false })}
               >
+                {!settings.currentSettings.localLogin && (
+                  <Alert
+                    title={intl.formatMessage(messages.localLoginDisabled, {
+                      strong: function strong(msg) {
+                        return (
+                          <strong className="font-semibold text-yellow-100">
+                            {msg}
+                          </strong>
+                        );
+                      },
+                    })}
+                    type="warning"
+                  />
+                )}
                 {!notificationSettings?.emailEnabled && (
                   <Alert
                     title={intl.formatMessage(messages.passwordinfodescription)}

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -701,6 +701,7 @@
   "components.UserList.importfromplex": "Import Users from Plex",
   "components.UserList.importfromplexerror": "Something went wrong while importing users from Plex.",
   "components.UserList.lastupdated": "Last Updated",
+  "components.UserList.localLoginDisabled": "The <strong>Enable Local Sign-In</strong> setting is currently disabled.",
   "components.UserList.localuser": "Local User",
   "components.UserList.nouserstoimport": "No new users to import from Plex.",
   "components.UserList.owner": "Owner",


### PR DESCRIPTION
#### Description

The Plex info alert box isn't really necessary after the initial setup.

And since we've now moved the `Enable Local Sign-In` setting to the `Settings > Users` (it used to be in `Settings > General`), I think it's worth having an alert in the `Create Local User` modal.

#### Screenshot (if UI-related)

![image](https://user-images.githubusercontent.com/52870424/117518657-a8e86d00-af6e-11eb-85e6-90e8bde0c7c6.png)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A