### PR TITLE
fix(sonarr): do not mark media as failed if there is no season data on TVDB

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -416,7 +416,8 @@ class BaseScanner<T> {
                   season.status === MediaStatus.AVAILABLE
               )
             ? MediaStatus.PARTIALLY_AVAILABLE
-            : media.seasons.some(
+            : !seasons.length ||
+              media.seasons.some(
                 (season) => season.status === MediaStatus.PROCESSING
               )
             ? MediaStatus.PROCESSING
@@ -431,7 +432,8 @@ class BaseScanner<T> {
                   season.status4k === MediaStatus.AVAILABLE
               )
             ? MediaStatus.PARTIALLY_AVAILABLE
-            : media.seasons.some(
+            : !seasons.length ||
+              media.seasons.some(
                 (season) => season.status4k === MediaStatus.PROCESSING
               )
             ? MediaStatus.PROCESSING


### PR DESCRIPTION
#### Description

When there is no season data on TVDB, Sonarr will return 0 seasons and the scanner will set the media status to `UNKNOWN` (since there are no seasons with status `PROCESSING`).

This PR adds a check to see if no seasons were passed to `processShow()`.  This should only impact Sonarr scans, since in order for series to exist / be picked up by a Plex scan, they must have at least one episode (and thus at least one season result).

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #1690