### PR TITLE
fix(sensitiveinput): do not capture enter key input

### DIFF
--- a/src/components/Common/SensitiveInput/index.tsx
+++ b/src/components/Common/SensitiveInput/index.tsx
@@ -43,6 +43,7 @@ const SensitiveInput: React.FC<SensitiveInputProps> = ({
           e.preventDefault();
           setHidden(!isHidden);
         }}
+        type="button"
         className="input-action"
       >
         {isHidden ? <EyeOffIcon /> : <EyeIcon />}


### PR DESCRIPTION
#### Description

The hide/unhide button for the `SensitiveInput` component needs to explicitly specify `type="button"` to prevent it from capturing enter key inputs.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #1647