### PR TITLE
fix(webpush): load user in push sub query

### DIFF
--- a/server/lib/notifications/agents/webpush.ts
+++ b/server/lib/notifications/agents/webpush.ts
@@ -190,6 +190,7 @@ class WebPushAgent
 
       const allSubs = await userPushSubRepository
         .createQueryBuilder('pushSub')
+        .leftJoinAndSelect('pushSub.user', 'user')
         .where('pushSub.userId IN (:users)', {
           users: manageUsers.map((user) => user.id),
         })


### PR DESCRIPTION
#### Description

"Management" type notifications (e.g., `Media Requested` and `Media Automatically Approved`) are failing to send via web push due to the user relation not being loaded in the push sub query:
```
(node:28) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'displayName' of undefined
     at /app/dist/lib/notifications/agents/webpush.js:153:41
     at Array.map (<anonymous>)
     at WebPushAgent.send (/app/dist/lib/notifications/agents/webpush.js:150:40)
 (node:28) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag --unhandled-rejections=strict (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 44)
```

Fixes [issue reported by `barkcollar` on Discord](https://discord.com/channels/783137440809746482/789002037529804833/864583809198194698).

Props to @danshilm for finding the root cause of this bug! 👍🏻

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes issue noted above