### PR TITLE
feat: adding embedded trailers to desktop and deep linking to mobile 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-intersection-observer": "^8.32.1",
     "react-intl": "5.20.10",
     "react-markdown": "^6.0.2",
+    "react-player": "^2.9.0",
     "react-select": "^4.3.1",
     "react-spring": "^9.2.4",
     "react-toast-notifications": "^2.5.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -168,7 +168,7 @@ app
     });
     server.use('/api/v1', routes);
     server.get('/deep-link', (req, res) => {
-      const url = req.query.url as string;
+      const url = encodeURI(req.query.url as string);
       if (!url) {
         res.status(400);
         res.send('URL was not supplied.');

--- a/src/components/Common/PlayButton/index.tsx
+++ b/src/components/Common/PlayButton/index.tsx
@@ -8,8 +8,8 @@ interface PlayButtonProps {
 }
 
 export enum PlayButtonLinkTypes {
-  Web = 'web',
-  Trailer = 'trailer',
+  WEB = 'web',
+  TRAILER = 'trailer',
 }
 
 export interface PlayButtonLink {

--- a/src/components/Common/PlayButton/index.tsx
+++ b/src/components/Common/PlayButton/index.tsx
@@ -1,50 +1,83 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
+
 import ButtonWithDropdown from '../ButtonWithDropdown';
+import Trailer from '../../Trailer';
 
 interface PlayButtonProps {
   links: PlayButtonLink[];
 }
 
+export enum PlayButtonLinkTypes {
+  Web = 'web',
+  Trailer = 'trailer',
+}
+
 export interface PlayButtonLink {
+  type?: string;
   text: string;
   url: string;
   svg: ReactNode;
 }
 
 const PlayButton: React.FC<PlayButtonProps> = ({ links }) => {
+  const [viewingUrl, setViewingUrl] = useState<string | undefined>();
+
+  function openLink(link: PlayButtonLink): void {
+    switch (link.type) {
+      case PlayButtonLinkTypes.Trailer:
+        if (/Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+          window.open(`/deep-link?url=${link.url}`, '_blank');
+          return;
+        }
+
+        setViewingUrl(link.url);
+        break;
+      default:
+        window.open(link.url, '_blank');
+        break;
+    }
+  }
+
   if (!links || !links.length) {
     return null;
   }
 
   return (
-    <ButtonWithDropdown
-      buttonType="ghost"
-      text={
-        <>
-          {links[0].svg}
-          <span>{links[0].text}</span>
-        </>
-      }
-      onClick={() => {
-        window.open(links[0].url, '_blank');
-      }}
-    >
-      {links.length > 1 &&
-        links.slice(1).map((link, i) => {
-          return (
-            <ButtonWithDropdown.Item
-              key={`play-button-dropdown-item-${i}`}
-              onClick={() => {
-                window.open(link.url, '_blank');
-              }}
-              buttonType="ghost"
-            >
-              {link.svg}
-              <span>{link.text}</span>
-            </ButtonWithDropdown.Item>
-          );
-        })}
-    </ButtonWithDropdown>
+    <>
+      <ButtonWithDropdown
+        buttonType="ghost"
+        text={
+          <>
+            {links[0].svg}
+            <span>{links[0].text}</span>
+          </>
+        }
+        onClick={() => openLink(links[0])}
+      >
+        {links.length > 1 &&
+          links.slice(1).map((link, i) => {
+            return (
+              <ButtonWithDropdown.Item
+                key={`play-button-dropdown-item-${i}`}
+                onClick={() => openLink(link)}
+                buttonType="ghost"
+              >
+                {link.svg}
+                <span>{link.text}</span>
+              </ButtonWithDropdown.Item>
+            );
+          })}
+      </ButtonWithDropdown>
+
+      {viewingUrl ? (
+        <Trailer
+          url={viewingUrl}
+          close={() => {
+            setViewingUrl(undefined);
+          }}
+        />
+      ) : undefined}
+    </>
   );
 };
 

--- a/src/components/Common/PlayButton/index.tsx
+++ b/src/components/Common/PlayButton/index.tsx
@@ -24,7 +24,7 @@ const PlayButton: React.FC<PlayButtonProps> = ({ links }) => {
 
   function openLink(link: PlayButtonLink): void {
     switch (link.type) {
-      case PlayButtonLinkTypes.Trailer:
+      case PlayButtonLinkTypes.TRAILER:
         if (/Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
           window.open(`/deep-link?url=${link.url}`, '_blank');
           return;

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -36,7 +36,7 @@ import Button from '../Common/Button';
 import CachedImage from '../Common/CachedImage';
 import LoadingSpinner from '../Common/LoadingSpinner';
 import PageTitle from '../Common/PageTitle';
-import PlayButton, { PlayButtonLink } from '../Common/PlayButton';
+import PlayButton, { PlayButtonLink, PlayButtonLinkTypes } from '../Common/PlayButton';
 import ExternalLinkBlock from '../ExternalLinkBlock';
 import IssueModal from '../IssueModal';
 import ManageSlideOver from '../ManageSlideOver';
@@ -146,6 +146,7 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
 
   if (trailerUrl) {
     mediaLinks.push({
+      type: PlayButtonLinkTypes.Trailer,
       text: intl.formatMessage(messages.watchtrailer),
       url: trailerUrl,
       svg: <FilmIcon />,

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -149,7 +149,7 @@ const MovieDetails: React.FC<MovieDetailsProps> = ({ movie }) => {
 
   if (trailerUrl) {
     mediaLinks.push({
-      type: PlayButtonLinkTypes.Trailer,
+      type: PlayButtonLinkTypes.TRAILER,
       text: intl.formatMessage(messages.watchtrailer),
       url: trailerUrl,
       svg: <FilmIcon />,

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -36,7 +36,10 @@ import Button from '../Common/Button';
 import CachedImage from '../Common/CachedImage';
 import LoadingSpinner from '../Common/LoadingSpinner';
 import PageTitle from '../Common/PageTitle';
-import PlayButton, { PlayButtonLink, PlayButtonLinkTypes } from '../Common/PlayButton';
+import PlayButton, {
+  PlayButtonLink,
+  PlayButtonLinkTypes,
+} from '../Common/PlayButton';
 import ExternalLinkBlock from '../ExternalLinkBlock';
 import IssueModal from '../IssueModal';
 import ManageSlideOver from '../ManageSlideOver';

--- a/src/components/Trailer/index.tsx
+++ b/src/components/Trailer/index.tsx
@@ -1,0 +1,55 @@
+import ReactDOM from 'react-dom';
+import React, { useEffect } from 'react';
+import ReactPlayer from 'react-player/youtube';
+import { useLockBodyScroll } from '../../hooks/useLockBodyScroll';
+import { XIcon } from '@heroicons/react/outline';
+
+const Trailer: React.FC<{
+  url: string;
+  close: () => void;
+}> = ({ url, close }) => {
+  useLockBodyScroll(true);
+
+  const escapeFunction = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.code === 'Escape') {
+      close();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', escapeFunction, false);
+    return () => {
+      document.removeEventListener('keydown', escapeFunction, false);
+    };
+  }, []);
+
+  return ReactDOM.createPortal(
+    <>
+      <div
+        className={`fixed p-5 top-0 bottom-0 right-0 left-0 z-30 bg-black inset-0`}
+      >
+        <div className={`fixed top-0 left-0 z-40 p-1`}>
+          <XIcon
+            onClick={() => close()}
+            onKeyPress={escapeFunction}
+            className={`w-10 h-10 cursor-pointer fill-current text-indigo-500`}
+          />
+        </div>
+        <div className={`aspect-w-16 aspect-h-9`}>
+          <ReactPlayer
+            width={`calc(100vw - 3rem)`}
+            height={`calc(100vh - 3rem)`}
+            url={url}
+            playing={true}
+            playsinline={true}
+            controls={true}
+            onEnded={() => close()}
+          />
+        </div>
+      </div>
+    </>,
+    document.body
+  );
+};
+
+export default Trailer;

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -31,7 +31,10 @@ import Button from '../Common/Button';
 import CachedImage from '../Common/CachedImage';
 import LoadingSpinner from '../Common/LoadingSpinner';
 import PageTitle from '../Common/PageTitle';
-import PlayButton, { PlayButtonLink, PlayButtonLinkTypes } from '../Common/PlayButton';
+import PlayButton, {
+  PlayButtonLink,
+  PlayButtonLinkTypes,
+} from '../Common/PlayButton';
 import ExternalLinkBlock from '../ExternalLinkBlock';
 import IssueModal from '../IssueModal';
 import ManageSlideOver from '../ManageSlideOver';

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -31,7 +31,7 @@ import Button from '../Common/Button';
 import CachedImage from '../Common/CachedImage';
 import LoadingSpinner from '../Common/LoadingSpinner';
 import PageTitle from '../Common/PageTitle';
-import PlayButton, { PlayButtonLink } from '../Common/PlayButton';
+import PlayButton, { PlayButtonLink, PlayButtonLinkTypes } from '../Common/PlayButton';
 import ExternalLinkBlock from '../ExternalLinkBlock';
 import IssueModal from '../IssueModal';
 import ManageSlideOver from '../ManageSlideOver';
@@ -133,6 +133,7 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
 
   if (trailerUrl) {
     mediaLinks.push({
+      type: PlayButtonLinkTypes.Trailer,
       text: intl.formatMessage(messages.watchtrailer),
       url: trailerUrl,
       svg: <FilmIcon />,

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -136,7 +136,7 @@ const TvDetails: React.FC<TvDetailsProps> = ({ tv }) => {
 
   if (trailerUrl) {
     mediaLinks.push({
-      type: PlayButtonLinkTypes.Trailer,
+      type: PlayButtonLinkTypes.TRAILER,
       text: intl.formatMessage(messages.watchtrailer),
       url: trailerUrl,
       svg: <FilmIcon />,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,7 +5234,7 @@ deepmerge@^2.1.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
-deepmerge@^4.2.2:
+deepmerge@^4.0.0, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -8775,6 +8775,11 @@ load-json-file@^6.2.0:
     strip-bom "^4.0.0"
     type-fest "^0.6.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-utils@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
@@ -11476,6 +11481,11 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-input-autosize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
@@ -11532,6 +11542,17 @@ react-markdown@^6.0.2:
     unified "^9.0.0"
     unist-util-visit "^2.0.0"
     vfile "^4.0.0"
+
+react-player@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.9.0.tgz#ef7fe7073434087565f00ff219824e1e02c4b046"
+  integrity sha512-jNUkTfMmUhwPPAktAdIqiBcVUKsFKrVGH6Ocutj6535CNfM91yrvWxHg6fvIX8Y/fjYUPoejddwh7qboNV9vGA==
+  dependencies:
+    deepmerge "^4.0.0"
+    load-script "^1.0.0"
+    memoize-one "^5.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
 
 react-refresh@0.8.3:
   version "0.8.3"


### PR DESCRIPTION
feat: adding deep link for youtube trailers

#### Description
Adding Embedded Trailers for Desktop / Adding Deep Linking Capabilities for mobile

#### Screenshot (if UI-related)
![image](https://user-images.githubusercontent.com/2066668/125792310-38d13b70-fbc3-4806-afb5-b619f63182ee.png)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #962
- Fixed #1576


Im sure you will want to move a couple of things around , also this assumes that only `youtube` is used (which is bad IMO).

Let me know if you would like me to move forward with this. 

