### PR TITLE
fix(plex): do not fail to import Plex users when Plex Home has managed users

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -48,7 +48,13 @@ export class User {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column({ unique: true })
+  @Column({
+    unique: true,
+    transformer: {
+      from: (value: string): string => value.toLowerCase(),
+      to: (value: string): string => value.toLowerCase(),
+    },
+  })
   public email: string;
 
   @Column({ nullable: true })

--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -52,7 +52,7 @@ export class User {
   public email: string;
 
   @Column({ nullable: true })
-  public plexUsername: string;
+  public plexUsername?: string;
 
   @Column({ nullable: true })
   public username?: string;
@@ -220,7 +220,7 @@ export class User {
 
   @AfterLoad()
   public setDisplayName(): void {
-    this.displayName = this.username || this.plexUsername;
+    this.displayName = this.username || this.plexUsername || this.email;
   }
 
   public async getQuota(): Promise<QuotaResponse> {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -57,7 +57,10 @@ authRoutes.post('/plex', async (req, res, next) => {
       // Update the user's avatar with their Plex thumbnail, in case it changed
       user.avatar = account.thumb;
       user.email = account.email;
-      user.plexUsername = account.username;
+      user.plexUsername =
+        account.username.toLowerCase() === account.email.toLowerCase()
+          ? ''
+          : account.username;
 
       // In case the user was previously a local account
       if (user.userType === UserType.LOCAL) {
@@ -65,7 +68,10 @@ authRoutes.post('/plex', async (req, res, next) => {
         user.plexId = account.id;
       }
 
-      if (user.username === account.username) {
+      if (
+        user.username === account.username ||
+        (user.username ?? '').toLowerCase() === user.email.toLowerCase()
+      ) {
         user.username = '';
       }
       await userRepository.save(user);
@@ -77,7 +83,10 @@ authRoutes.post('/plex', async (req, res, next) => {
       if (totalUsers === 0) {
         user = new User({
           email: account.email,
-          plexUsername: account.username,
+          plexUsername:
+            account.username.toLowerCase() === account.email.toLowerCase()
+              ? ''
+              : account.username,
           plexId: account.id,
           plexToken: account.authToken,
           permissions: Permission.ADMIN,
@@ -118,7 +127,10 @@ authRoutes.post('/plex', async (req, res, next) => {
         if (await mainPlexTv.checkUserAccess(account.id)) {
           user = new User({
             email: account.email,
-            plexUsername: account.username,
+            plexUsername:
+              account.username.toLowerCase() === account.email.toLowerCase()
+                ? ''
+                : account.username,
             plexId: account.id,
             plexToken: account.authToken,
             permissions: settings.main.defaultPermissions,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -57,10 +57,7 @@ authRoutes.post('/plex', async (req, res, next) => {
       // Update the user's avatar with their Plex thumbnail, in case it changed
       user.avatar = account.thumb;
       user.email = account.email;
-      user.plexUsername =
-        account.username.toLowerCase() === account.email.toLowerCase()
-          ? ''
-          : account.username;
+      user.plexUsername = account.username;
 
       // In case the user was previously a local account
       if (user.userType === UserType.LOCAL) {
@@ -68,12 +65,6 @@ authRoutes.post('/plex', async (req, res, next) => {
         user.plexId = account.id;
       }
 
-      if (
-        user.username === account.username ||
-        (user.username ?? '').toLowerCase() === user.email.toLowerCase()
-      ) {
-        user.username = '';
-      }
       await userRepository.save(user);
     } else {
       // Here we check if it's the first user. If it is, we create the user with no check
@@ -83,10 +74,7 @@ authRoutes.post('/plex', async (req, res, next) => {
       if (totalUsers === 0) {
         user = new User({
           email: account.email,
-          plexUsername:
-            account.username.toLowerCase() === account.email.toLowerCase()
-              ? ''
-              : account.username,
+          plexUsername: account.username,
           plexId: account.id,
           plexToken: account.authToken,
           permissions: Permission.ADMIN,
@@ -127,10 +115,7 @@ authRoutes.post('/plex', async (req, res, next) => {
         if (await mainPlexTv.checkUserAccess(account.id)) {
           user = new User({
             email: account.email,
-            plexUsername:
-              account.username.toLowerCase() === account.email.toLowerCase()
-                ? ''
-                : account.username,
+            plexUsername: account.username,
             plexId: account.id,
             plexToken: account.authToken,
             permissions: settings.main.defaultPermissions,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -43,7 +43,7 @@ authRoutes.post('/plex', async (req, res, next) => {
     let user = await userRepository
       .createQueryBuilder('user')
       .where('user.plexId = :id', { id: account.id })
-      .orWhere('LOWER(user.email) = :email', {
+      .orWhere('user.email = :email', {
         email: account.email.toLowerCase(),
       })
       .getOne();
@@ -174,7 +174,7 @@ authRoutes.post('/local', async (req, res, next) => {
     const user = await userRepository
       .createQueryBuilder('user')
       .select(['user.id', 'user.password'])
-      .where('LOWER(user.email) = :email', { email: body.email.toLowerCase() })
+      .where('user.email = :email', { email: body.email.toLowerCase() })
       .getOne();
 
     const isCorrectCredentials = await user?.passwordMatch(body.password);
@@ -241,7 +241,7 @@ authRoutes.post('/reset-password', async (req, res) => {
 
   const user = await userRepository
     .createQueryBuilder('user')
-    .where('LOWER(user.email) = :email', { email: body.email.toLowerCase() })
+    .where('user.email = :email', { email: body.email.toLowerCase() })
     .getOne();
 
   if (user) {

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -409,31 +409,18 @@ router.post(
             // Update the user's avatar with their Plex thumbnail, in case it changed
             user.avatar = account.thumb;
             user.email = account.email;
-            user.plexUsername =
-              account.username.toLowerCase() === account.email.toLowerCase()
-                ? ''
-                : account.username;
+            user.plexUsername = account.username;
 
             // In case the user was previously a local account
             if (user.userType === UserType.LOCAL) {
               user.userType = UserType.PLEX;
               user.plexId = parseInt(account.id);
-
-              if (
-                user.username === account.username ||
-                (user.username ?? '').toLowerCase() === user.email.toLowerCase()
-              ) {
-                user.username = '';
-              }
             }
             await userRepository.save(user);
           } else {
             if (await mainPlexTv.checkUserAccess(parseInt(account.id))) {
               const newUser = new User({
-                plexUsername:
-                  account.username.toLowerCase() === account.email.toLowerCase()
-                    ? ''
-                    : account.username,
+                plexUsername: account.username,
                 email: account.email,
                 permissions: settings.main.defaultPermissions,
                 plexId: parseInt(account.id),

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -31,7 +31,7 @@ router.get('/', async (req, res, next) => {
         break;
       case 'displayname':
         query = query.orderBy(
-          "(CASE WHEN (user.username IS NULL OR user.username = '') THEN (CASE WHEN (user.plexUsername IS NULL OR user.plexUsername = '') THEN LOWER(user.email) ELSE LOWER(user.plexUsername) END) ELSE LOWER(user.username) END)",
+          "(CASE WHEN (user.username IS NULL OR user.username = '') THEN (CASE WHEN (user.plexUsername IS NULL OR user.plexUsername = '') THEN user.email ELSE LOWER(user.plexUsername) END) ELSE LOWER(user.username) END)",
           'ASC'
         );
         break;
@@ -84,7 +84,7 @@ router.post(
 
       const existingUser = await userRepository
         .createQueryBuilder('user')
-        .where('LOWER(user.email) = :email', {
+        .where('user.email = :email', {
           email: body.email.toLowerCase(),
         })
         .getOne();
@@ -400,7 +400,7 @@ router.post(
           const user = await userRepository
             .createQueryBuilder('user')
             .where('user.plexId = :id', { id: account.id })
-            .orWhere('LOWER(user.email) = :email', {
+            .orWhere('user.email = :email', {
               email: account.email.toLowerCase(),
             })
             .getOne();

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -522,7 +522,8 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                           <span className="block ml-3">
                             {selectedUser.displayName}
                           </span>
-                          {selectedUser.displayName !== selectedUser.email && (
+                          {selectedUser.displayName.toLowerCase() !==
+                            selectedUser.email.toLowerCase() && (
                             <span className="ml-1 text-gray-400 truncate">
                               ({selectedUser.email})
                             </span>
@@ -571,7 +572,8 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                                   <span className="flex-shrink-0 block ml-3">
                                     {user.displayName}
                                   </span>
-                                  {user.displayName !== user.email && (
+                                  {user.displayName.toLowerCase() !==
+                                    user.email.toLowerCase() && (
                                     <span className="ml-1 text-gray-400 truncate">
                                       ({user.email})
                                     </span>

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -523,7 +523,7 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                             {selectedUser.displayName}
                           </span>
                           {selectedUser.displayName.toLowerCase() !==
-                            selectedUser.email.toLowerCase() && (
+                            selectedUser.email && (
                             <span className="ml-1 text-gray-400 truncate">
                               ({selectedUser.email})
                             </span>
@@ -573,7 +573,7 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                                     {user.displayName}
                                   </span>
                                   {user.displayName.toLowerCase() !==
-                                    user.email.toLowerCase() && (
+                                    user.email && (
                                     <span className="ml-1 text-gray-400 truncate">
                                       ({user.email})
                                     </span>

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -522,9 +522,11 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                           <span className="block ml-3">
                             {selectedUser.displayName}
                           </span>
-                          <span className="ml-1 text-gray-400 truncate">
-                            ({selectedUser.email})
-                          </span>
+                          {selectedUser.displayName !== selectedUser.email && (
+                            <span className="ml-1 text-gray-400 truncate">
+                              ({selectedUser.email})
+                            </span>
+                          )}
                         </span>
                         <span className="absolute inset-y-0 right-0 flex items-center pr-2 text-gray-500 pointer-events-none">
                           <ChevronDownIcon className="w-5 h-5" />
@@ -569,9 +571,11 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
                                   <span className="flex-shrink-0 block ml-3">
                                     {user.displayName}
                                   </span>
-                                  <span className="ml-1 text-gray-400 truncate">
-                                    ({user.email})
-                                  </span>
+                                  {user.displayName !== user.email && (
+                                    <span className="ml-1 text-gray-400 truncate">
+                                      ({user.email})
+                                    </span>
+                                  )}
                                 </span>
                                 {selected && (
                                   <span

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -602,7 +602,8 @@ const UserList: React.FC = () => {
                         {user.displayName}
                       </a>
                     </Link>
-                    {user.displayName !== user.email && (
+                    {user.displayName.toLowerCase() !==
+                      user.email.toLowerCase() && (
                       <div className="text-sm leading-5 text-gray-300">
                         {user.email}
                       </div>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -602,8 +602,7 @@ const UserList: React.FC = () => {
                         {user.displayName}
                       </a>
                     </Link>
-                    {user.displayName.toLowerCase() !==
-                      user.email.toLowerCase() && (
+                    {user.displayName.toLowerCase() !== user.email && (
                       <div className="text-sm leading-5 text-gray-300">
                         {user.email}
                       </div>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -602,9 +602,11 @@ const UserList: React.FC = () => {
                         {user.displayName}
                       </a>
                     </Link>
-                    <div className="text-sm leading-5 text-gray-300">
-                      {user.email}
-                    </div>
+                    {user.displayName !== user.email && (
+                      <div className="text-sm leading-5 text-gray-300">
+                        {user.email}
+                      </div>
+                    )}
                   </div>
                 </div>
               </Table.TD>

--- a/src/components/UserProfile/ProfileHeader/index.tsx
+++ b/src/components/UserProfile/ProfileHeader/index.tsx
@@ -65,7 +65,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 {user.displayName}
               </a>
             </Link>
-            {user.email && (
+            {user.displayName !== user.email && (
               <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">
                 ({user.email})
               </span>

--- a/src/components/UserProfile/ProfileHeader/index.tsx
+++ b/src/components/UserProfile/ProfileHeader/index.tsx
@@ -65,11 +65,13 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 {user.displayName}
               </a>
             </Link>
-            {user.displayName !== user.email && (
-              <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">
-                ({user.email})
-              </span>
-            )}
+            {user.displayName !== user.email &&
+              (user.id === loggedInUser?.id ||
+                hasPermission(Permission.MANAGE_USERS)) && (
+                <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">
+                  ({user.email})
+                </span>
+              )}
           </h1>
           <p className="text-sm font-medium text-gray-400">
             {subtextItems.reduce((prev, curr) => (

--- a/src/components/UserProfile/ProfileHeader/index.tsx
+++ b/src/components/UserProfile/ProfileHeader/index.tsx
@@ -65,7 +65,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 {user.displayName}
               </a>
             </Link>
-            {user.displayName !== user.email &&
+            {user.displayName.toLowerCase() !== user.email.toLowerCase() &&
               (user.id === loggedInUser?.id ||
                 hasPermission(Permission.MANAGE_USERS)) && (
                 <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">

--- a/src/components/UserProfile/ProfileHeader/index.tsx
+++ b/src/components/UserProfile/ProfileHeader/index.tsx
@@ -65,9 +65,8 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 {user.displayName}
               </a>
             </Link>
-            {user.displayName.toLowerCase() !== user.email.toLowerCase() &&
-              (user.id === loggedInUser?.id ||
-                hasPermission(Permission.MANAGE_USERS)) && (
+            {user.email &&
+              user.displayName.toLowerCase() !== user.email.toLowerCase() && (
                 <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">
                   ({user.email})
                 </span>

--- a/src/components/UserProfile/ProfileHeader/index.tsx
+++ b/src/components/UserProfile/ProfileHeader/index.tsx
@@ -65,12 +65,11 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 {user.displayName}
               </a>
             </Link>
-            {user.email &&
-              user.displayName.toLowerCase() !== user.email.toLowerCase() && (
-                <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">
-                  ({user.email})
-                </span>
-              )}
+            {user.email && user.displayName.toLowerCase() !== user.email && (
+              <span className="text-sm text-gray-400 sm:text-lg sm:ml-2">
+                ({user.email})
+              </span>
+            )}
           </h1>
           <p className="text-sm font-medium text-gray-400">
             {subtextItems.reduce((prev, curr) => (

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -188,7 +188,9 @@ const UserGeneralSettings: React.FC = () => {
                       id="displayName"
                       name="displayName"
                       type="text"
-                      placeholder={user?.displayName}
+                      placeholder={
+                        user?.plexUsername ? user.plexUsername : user?.email
+                      }
                     />
                   </div>
                   {errors.displayName && touched.displayName && (


### PR DESCRIPTION
#### Description

Managed users do not have email addresses, which causes the DB query to check for an existing user to fail when we attempt to lowercase the e-mail address.

Also:
- ~~Do not set username when it is the same as the user's email address~~
- Fix weird UX when a user doesn't have a username set
- Make the display name sort on the user list case-insensitive
- Set appropriate placeholder for display name field (so it reflects what the user's display name would be if they do not set a username)
- Hide user email addresses from users without the `Manage Users` permission (unless the user does not have a display name set, in which case their email address is also their display name)

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #1698