### PR TITLE
fix(locale): properly restore display language upon page refresh

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -11,7 +11,7 @@ export const checkUser: Middleware = async (req, _res, next) => {
 
     let userId = 1; // Work on original administrator account
 
-    // If a User ID is provided, we will act on that users behalf
+    // If a User ID is provided, we will act on that user's behalf
     if (req.header('X-API-User')) {
       userId = Number(req.header('X-API-User'));
     }
@@ -20,6 +20,10 @@ export const checkUser: Middleware = async (req, _res, next) => {
     if (user) {
       req.user = user;
     }
+
+    req.locale = user?.settings?.locale
+      ? user.settings.locale
+      : settings.main.locale;
   } else if (req.session?.userId) {
     const userRepository = getRepository(User);
 
@@ -29,10 +33,13 @@ export const checkUser: Middleware = async (req, _res, next) => {
 
     if (user) {
       req.user = user;
-      req.locale = user.settings?.locale
-        ? user.settings?.locale
-        : settings.main.locale;
     }
+
+    req.locale = user?.settings?.locale
+      ? user.settings.locale
+      : settings.main.locale;
+  } else {
+    req.locale = settings.main.locale;
   }
 
   next();

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -5,6 +5,7 @@ import { getSettings } from '../lib/settings';
 
 export const checkUser: Middleware = async (req, _res, next) => {
   const settings = getSettings();
+  let user: User | undefined;
 
   if (req.header('X-API-Key') === settings.main.apiKey) {
     const userRepository = getRepository(User);
@@ -15,32 +16,23 @@ export const checkUser: Middleware = async (req, _res, next) => {
     if (req.header('X-API-User')) {
       userId = Number(req.header('X-API-User'));
     }
-    const user = await userRepository.findOne({ where: { id: userId } });
 
-    if (user) {
-      req.user = user;
-    }
-
-    req.locale = user?.settings?.locale
-      ? user.settings.locale
-      : settings.main.locale;
+    user = await userRepository.findOne({ where: { id: userId } });
   } else if (req.session?.userId) {
     const userRepository = getRepository(User);
 
-    const user = await userRepository.findOne({
+    user = await userRepository.findOne({
       where: { id: req.session.userId },
     });
-
-    if (user) {
-      req.user = user;
-    }
-
-    req.locale = user?.settings?.locale
-      ? user.settings.locale
-      : settings.main.locale;
-  } else {
-    req.locale = settings.main.locale;
   }
+
+  if (user) {
+    req.user = user;
+  }
+
+  req.locale = user?.settings?.locale
+    ? user.settings.locale
+    : settings.main.locale;
 
   next();
 };

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -3,9 +3,6 @@ import { ArrowLeftIcon, InformationCircleIcon } from '@heroicons/react/solid';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import { AvailableLocale } from '../../context/LanguageContext';
-import useLocale from '../../hooks/useLocale';
-import useSettings from '../../hooks/useSettings';
 import { Permission, useUser } from '../../hooks/useUser';
 import SearchInput from './SearchInput';
 import Sidebar from './Sidebar';
@@ -19,21 +16,9 @@ const messages = defineMessages({
 const Layout: React.FC = ({ children }) => {
   const [isSidebarOpen, setSidebarOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
-  const { user, hasPermission } = useUser();
+  const { hasPermission } = useUser();
   const router = useRouter();
   const intl = useIntl();
-  const { currentSettings } = useSettings();
-  const { setLocale } = useLocale();
-
-  useEffect(() => {
-    if (setLocale) {
-      setLocale(
-        (user?.settings?.locale
-          ? user.settings.locale
-          : currentSettings.locale) as AvailableLocale
-      );
-    }
-  }, [setLocale, currentSettings.locale, user]);
 
   useEffect(() => {
     const updateScrolled = () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -91,6 +91,14 @@ const CoreApp: Omit<NextAppComponentType, 'origGetInitialProps'> = ({
   const [currentLocale, setLocale] = useState<AvailableLocale>(locale);
 
   useEffect(() => {
+    setLocale(
+      (user?.settings?.locale
+        ? user.settings.locale
+        : currentSettings.locale) as AvailableLocale
+    );
+  }, [currentSettings.locale, user?.settings?.locale]);
+
+  useEffect(() => {
     loadLocaleData(currentLocale).then(setMessages);
   }, [currentLocale]);
 


### PR DESCRIPTION
#### Description

Currently, the user's locale setting is being lost upon page refresh.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #1645