### PR TITLE
fix(quota): block multi-season requests that would exceed a user's quota

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4204,6 +4204,9 @@ paths:
                   type: string
                 languageProfileId:
                   type: number
+                userId:
+                  type: number
+                  nullable: true
               required:
                 - mediaType
                 - mediaId

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -350,6 +350,14 @@ requestRoutes.post('/', async (req, res, next) => {
           status: 202,
           message: 'No seasons available to request',
         });
+      } else if (
+        quotas.tv.limit &&
+        finalSeasons.length > (quotas.tv.remaining ?? 0)
+      ) {
+        return next({
+          status: 403,
+          message: 'Series Quota Exceeded',
+        });
       }
 
       await mediaRepository.save(media);


### PR DESCRIPTION
#### Description

Currently, multi-season requests that would exceed a user's remaining series request quota made via the API (e.g., from Requestrr) are not being blocked if the user has at least one season request remaining.

Also add optional but missing `userId` to API docs for the `/request` POST endpoint (used for the "Request As" feature).

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A