### PR TITLE
fix(quotas): do not count already-requested seasons when editing TV request

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -92,7 +92,9 @@ const TvRequestModal: React.FC<RequestModalProps> = ({
   );
 
   const currentlyRemaining =
-    (quota?.tv.remaining ?? 0) - selectedSeasons.length;
+    (quota?.tv.remaining ?? 0) -
+    selectedSeasons.length +
+    (editRequest?.seasons ?? []).length;
 
   const updateRequest = async () => {
     if (!editRequest) {


### PR DESCRIPTION
#### Description

Currently, when editing an existing TV series request, seasons in the existing request are being counted twice.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #1648