### PR TITLE
build(deps-dev): bump prettier from 2.3.0 to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "lint-staged": "^11.0.0",
     "nodemon": "^2.0.7",
     "postcss": "^8.3.0",
-    "prettier": "^2.3.0",
+    "prettier": "^2.3.1",
     "semantic-release": "^17.4.3",
     "semantic-release-docker-buildx": "^1.0.1",
     "tailwindcss": "^2.1.4",

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -92,8 +92,9 @@ interface SettingsPlexProps {
 const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
   const [isSyncing, setIsSyncing] = useState(false);
   const [isRefreshingPresets, setIsRefreshingPresets] = useState(false);
-  const [availableServers, setAvailableServers] =
-    useState<PlexDevice[] | null>(null);
+  const [availableServers, setAvailableServers] = useState<PlexDevice[] | null>(
+    null
+  );
   const { data, error, revalidate } = useSWR<PlexSettings>(
     '/api/v1/settings/plex'
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10946,10 +10946,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
+  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Resolves build error from #1751 

Bumps [prettier](https://github.com/prettier/prettier) from 2.3.0 to 2.3.1.
- [Release notes](https://github.com/prettier/prettier/releases)
- [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
- [Commits](https://github.com/prettier/prettier/compare/2.3.0...2.3.1)

---
updated-dependencies:
- dependency-name: prettier
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
