### PR TITLE
fix(plex): do not fail to scan empty libraries

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -142,7 +142,7 @@ class PlexAPI {
       `/library/sections/${id}/all`
     );
 
-    return response.MediaContainer.Metadata;
+    return response.MediaContainer.Metadata ?? [];
   }
 
   public async getMetadata(

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -7,9 +7,9 @@ import { User } from '../../../entity/User';
 import { getSettings, Library } from '../../settings';
 import BaseScanner, {
   MediaIds,
+  ProcessableSeason,
   RunnableScanner,
   StatusBase,
-  ProcessableSeason,
 } from '../baseScanner';
 
 const imdbRegex = new RegExp(/imdb:\/\/(tt[0-9]+)/);
@@ -109,7 +109,8 @@ class PlexScanner
         for (const library of this.libraries) {
           this.currentLibrary = library;
           this.log(`Beginning to process library: ${library.name}`, 'info');
-          this.items = await this.plexClient.getLibraryContents(library.id);
+          this.items =
+            (await this.plexClient.getLibraryContents(library.id)) ?? [];
           await this.loop(this.processItem.bind(this), { sessionId });
         }
       }

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -109,8 +109,7 @@ class PlexScanner
         for (const library of this.libraries) {
           this.currentLibrary = library;
           this.log(`Beginning to process library: ${library.name}`, 'info');
-          this.items =
-            (await this.plexClient.getLibraryContents(library.id)) ?? [];
+          this.items = await this.plexClient.getLibraryContents(library.id);
           await this.loop(this.processItem.bind(this), { sessionId });
         }
       }


### PR DESCRIPTION
#### Description

Plex scans on empty libraries are failing because the library contents are `undefined`.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A