### PR TITLE
fix(notif): truncate media overviews

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual, truncate } from 'lodash';
 import {
   AfterInsert,
   AfterRemove,
@@ -145,7 +145,11 @@ export class MediaRequest {
           subject: `${movie.title}${
             movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
           }`,
-          message: movie.overview,
+          message: truncate(movie.overview, {
+            length: 500,
+            separator: /\s/,
+            omission: '…',
+          }),
           image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
           media,
           request: this,
@@ -158,7 +162,11 @@ export class MediaRequest {
           subject: `${tv.name}${
             tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
           }`,
-          message: tv.overview,
+          message: truncate(tv.overview, {
+            length: 500,
+            separator: /\s/,
+            omission: '…',
+          }),
           image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${tv.poster_path}`,
           media,
           extra: [
@@ -217,7 +225,11 @@ export class MediaRequest {
             subject: `${movie.title}${
               movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
             }`,
-            message: movie.overview,
+            message: truncate(movie.overview, {
+              length: 500,
+              separator: /\s/,
+              omission: '…',
+            }),
             image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
             notifyUser: autoApproved ? undefined : this.requestedBy,
             media,
@@ -236,7 +248,11 @@ export class MediaRequest {
             subject: `${tv.name}${
               tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
             }`,
-            message: tv.overview,
+            message: truncate(tv.overview, {
+              length: 500,
+              separator: /\s/,
+              omission: '…',
+            }),
             image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${tv.poster_path}`,
             notifyUser: autoApproved ? undefined : this.requestedBy,
             media,
@@ -495,7 +511,11 @@ export class MediaRequest {
               subject: `${movie.title}${
                 movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
               }`,
-              message: movie.overview,
+              message: truncate(movie.overview, {
+                length: 500,
+                separator: /\s/,
+                omission: '…',
+              }),
               media,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
               request: this,
@@ -707,7 +727,11 @@ export class MediaRequest {
                   ? ` (${series.first_air_date.slice(0, 4)})`
                   : ''
               }`,
-              message: series.overview,
+              message: truncate(series.overview, {
+                length: 500,
+                separator: /\s/,
+                omission: '…',
+              }),
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${series.poster_path}`,
               media,
               extra: [

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -1,3 +1,4 @@
+import { truncate } from 'lodash';
 import {
   EntitySubscriberInterface,
   EventSubscriber,
@@ -34,7 +35,11 @@ export class MediaSubscriber implements EntitySubscriberInterface {
               subject: `${movie.title}${
                 movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
               }`,
-              message: movie.overview,
+              message: truncate(movie.overview, {
+                length: 500,
+                separator: /\s/,
+                omission: '…',
+              }),
               media: entity,
               image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
               request: request,
@@ -89,7 +94,11 @@ export class MediaSubscriber implements EntitySubscriberInterface {
             subject: `${tv.name}${
               tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
             }`,
-            message: tv.overview,
+            message: truncate(tv.overview, {
+              length: 500,
+              separator: /\s/,
+              omission: '…',
+            }),
             notifyUser: request.requestedBy,
             image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${tv.poster_path}`,
             media: entity,


### PR DESCRIPTION
#### Description

The overviews for some media items on TMDb are ridiculously long (1000+ characters), which results in notifications failing to send because the acceptable payload size is exceeded.

This PR truncates the media overviews in notifications to 500 characters or less (breaking on whitespace only, and appending `…` when truncation occurs) to avoid such notification failures.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A