### PR TITLE
fix(frontend): add missing route guards to settings pages

### DIFF
--- a/src/pages/settings/logs.tsx
+++ b/src/pages/settings/logs.tsx
@@ -2,8 +2,11 @@ import { NextPage } from 'next';
 import React from 'react';
 import SettingsLayout from '../../components/Settings/SettingsLayout';
 import SettingsLogs from '../../components/Settings/SettingsLogs';
+import useRouteGuard from '../../hooks/useRouteGuard';
+import { Permission } from '../../hooks/useUser';
 
 const SettingsLogsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsLogs />

--- a/src/pages/settings/notifications/discord.tsx
+++ b/src/pages/settings/notifications/discord.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsDiscord from '../../../components/Settings/Notifications/NotificationsDiscord';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/email.tsx
+++ b/src/pages/settings/notifications/email.tsx
@@ -1,10 +1,13 @@
 import { NextPage } from 'next';
 import React from 'react';
+import NotificationsEmail from '../../../components/Settings/Notifications/NotificationsEmail';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
-import NotificationsEmail from '../../../components/Settings/Notifications/NotificationsEmail';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/lunasea.tsx
+++ b/src/pages/settings/notifications/lunasea.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsLunaSea from '../../../components/Settings/Notifications/NotificationsLunaSea';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/pushbullet.tsx
+++ b/src/pages/settings/notifications/pushbullet.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsPushbullet from '../../../components/Settings/Notifications/NotificationsPushbullet';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/pushover.tsx
+++ b/src/pages/settings/notifications/pushover.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsPushover from '../../../components/Settings/Notifications/NotificationsPushover';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/slack.tsx
+++ b/src/pages/settings/notifications/slack.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsSlack from '../../../components/Settings/Notifications/NotificationsSlack';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsSlackPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/telegram.tsx
+++ b/src/pages/settings/notifications/telegram.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsTelegram from '../../../components/Settings/Notifications/NotificationsTelegram';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/webhook.tsx
+++ b/src/pages/settings/notifications/webhook.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsWebhook from '../../../components/Settings/Notifications/NotificationsWebhook';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>

--- a/src/pages/settings/notifications/webpush.tsx
+++ b/src/pages/settings/notifications/webpush.tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import NotificationsWebPush from '../../../components/Settings/Notifications/NotificationsWebPush';
 import SettingsLayout from '../../../components/Settings/SettingsLayout';
 import SettingsNotifications from '../../../components/Settings/SettingsNotifications';
+import useRouteGuard from '../../../hooks/useRouteGuard';
+import { Permission } from '../../../hooks/useUser';
 
 const NotificationsWebPushPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_SETTINGS);
   return (
     <SettingsLayout>
       <SettingsNotifications>


### PR DESCRIPTION
#### Description

Logs & notification settings pages are missing route guards, resulting in errors if a user without the required `MANAGE_SETTINGS` permission attempts to directly navigate to one of those pages by entering the URL.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A