### PR TITLE
fix(requests): appropriately set modifiedBy user for new requests

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -293,6 +293,7 @@ requestRoutes.post('/', async (req, res, next) => {
         )
           ? MediaRequestStatus.APPROVED
           : MediaRequestStatus.PENDING,
+        modifiedBy: requestUser.id === req.user?.id ? undefined : req.user,
         is4k: req.body.is4k,
         serverId: req.body.serverId,
         profileId: req.body.profileId,

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -293,20 +293,6 @@ requestRoutes.post('/', async (req, res, next) => {
         )
           ? MediaRequestStatus.APPROVED
           : MediaRequestStatus.PENDING,
-        modifiedBy: req.user?.hasPermission(
-          [
-            req.body.is4k
-              ? Permission.AUTO_APPROVE_4K
-              : Permission.AUTO_APPROVE,
-            req.body.is4k
-              ? Permission.AUTO_APPROVE_4K_MOVIE
-              : Permission.AUTO_APPROVE_MOVIE,
-            Permission.MANAGE_REQUESTS,
-          ],
-          { type: 'or' }
-        )
-          ? req.user
-          : undefined,
         is4k: req.body.is4k,
         serverId: req.body.serverId,
         profileId: req.body.profileId,


### PR DESCRIPTION
#### Description

- Do not set `modifiedBy` user for auto-approved requests submitted by a user for themselves
- Set `modifiedBy` user for all requests submitted on behalf of other users

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A