### PR TITLE
fix(ui): remove delete button from request cards

### DIFF
--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -317,19 +317,6 @@ const RequestCard: React.FC<RequestCardProps> = ({ request, onTitleData }) => {
                   </span>
                 </Button>
               )}
-            {requestData.status !== MediaRequestStatus.PENDING &&
-              hasPermission(Permission.MANAGE_REQUESTS) && (
-                <Button
-                  buttonType="danger"
-                  buttonSize="sm"
-                  onClick={() => deleteRequest()}
-                >
-                  <TrashIcon style={{ marginRight: '0' }} />
-                  <span className="hidden ml-1.5 sm:block">
-                    {intl.formatMessage(globalMessages.delete)}
-                  </span>
-                </Button>
-              )}
             {requestData.status === MediaRequestStatus.PENDING &&
               hasPermission(Permission.MANAGE_REQUESTS) && (
                 <>


### PR DESCRIPTION
#### Description

Removes delete button from request cards to reduce likelihood of accidental deletion of requests.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A