### PR TITLE
feat(notifs): add channel tag to pushbullet settings

### DIFF
--- a/server/lib/notifications/agents/pushbullet.ts
+++ b/server/lib/notifications/agents/pushbullet.ts
@@ -37,10 +37,7 @@ class PushbulletAgent
   private constructMessageDetails(
     type: Notification,
     payload: NotificationPayload
-  ): {
-    title: string;
-    body: string;
-  } {
+  ): PushbulletPayload {
     let messageTitle = '';
     let message = '';
 
@@ -156,7 +153,8 @@ class PushbulletAgent
           type: 'note',
           title: title,
           body: body,
-        } as PushbulletPayload,
+          channel_tag: settings.options.channelTag,
+        },
         {
           headers: {
             'Access-Token': settings.options.accessToken,

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -168,6 +168,7 @@ export interface NotificationAgentTelegram extends NotificationAgentConfig {
 export interface NotificationAgentPushbullet extends NotificationAgentConfig {
   options: {
     accessToken: string;
+    channelTag?: string;
   };
 }
 

--- a/src/components/Settings/Notifications/NotificationsPushbullet/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushbullet/index.tsx
@@ -17,6 +17,7 @@ const messages = defineMessages({
   accessToken: 'Access Token',
   accessTokenTip:
     'Create a token from your <PushbulletSettingsLink>Account Settings</PushbulletSettingsLink>',
+  channelTag: 'Channel Tag',
   validationAccessTokenRequired: 'You must provide an access token',
   pushbulletSettingsSaved:
     'Pushbullet notification settings saved successfully!',
@@ -62,6 +63,7 @@ const NotificationsPushbullet: React.FC = () => {
         enabled: data?.enabled,
         types: data?.types,
         accessToken: data?.options.accessToken,
+        channelTag: data?.options.channelTag,
       }}
       validationSchema={NotificationsPushbulletSchema}
       onSubmit={async (values) => {
@@ -71,6 +73,7 @@ const NotificationsPushbullet: React.FC = () => {
             types: values.types,
             options: {
               accessToken: values.accessToken,
+              channelTag: values.channelTag,
             },
           });
           addToast(intl.formatMessage(messages.pushbulletSettingsSaved), {
@@ -115,6 +118,7 @@ const NotificationsPushbullet: React.FC = () => {
               types: values.types,
               options: {
                 accessToken: values.accessToken,
+                channelTag: values.channelTag,
               },
             });
 
@@ -184,6 +188,16 @@ const NotificationsPushbullet: React.FC = () => {
                 {errors.accessToken && touched.accessToken && (
                   <div className="error">{errors.accessToken}</div>
                 )}
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="channelTag" className="text-label">
+                {intl.formatMessage(messages.channelTag)}
+              </label>
+              <div className="form-input">
+                <div className="form-input-field">
+                  <Field id="channelTag" name="channelTag" type="text" />
+                </div>
               </div>
             </div>
             <NotificationTypeSelector

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -275,6 +275,7 @@
   "components.Settings.Notifications.NotificationsPushbullet.accessToken": "Access Token",
   "components.Settings.Notifications.NotificationsPushbullet.accessTokenTip": "Create a token from your <PushbulletSettingsLink>Account Settings</PushbulletSettingsLink>",
   "components.Settings.Notifications.NotificationsPushbullet.agentEnabled": "Enable Agent",
+  "components.Settings.Notifications.NotificationsPushbullet.channelTag": "Channel Tag",
   "components.Settings.Notifications.NotificationsPushbullet.pushbulletSettingsFailed": "Pushbullet notification settings failed to save.",
   "components.Settings.Notifications.NotificationsPushbullet.pushbulletSettingsSaved": "Pushbullet notification settings saved successfully!",
   "components.Settings.Notifications.NotificationsPushbullet.toastPushbulletTestFailed": "Pushbullet test notification failed to send.",


### PR DESCRIPTION
#### Description
This adds a channel tag that's optional to the pushbullet settings. Setting one will make notifications go to the channel that's associated with that tag only.

#### Screenshot (if UI-related)
![Screenshot_43](https://user-images.githubusercontent.com/20923978/133304663-0efbbc6d-b21a-427f-819c-128ffad65fa3.png)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #2087
