### PR TITLE
feat(notif): prevent manage-request users receiving auto-approve notif from their requests

### DIFF
--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -249,7 +249,10 @@ class DiscordAgent
                 NotificationAgentKey.DISCORD,
                 type
               ) &&
-              user.settings?.discordId
+              user.settings?.discordId &&
+              // Check if it's the user's own auto-approved request
+              (type !== Notification.MEDIA_AUTO_APPROVED ||
+                user.id !== payload.request?.requestedBy.id)
           )
           .map((user) => `<@${user.settings?.discordId}>`)
           .join(' ');

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -208,7 +208,10 @@ class EmailAgent
                   NotificationAgentKey.EMAIL,
                   type
                 ) ??
-                  true))
+                  true)) &&
+              // Check if it's the user's own auto-approved request
+              (type !== Notification.MEDIA_AUTO_APPROVED ||
+                user.id !== payload.request?.requestedBy.id)
           )
           .map(async (user) => {
             logger.debug('Sending email notification', {

--- a/server/lib/notifications/agents/webpush.ts
+++ b/server/lib/notifications/agents/webpush.ts
@@ -185,7 +185,10 @@ class WebPushAgent
             NotificationAgentKey.WEBPUSH,
             type
           ) ??
-            true)
+            true) &&
+          // Check if it's the user's own auto-approved request
+          (type !== Notification.MEDIA_AUTO_APPROVED ||
+            user.id !== payload.request?.requestedBy.id)
       );
 
       const allSubs = await userPushSubRepository


### PR DESCRIPTION
#### Description

Email and webpush agents will filter out these users. Discord agent won't @ them.

#### To-Dos

- [X] Successful build `yarn build`
- [X] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #1707
