### PR TITLE
fix: correctly display error messages

### DIFF
--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -40,8 +40,8 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
       <div className="text-4xl">
         {statusCode
           ? intl.formatMessage(messages.errormessagewithcode, {
-              statusCode: statusCode,
-              message: getErrorMessage(statusCode),
+              statusCode,
+              error: getErrorMessage(statusCode),
             })
           : getErrorMessage(statusCode)}
       </div>


### PR DESCRIPTION
#### Description

The language string is `'{statusCode} - {error}'`, but `message` is being specified instead of `error`.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A