### PR TITLE
refactor: remove no-longer-needed transform Tailwind class

### DIFF
--- a/src/components/Common/ButtonWithDropdown/index.tsx
+++ b/src/components/Common/ButtonWithDropdown/index.tsx
@@ -105,11 +105,11 @@ const ButtonWithDropdown: React.FC<ButtonWithDropdownProps> = ({
           <Transition
             show={isOpen}
             enter="transition ease-out duration-100 opacity-0"
-            enterFrom="transform opacity-0 scale-95"
-            enterTo="transform opacity-100 scale-100"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
             leave="transition ease-in duration-75 opacity-100"
-            leaveFrom="transform opacity-100 scale-100"
-            leaveTo="transform opacity-0 scale-95"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
           >
             <div className="absolute right-0 z-40 w-56 mt-2 -mr-1 origin-top-right rounded-md shadow-lg">
               <div

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -79,7 +79,7 @@ const Modal: React.FC<ModalProps> = ({
       }}
     >
       <Transition
-        enter="transition opacity-0 duration-300 transform scale-75"
+        enter="transition opacity-0 duration-300 scale-75"
         enterFrom="opacity-0 scale-75"
         enterTo="opacity-100 scale-100"
         leave="transition opacity-100 duration-300"
@@ -92,7 +92,7 @@ const Modal: React.FC<ModalProps> = ({
         </div>
       </Transition>
       <Transition
-        enter="transition opacity-0 duration-300 transform scale-75"
+        enter="transition opacity-0 duration-300 scale-75"
         enterFrom="opacity-0 scale-75"
         enterTo="opacity-100 scale-100"
         leave="transition opacity-100 duration-300"
@@ -101,7 +101,7 @@ const Modal: React.FC<ModalProps> = ({
         show={!loading}
       >
         <div
-          className="relative inline-block w-full px-4 pt-5 pb-4 overflow-auto text-left align-bottom transition-all transform bg-gray-700 shadow-xl ring-1 ring-gray-500 sm:rounded-lg sm:my-8 sm:align-middle sm:max-w-3xl"
+          className="relative inline-block w-full px-4 pt-5 pb-4 overflow-auto text-left align-bottom transition-all bg-gray-700 shadow-xl ring-1 ring-gray-500 sm:rounded-lg sm:my-8 sm:align-middle sm:max-w-3xl"
           role="dialog"
           aria-modal="true"
           aria-labelledby="modal-headline"

--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -57,10 +57,10 @@ const SlideOver: React.FC<SlideOverProps> = ({
             <Transition
               show={show}
               appear
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
+              enter="transition ease-in-out duration-500 sm:duration-700"
               enterFrom="translate-x-full"
               enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
+              leave="transition ease-in-out duration-500 sm:duration-700"
               leaveFrom="translate-x-0"
               leaveTo="translate-x-full"
             >

--- a/src/components/Layout/LanguagePicker/index.tsx
+++ b/src/components/Layout/LanguagePicker/index.tsx
@@ -36,11 +36,11 @@ const LanguagePicker: React.FC = () => {
       <Transition
         show={isDropdownOpen}
         enter="transition ease-out duration-100 opacity-0"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
+        enterFrom="opacity-0 scale-95"
+        enterTo="opacity-100 scale-100"
         leave="transition ease-in duration-75 opacity-100"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
+        leaveFrom="opacity-100 scale-100"
+        leaveTo="opacity-0 scale-95"
       >
         <div
           className="absolute right-0 w-56 mt-2 origin-top-right rounded-md shadow-lg"

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -49,11 +49,11 @@ const UserDropdown: React.FC = () => {
       <Transition
         show={isDropdownOpen}
         enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
+        enterFrom="opacity-0 scale-95"
+        enterTo="opacity-100 scale-100"
         leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
+        leaveFrom="opacity-100 scale-100"
+        leaveTo="opacity-0 scale-95"
       >
         <div
           className="absolute right-0 w-48 mt-2 origin-top-right rounded-md shadow-lg"

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -515,7 +515,7 @@ const TvRequestModal: React.FC<RequestModalProps> = ({
                           aria-hidden="true"
                           className={`${
                             isAllSeasons() ? 'translate-x-5' : 'translate-x-0'
-                          } absolute left-0 inline-block h-5 w-5 border border-gray-200 rounded-full bg-white shadow transform group-focus:ring group-focus:border-blue-300 transition-transform ease-in-out duration-200`}
+                          } absolute left-0 inline-block h-5 w-5 border border-gray-200 rounded-full bg-white shadow group-focus:ring group-focus:border-blue-300 transition-transform ease-in-out duration-200`}
                         ></span>
                       </span>
                     </th>
@@ -603,7 +603,7 @@ const TvRequestModal: React.FC<RequestModalProps> = ({
                                   isSelectedSeason(season.seasonNumber)
                                     ? 'translate-x-5'
                                     : 'translate-x-0'
-                                } absolute left-0 inline-block h-5 w-5 border border-gray-200 rounded-full bg-white shadow transform group-focus:ring group-focus:border-blue-300 transition-transform ease-in-out duration-200`}
+                                } absolute left-0 inline-block h-5 w-5 border border-gray-200 rounded-full bg-white shadow group-focus:ring group-focus:border-blue-300 transition-transform ease-in-out duration-200`}
                               ></span>
                             </span>
                           </td>

--- a/src/components/Settings/LibraryItem.tsx
+++ b/src/components/Settings/LibraryItem.tsx
@@ -37,7 +37,7 @@ const LibraryItem: React.FC<LibraryItemProps> = ({
               aria-hidden="true"
               className={`${
                 isEnabled ? 'translate-x-5' : 'translate-x-0'
-              } relative inline-block h-5 w-5 rounded-full bg-white shadow transform transition ease-in-out duration-200`}
+              } relative inline-block h-5 w-5 rounded-full bg-white shadow transition ease-in-out duration-200`}
             >
               <span
                 className={`${

--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -217,10 +217,10 @@ const RadarrModal: React.FC<RadarrModalProps> = ({
     <Transition
       appear
       show
-      enter="transition ease-in-out duration-300 transform opacity-0"
+      enter="transition ease-in-out duration-300 opacity-0"
       enterFrom="opacity-0"
       enterTo="opacuty-100"
-      leave="transition ease-in-out duration-300 transform opacity-100"
+      leave="transition ease-in-out duration-300 opacity-100"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
     >

--- a/src/components/Settings/SettingsServices.tsx
+++ b/src/components/Settings/SettingsServices.tsx
@@ -248,10 +248,10 @@ const SettingsServices: React.FC = () => {
       )}
       <Transition
         show={deleteServerModal.open}
-        enter="transition ease-in-out duration-300 transform opacity-0"
+        enter="transition ease-in-out duration-300 opacity-0"
         enterFrom="opacity-0"
         enterTo="opacuty-100"
-        leave="transition ease-in-out duration-300 transform opacity-100"
+        leave="transition ease-in-out duration-300 opacity-100"
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -228,10 +228,10 @@ const SonarrModal: React.FC<SonarrModalProps> = ({
     <Transition
       appear
       show
-      enter="transition ease-in-out duration-300 transform opacity-0"
+      enter="transition ease-in-out duration-300 opacity-0"
       enterFrom="opacity-0"
       enterTo="opacuty-100"
-      leave="transition ease-in-out duration-300 transform opacity-100"
+      leave="transition ease-in-out duration-300 opacity-100"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
     >

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -160,10 +160,10 @@ const TitleCard: React.FC<TitleCardProps> = ({
           </div>
           <Transition
             show={isUpdating}
-            enter="transition ease-in-out duration-300 transform opacity-0"
+            enter="transition ease-in-out duration-300 opacity-0"
             enterFrom="opacity-0"
             enterTo="opacity-100"
-            leave="transition ease-in-out duration-300 transform opacity-100"
+            leave="transition ease-in-out duration-300 opacity-100"
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
@@ -174,10 +174,10 @@ const TitleCard: React.FC<TitleCardProps> = ({
 
           <Transition
             show={!image || showDetail || showRequestModal}
-            enter="transition transform opacity-0"
+            enter="transition opacity-0"
             enterFrom="opacity-0"
             enterTo="opacity-100"
-            leave="transition transform opacity-100"
+            leave="transition opacity-100"
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@tailwind screens;
 
 html {
   min-height: calc(100% + env(safe-area-inset-top));

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -180,7 +180,7 @@ a.crew-name,
 }
 
 .media-ratings {
-  @apply flex items-center justify-center px-4 py-2 border-b border-gray-700 last:border-b-0;
+  @apply flex items-center justify-center px-4 py-2 font-medium border-b border-gray-700 last:border-b-0;
 }
 
 .media-rating {
@@ -209,6 +209,10 @@ img.avatar-sm {
 
 .card-field-name {
   @apply mr-2 font-bold;
+}
+
+.card-field a {
+  @apply transition duration-300 hover:text-white hover:underline;
 }
 
 .section {


### PR DESCRIPTION
#### Description

- `transform` is no longer needed (https://github.com/tailwindlabs/tailwindcss/releases/tag/v2.2.0#simplified-transform-and-filter-composition)
- `@tailwind screens` is now `@tailwind variants`, but is optional (https://github.com/tailwindlabs/tailwindcss/releases/tag/v2.2.0#deprecate-tailwind-screens-for-tailwind-variants-in-just-in-time-mode)

Also fixes font weight of media rating values and link hover effects in request cards (both in the Discover page slider & request list).

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A