### PR TITLE
docs(installation): increase log level in example commands in install docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,7 +16,7 @@ After running Overseerr for the first time, configure it by visiting the web UI 
 ```bash
 docker run -d \
   --name overseerr \
-  -e LOG_LEVEL=info \
+  -e LOG_LEVEL=debug \
   -e TZ=Asia/Tokyo \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
@@ -39,7 +39,7 @@ services:
     image: sctx/overseerr:latest
     container_name: overseerr
     environment:
-      - LOG_LEVEL=info
+      - LOG_LEVEL=debug
       - TZ=Asia/Tokyo
     ports:
       - 5055:5055
@@ -56,7 +56,7 @@ services:
 docker run -d \
   --name overseerr \
   --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ] \
-  -e LOG_LEVEL=info \
+  -e LOG_LEVEL=debug \
   -e TZ=Asia/Tokyo \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
@@ -121,7 +121,7 @@ or the Docker Desktop app:
 Then, create and start the Overseerr container:
 
 ```bash
-docker run -d -e LOG_LEVEL=info -e TZ=Asia/Tokyo -p 5055:5055 -v "overseerr-data:/app/config" --restart unless-stopped sctx/overseerr
+docker run -d -e LOG_LEVEL=debug -e TZ=Asia/Tokyo -p 5055:5055 -v "overseerr-data:/app/config" --restart unless-stopped sctx/overseerr
 ```
 
 If using a named volume like above, you can safely ignore the warning about the `/app/config` folder being incorrectly mounted on the setup page.


### PR DESCRIPTION
#### Description

Sets the log level in all the example commands on the installation page in the documentation to `debug` instead of `info`. Keeping it at `info` would sometimes result in not enough information being available when users ask for support.
This shouldn't have any drawbacks since filters can be used in the log viewer to only view the log messages with a less verbose level. There will also not be an excessive amount of logs since the log files are compressed and rotated every day, capping out at a maximum of 7 days.

#### Screenshot (if UI-related)
N/A

#### To-Dos
N/A

#### Issues Fixed or Closed

- Fixes none
