### PR TITLE
fix(email): omit action link when application URL is not configured

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -212,7 +212,7 @@ export class User {
         },
         locals: {
           resetPasswordLink,
-          applicationUrl: resetPasswordLink,
+          applicationUrl,
           applicationTitle,
         },
       });

--- a/server/templates/email/generatedpassword/html.pug
+++ b/server/templates/email/generatedpassword/html.pug
@@ -75,23 +75,5 @@ div(role='article' aria-roledescription='email' aria-label='' lang='en')
         margin-bottom: 20px;\
         color: #51545e;\
         ')
-          a(href=applicationUrl style='color: #3869d4') Open #{applicationTitle}
-tr
-  td
-    table.sm-w-full(align='center' style='\
-    margin-left: auto;\
-    margin-right: auto;\
-    text-align: center;\
-    width: 570px;\
-    ' width='570' cellpadding='0' cellspacing='0' role='presentation')
-      tr
-        td(align='center' style='font-size: 16px; padding: 45px')
-          p(style='\
-          font-size: 13px;\
-          line-height: 24px;\
-          margin-top: 6px;\
-          margin-bottom: 20px;\
-          text-align: center;\
-          color: #a8aaaf;\
-          ')
-            | #{applicationTitle}
+          if applicationUrl
+            a(href=applicationUrl style='color: #3869d4') Open #{applicationTitle}

--- a/server/templates/email/media-request/html.pug
+++ b/server/templates/email/media-request/html.pug
@@ -77,9 +77,9 @@ div(role='article' aria-roledescription='email' aria-label='' lang='en')
                           | #{extra.value}
                       table(align='center' cellpadding='0' cellspacing='0' role='presentation')
                         tr
-                          td
+                          td(style='text-align: center')
                             a(href=actionUrl style='color: #3869d4')
-                              img(src=imageUrl alt='')
+                              img(src=imageUrl alt='' style='max-width: 50%')
         p(style='\
         font-size: 16px;\
         line-height: 24px;\
@@ -95,23 +95,5 @@ div(role='article' aria-roledescription='email' aria-label='' lang='en')
         margin-bottom: 20px;\
         color: #51545e;\
         ')
-          a(href=actionUrl style='color: #3869d4') Open in #{applicationTitle}
-tr
-  td
-    table.sm-w-full(align='center' style='\
-    margin-left: auto;\
-    margin-right: auto;\
-    text-align: center;\
-    width: 570px;\
-    ' width='570' cellpadding='0' cellspacing='0' role='presentation')
-      tr
-        td(align='center' style='font-size: 16px; padding: 45px')
-          p(style='\
-          font-size: 13px;\
-          line-height: 24px;\
-          margin-top: 6px;\
-          margin-bottom: 20px;\
-          text-align: center;\
-          color: #a8aaaf;\
-          ')
-            | #{applicationTitle}
+          if actionUrl
+            a(href=actionUrl style='color: #3869d4') Open in #{applicationTitle}

--- a/server/templates/email/resetpassword/html.pug
+++ b/server/templates/email/resetpassword/html.pug
@@ -64,12 +64,15 @@ div(role='article' aria-roledescription='email' aria-label='' lang='en')
               ' width='570' bgcolor='#ffffff' cellpadding='0' cellspacing='0' role='presentation')
                 tr
                   td(style='padding: 45px')
-                    div(style='font-size: 16px; text-align: center; padding-bottom: 14px;')
-                      | A request to reset the password was made. Click
-                      a(href=applicationUrl style='color: #3869d4; padding: 0px 5px;') here
-                      | to set a new password.
-                    div(style='font-size: 16px; text-align: center; padding-bottom: 14px;')
-                      | If you did not request this recovery link you can safely ignore this email.
+                    div(style='font-size: 16px; padding-bottom: 14px;')
+                      p
+                        | We received a request to reset your password.
+                      p
+                        | Please
+                        a(href=resetPasswordLink style='color: #3869d4; padding: 0px 5px;') click here
+                        | to change your #{applicationTitle} password.
+                      p
+                        | If you did not request that your password be reset, you can safely ignore this email.
         p(style='\
         font-size: 13px;\
         line-height: 24px;\
@@ -77,23 +80,5 @@ div(role='article' aria-roledescription='email' aria-label='' lang='en')
         margin-bottom: 20px;\
         color: #51545e;\
         ')
-          a(href=applicationUrl style='color: #3869d4') Open #{applicationTitle}
-tr
-  td
-    table.sm-w-full(align='center' style='\
-    margin-left: auto;\
-    margin-right: auto;\
-    text-align: center;\
-    width: 570px;\
-    ' width='570' cellpadding='0' cellspacing='0' role='presentation')
-      tr
-        td(align='center' style='font-size: 16px; padding: 45px')
-          p(style='\
-          font-size: 13px;\
-          line-height: 24px;\
-          margin-top: 6px;\
-          margin-bottom: 20px;\
-          text-align: center;\
-          color: #a8aaaf;\
-          ')
-            | #{applicationTitle}.
+          if applicationUrl
+            a(href=applicationUrl style='color: #3869d4') Open #{applicationTitle}

--- a/server/templates/email/test-email/html.pug
+++ b/server/templates/email/test-email/html.pug
@@ -73,23 +73,5 @@ div(role='article' aria-roledescription='email' aria-label='' lang='en')
         margin-bottom: 20px;\
         color: #51545e;\
         ')
-          a(href=applicationUrl style='color: #3869d4') Open #{applicationTitle}
-tr
-  td
-    table.sm-w-full(align='center' style='\
-    margin-left: auto;\
-    margin-right: auto;\
-    text-align: center;\
-    width: 570px;\
-    ' width='570' cellpadding='0' cellspacing='0' role='presentation')
-      tr
-        td(align='center' style='font-size: 16px; padding: 45px')
-          p(style='\
-          font-size: 13px;\
-          line-height: 24px;\
-          margin-top: 6px;\
-          margin-bottom: 20px;\
-          text-align: center;\
-          color: #a8aaaf;\
-          ')
-            | #{applicationTitle}
+          if applicationUrl
+            a(href=applicationUrl style='color: #3869d4') Open #{applicationTitle}


### PR DESCRIPTION
#### Description

When the application/action URL is not configured, we should not display the `Open in ____` action link at the bottom of the email.

Also, the following refinements:
- Resize media posters to a more reasonable size
- Remove application title at the bottom of the email (it's unnecessary when you have the title at the top and action link text immediately above)
- Fix application URL for password reset emails (currently, all links in the email are to the password reset page)
- Slight refinement of language & formatting of password reset email

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A