### PR TITLE
fix(lang): minor changes to password reset strings

### DIFF
--- a/src/components/ResetPassword/RequestResetLink.tsx
+++ b/src/components/ResetPassword/RequestResetLink.tsx
@@ -13,7 +13,7 @@ import LanguagePicker from '../Layout/LanguagePicker';
 const messages = defineMessages({
   passwordreset: 'Password Reset',
   resetpassword: 'Reset your password',
-  emailresetlink: 'Email a Recovery Link',
+  emailresetlink: 'Email Recovery Link',
   email: 'Email Address',
   validationemailrequired: 'You must provide a valid email address',
   gobacklogin: 'Return to Sign-In Page',

--- a/src/components/ResetPassword/index.tsx
+++ b/src/components/ResetPassword/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import * as Yup from 'yup';
+import globalMessages from '../../i18n/globalMessages';
 import Button from '../Common/Button';
 import ImageFader from '../Common/ImageFader';
 import SensitiveInput from '../Common/SensitiveInput';
@@ -163,7 +164,9 @@ const ResetPassword: React.FC = () => {
                               type="submit"
                               disabled={isSubmitting || !isValid}
                             >
-                              {intl.formatMessage(messages.resetpassword)}
+                              {isSubmitting
+                                ? intl.formatMessage(globalMessages.saving)
+                                : intl.formatMessage(globalMessages.save)}
                             </Button>
                           </span>
                         </div>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -246,7 +246,7 @@
   "components.RequestModal.selectseason": "Select Season(s)",
   "components.ResetPassword.confirmpassword": "Confirm Password",
   "components.ResetPassword.email": "Email Address",
-  "components.ResetPassword.emailresetlink": "Email a Recovery Link",
+  "components.ResetPassword.emailresetlink": "Email Recovery Link",
   "components.ResetPassword.gobacklogin": "Return to Sign-In Page",
   "components.ResetPassword.password": "Password",
   "components.ResetPassword.passwordreset": "Password Reset",


### PR DESCRIPTION
#### Description

- Remove the `a` from `Email a Recovery Link`
- Use global `save`/`saving` strings for button on password reset form (to be consistent with password page in user settings)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

N/A