### PR TITLE
feat(discord): add 'Enable Mentions' setting

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1138,6 +1138,8 @@ components:
               type: string
             webhookUrl:
               type: string
+            enableMentions:
+              type: boolean
     SlackSettings:
       type: object
       properties:

--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -258,35 +258,37 @@ class DiscordAgent
     const userMentions: string[] = [];
 
     try {
-      if (payload.notifyUser) {
-        if (
-          payload.notifyUser.settings?.hasNotificationType(
-            NotificationAgentKey.DISCORD,
-            type
-          ) &&
-          payload.notifyUser.settings.discordId
-        ) {
-          userMentions.push(`<@${payload.notifyUser.settings.discordId}>`);
+      if (settings.options.enableMentions) {
+        if (payload.notifyUser) {
+          if (
+            payload.notifyUser.settings?.hasNotificationType(
+              NotificationAgentKey.DISCORD,
+              type
+            ) &&
+            payload.notifyUser.settings.discordId
+          ) {
+            userMentions.push(`<@${payload.notifyUser.settings.discordId}>`);
+          }
         }
-      }
 
-      if (payload.notifyAdmin) {
-        const userRepository = getRepository(User);
-        const users = await userRepository.find();
+        if (payload.notifyAdmin) {
+          const userRepository = getRepository(User);
+          const users = await userRepository.find();
 
-        userMentions.push(
-          ...users
-            .filter(
-              (user) =>
-                user.settings?.hasNotificationType(
-                  NotificationAgentKey.DISCORD,
-                  type
-                ) &&
-                user.settings.discordId &&
-                shouldSendAdminNotification(type, user, payload)
-            )
-            .map((user) => `<@${user.settings?.discordId}>`)
-        );
+          userMentions.push(
+            ...users
+              .filter(
+                (user) =>
+                  user.settings?.hasNotificationType(
+                    NotificationAgentKey.DISCORD,
+                    type
+                  ) &&
+                  user.settings.discordId &&
+                  shouldSendAdminNotification(type, user, payload)
+              )
+              .map((user) => `<@${user.settings?.discordId}>`)
+          );
+        }
       }
 
       await axios.post(settings.options.webhookUrl, {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -125,6 +125,7 @@ export interface NotificationAgentDiscord extends NotificationAgentConfig {
     botUsername?: string;
     botAvatarUrl?: string;
     webhookUrl: string;
+    enableMentions: boolean;
   };
 }
 
@@ -304,6 +305,7 @@ class Settings {
             types: 0,
             options: {
               webhookUrl: '',
+              enableMentions: true,
             },
           },
           lunasea: {

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -252,10 +252,12 @@ userSettingsRoutes.get<{ id: string }, UserSettingsNotificationsResponse>(
       return res.status(200).json({
         emailEnabled: settings?.email.enabled,
         pgpKey: user.settings?.pgpKey,
-        discordEnabled: settings?.discord.enabled,
-        discordEnabledTypes: settings?.discord.enabled
-          ? settings?.discord.types
-          : 0,
+        discordEnabled:
+          settings?.discord.enabled && settings.discord.options.enableMentions,
+        discordEnabledTypes:
+          settings?.discord.enabled && settings.discord.options.enableMentions
+            ? settings.discord.types
+            : 0,
         discordId: user.settings?.discordId,
         pushbulletAccessToken: user.settings?.pushbulletAccessToken,
         pushoverApplicationToken: user.settings?.pushoverApplicationToken,

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -26,6 +26,7 @@ const messages = defineMessages({
   toastDiscordTestFailed: 'Discord test notification failed to send.',
   validationUrl: 'You must provide a valid URL',
   validationTypes: 'You must select at least one notification type',
+  enableMentions: 'Enable Mentions',
 });
 
 const NotificationsDiscord: React.FC = () => {
@@ -64,6 +65,7 @@ const NotificationsDiscord: React.FC = () => {
         botUsername: data?.options.botUsername,
         botAvatarUrl: data?.options.botAvatarUrl,
         webhookUrl: data.options.webhookUrl,
+        enableMentions: data?.options.enableMentions,
       }}
       validationSchema={NotificationsDiscordSchema}
       onSubmit={async (values) => {
@@ -75,6 +77,7 @@ const NotificationsDiscord: React.FC = () => {
               botUsername: values.botUsername,
               botAvatarUrl: values.botAvatarUrl,
               webhookUrl: values.webhookUrl,
+              enableMentions: values.enableMentions,
             },
           });
 
@@ -122,6 +125,7 @@ const NotificationsDiscord: React.FC = () => {
                 botUsername: values.botUsername,
                 botAvatarUrl: values.botAvatarUrl,
                 webhookUrl: values.webhookUrl,
+                enableMentions: values.enableMentions,
               },
             });
 
@@ -225,6 +229,18 @@ const NotificationsDiscord: React.FC = () => {
                 {errors.botAvatarUrl && touched.botAvatarUrl && (
                   <div className="error">{errors.botAvatarUrl}</div>
                 )}
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="enableMentions" className="checkbox-label">
+                {intl.formatMessage(messages.enableMentions)}
+              </label>
+              <div className="form-input">
+                <Field
+                  type="checkbox"
+                  id="enableMentions"
+                  name="enableMentions"
+                />
               </div>
             </div>
             <NotificationTypeSelector

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -448,6 +448,7 @@
   "components.Settings.Notifications.emailsender": "Sender Address",
   "components.Settings.Notifications.emailsettingsfailed": "Email notification settings failed to save.",
   "components.Settings.Notifications.emailsettingssaved": "Email notification settings saved successfully!",
+  "components.Settings.Notifications.enableMentions": "Enable Mentions",
   "components.Settings.Notifications.encryption": "Encryption Method",
   "components.Settings.Notifications.encryptionDefault": "Use STARTTLS if available",
   "components.Settings.Notifications.encryptionImplicitTls": "Use Implicit TLS",


### PR DESCRIPTION
#### Description

Some admins may be sending Discord notifications to a channel that their users do not have access to.

This PR adds a setting to the Discord agent, to allow admins to enable/disable mentions (and the notification type selector in user settings).

By default, this setting is enabled, so the behavior is unchanged for users already utilizing the Discord agent.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A