### PR TITLE
fix(ui): do not display negative remaining quota

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -307,7 +307,7 @@ export class User {
         limit: movieQuotaLimit,
         used: movieQuotaUsed,
         remaining: movieQuotaLimit
-          ? movieQuotaLimit - movieQuotaUsed
+          ? Math.max(0, movieQuotaLimit - movieQuotaUsed)
           : undefined,
         restricted:
           movieQuotaLimit && movieQuotaLimit - movieQuotaUsed <= 0
@@ -318,7 +318,9 @@ export class User {
         days: tvQuotaDays,
         limit: tvQuotaLimit,
         used: tvQuotaUsed,
-        remaining: tvQuotaLimit ? tvQuotaLimit - tvQuotaUsed : undefined,
+        remaining: tvQuotaLimit
+          ? Math.max(0, tvQuotaLimit - tvQuotaUsed)
+          : undefined,
         restricted:
           tvQuotaLimit && tvQuotaLimit - tvQuotaUsed <= 0 ? true : false,
       },

--- a/src/components/RequestModal/QuotaDisplay/index.tsx
+++ b/src/components/RequestModal/QuotaDisplay/index.tsx
@@ -59,18 +59,14 @@ const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
       <div className="flex items-center">
         <ProgressCircle
           className="w-8 h-8"
-          progress={Math.max(
-            0,
-            Math.round(
-              ((remaining ?? quota?.remaining ?? 0) / (quota?.limit ?? 1)) * 100
-            )
+          progress={Math.round(
+            ((remaining ?? quota?.remaining ?? 0) / (quota?.limit ?? 1)) * 100
           )}
           useHeatLevel
         />
         <div
           className={`flex items-end ${
-            Math.max(0, remaining ?? quota?.remaining ?? 0) === 0 ||
-            quota?.restricted
+            (remaining ?? quota?.remaining ?? 0) <= 0 || quota?.restricted
               ? 'text-red-500'
               : ''
           }`}
@@ -79,7 +75,7 @@ const QuotaDisplay: React.FC<QuotaDisplayProps> = ({
             {overLimit !== undefined
               ? intl.formatMessage(messages.notenoughseasonrequests)
               : intl.formatMessage(messages.requestsremaining, {
-                  remaining: Math.max(0, remaining ?? quota?.remaining ?? 0),
+                  remaining: remaining ?? quota?.remaining ?? 0,
                   type: intl.formatMessage(
                     mediaType === 'movie' ? messages.movie : messages.season
                   ),

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -150,7 +150,10 @@ const UserProfile: React.FC = () => {
                           limit: (
                             <span className="text-3xl font-semibold">
                               {intl.formatMessage(messages.limit, {
-                                remaining: quota.movie.remaining,
+                                remaining: Math.max(
+                                  0,
+                                  quota.movie.remaining ?? 0
+                                ),
                                 limit: quota.movie.limit,
                               })}
                             </span>
@@ -209,7 +212,7 @@ const UserProfile: React.FC = () => {
                           limit: (
                             <span className="text-3xl font-semibold">
                               {intl.formatMessage(messages.limit, {
-                                remaining: quota.tv.remaining,
+                                remaining: Math.max(0, quota.tv.remaining ?? 0),
                                 limit: quota.tv.limit,
                               })}
                             </span>

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -134,13 +134,10 @@ const UserProfile: React.FC = () => {
                   {quota.movie.limit ? (
                     <>
                       <ProgressCircle
-                        progress={Math.max(
-                          0,
-                          Math.round(
-                            ((quota?.movie.remaining ?? 0) /
-                              (quota?.movie.limit ?? 1)) *
-                              100
-                          )
+                        progress={Math.round(
+                          ((quota?.movie.remaining ?? 0) /
+                            (quota?.movie.limit ?? 1)) *
+                            100
                         )}
                         useHeatLevel
                         className="w-8 h-8 mr-2"
@@ -150,10 +147,7 @@ const UserProfile: React.FC = () => {
                           limit: (
                             <span className="text-3xl font-semibold">
                               {intl.formatMessage(messages.limit, {
-                                remaining: Math.max(
-                                  0,
-                                  quota.movie.remaining ?? 0
-                                ),
+                                remaining: quota.movie.remaining,
                                 limit: quota.movie.limit,
                               })}
                             </span>
@@ -196,13 +190,10 @@ const UserProfile: React.FC = () => {
                   {quota.tv.limit ? (
                     <>
                       <ProgressCircle
-                        progress={Math.max(
-                          0,
-                          Math.round(
-                            ((quota?.tv.remaining ?? 0) /
-                              (quota?.tv.limit ?? 1)) *
-                              100
-                          )
+                        progress={Math.round(
+                          ((quota?.tv.remaining ?? 0) /
+                            (quota?.tv.limit ?? 1)) *
+                            100
                         )}
                         useHeatLevel
                         className="w-8 h-8 mr-2"
@@ -212,7 +203,7 @@ const UserProfile: React.FC = () => {
                           limit: (
                             <span className="text-3xl font-semibold">
                               {intl.formatMessage(messages.limit, {
-                                remaining: Math.max(0, quota.tv.remaining ?? 0),
+                                remaining: quota.tv.remaining,
                                 limit: quota.tv.limit,
                               })}
                             </span>


### PR DESCRIPTION
#### Description

If a user has exceeded their quota, we should display the remaining limit as 0 instead of a negative value.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes UI issue reported in #1858