### PR TITLE
fix(ui): apply pointer cursor style for clickable status badges

### DIFF
--- a/src/components/StatusBadge/index.tsx
+++ b/src/components/StatusBadge/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { MediaStatus } from '../../../server/constants/media';
-import Badge from '../Common/Badge';
 import { defineMessages, useIntl } from 'react-intl';
-import globalMessages from '../../i18n/globalMessages';
+import { MediaStatus } from '../../../server/constants/media';
 import Spinner from '../../assets/spinner.svg';
+import globalMessages from '../../i18n/globalMessages';
+import Badge from '../Common/Badge';
 
 const messages = defineMessages({
   status4k: '4K {status}',
@@ -34,7 +34,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({
             <a href={plexUrl4k} target="_blank" rel="noopener noreferrer">
               <Badge
                 badgeType="success"
-                className="transition cursor-pointer hover:bg-green-400"
+                className="transition !cursor-pointer hover:bg-green-400"
               >
                 {intl.formatMessage(messages.status4k, {
                   status: intl.formatMessage(globalMessages.available),
@@ -57,7 +57,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({
             <a href={plexUrl4k} target="_blank" rel="noopener noreferrer">
               <Badge
                 badgeType="success"
-                className="transition cursor-pointer hover:bg-green-400"
+                className="transition !cursor-pointer hover:bg-green-400"
               >
                 {intl.formatMessage(messages.status4k, {
                   status: intl.formatMessage(globalMessages.partiallyavailable),
@@ -109,7 +109,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({
           <a href={plexUrl} target="_blank" rel="noopener noreferrer">
             <Badge
               badgeType="success"
-              className="transition cursor-pointer hover:bg-green-400"
+              className="transition !cursor-pointer hover:bg-green-400"
             >
               <div className="flex items-center">
                 <span>{intl.formatMessage(globalMessages.available)}</span>
@@ -134,7 +134,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({
           <a href={plexUrl} target="_blank" rel="noopener noreferrer">
             <Badge
               badgeType="success"
-              className="transition cursor-pointer hover:bg-green-400"
+              className="transition !cursor-pointer hover:bg-green-400"
             >
               <div className="flex items-center">
                 <span>


### PR DESCRIPTION
#### Description

"Pointer" cursor style should be applied for status badges that link to Plex, instead of the default cursor style.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A