### PR TITLE
fix(email): do not attempt to display logo if app URL not configured

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -178,6 +178,7 @@ export class User {
           password: password,
           applicationUrl,
           applicationTitle,
+          recipientName: this.username,
         },
       });
     } catch (e) {
@@ -214,6 +215,7 @@ export class User {
           resetPasswordLink,
           applicationUrl,
           applicationTitle,
+          recipientName: this.username ?? this.plexUsername,
         },
       });
     } catch (e) {

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -46,7 +46,8 @@ class EmailAgent
   private buildMessage(
     type: Notification,
     payload: NotificationPayload,
-    toEmail: string
+    recipientEmail: string,
+    recipientName?: string
   ): EmailOptions | undefined {
     const { applicationUrl, applicationTitle } = getSettings().main;
 
@@ -54,12 +55,13 @@ class EmailAgent
       return {
         template: path.join(__dirname, '../../../templates/email/test-email'),
         message: {
-          to: toEmail,
+          to: recipientEmail,
         },
         locals: {
           body: payload.message,
           applicationUrl,
           applicationTitle,
+          recipientName,
         },
       };
     }
@@ -127,7 +129,7 @@ class EmailAgent
           '../../../templates/email/media-request'
         ),
         message: {
-          to: toEmail,
+          to: recipientEmail,
         },
         locals: {
           requestType,
@@ -143,6 +145,7 @@ class EmailAgent
             : undefined,
           applicationUrl,
           applicationTitle,
+          recipientName,
         },
       };
     }
@@ -179,7 +182,12 @@ class EmailAgent
             payload.notifyUser.settings?.pgpKey
           );
           await email.send(
-            this.buildMessage(type, payload, payload.notifyUser.email)
+            this.buildMessage(
+              type,
+              payload,
+              payload.notifyUser.email,
+              payload.notifyUser.username ?? payload.notifyUser.plexUsername
+            )
           );
         } catch (e) {
           logger.error('Error sending email notification', {
@@ -228,7 +236,14 @@ class EmailAgent
                 this.getSettings(),
                 user.settings?.pgpKey
               );
-              await email.send(this.buildMessage(type, payload, user.email));
+              await email.send(
+                this.buildMessage(
+                  type,
+                  payload,
+                  user.email,
+                  user.username ?? user.plexUsername
+                )
+              );
             } catch (e) {
               logger.error('Error sending email notification', {
                 label: 'Notifications',

--- a/server/templates/email/generatedpassword/html.pug
+++ b/server/templates/email/generatedpassword/html.pug
@@ -6,25 +6,6 @@ head
   meta(name='viewport' content='width=device-width, initial-scale=1')
   meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
   link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
-  //if mso
-    xml
-      o:officedocumentsettings
-        o:pixelsperinch 96
-    style.
-      td,
-      th,
-      div,
-      p,
-      a,
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-      font-family: 'Segoe UI', sans-serif;
-      mso-line-height-rule: exactly;
-      }
   style.
     .title:hover * {
     text-decoration: underline;
@@ -35,28 +16,35 @@ head
     width: 100% !important;
     }
     }
-div(style='display: block; background-color: #111827;')
-  table(style='margin: 0 auto; font-family: Inter, Arial, Sans-Serif; color: #fff; font-size: 16px; width: 26rem;')
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
     tr
       td(style="text-align: center;")
-        a(href=applicationUrl)
-          img(src=applicationUrl +'/logo_full.png' style='width: 26rem; padding: 1rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hi, #{recipientName}!
     tr
       td(style='text-align: center;')
-        div(style='margin: 0rem 1rem 1rem; font-size: 1.25em;')
-          span
-            | An account has been created for you at #{applicationTitle}.
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | An account has been created for you at #{applicationTitle}.
     tr
       td(style='text-align: center;')
-        div(style='margin: 1rem 1rem 1rem; font-size: 1.25em;')
-          span
-            | Your new password is:
-        div(style='margin: 0rem 1rem 1rem; font-size: 1.25em;')
-          span
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | Your password is:
+        div(style='font-size: 1.25em; font-weight: 500; line-height: 2.25em;')
+          span(style='padding: 0.5rem; font-weight: 500; border: 1px solid rgb(100,100,100); font-family: monospace;')
             | #{password}
     if applicationUrl
       tr
         td
-          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 2.5rem 3rem; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
-            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255, 255, 255, 0.2);')
+          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
               | Open #{applicationTitle}

--- a/server/templates/email/media-request/html.pug
+++ b/server/templates/email/media-request/html.pug
@@ -6,25 +6,6 @@ head
   meta(name='viewport' content='width=device-width, initial-scale=1')
   meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
   link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
-  //if mso
-    xml
-      o:officedocumentsettings
-        o:pixelsperinch 96
-    style.
-      td,
-      th,
-      div,
-      p,
-      a,
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-      font-family: 'Segoe UI', sans-serif;
-      mso-line-height-rule: exactly;
-      }
   style.
     .title:hover * {
     text-decoration: underline;
@@ -35,20 +16,28 @@ head
     width: 100% !important;
     }
     }
-div(style='display: block; background-color: #111827;')
-  table(style='margin: 0 auto; font-family: Inter, Arial, Sans-Serif; color: #fff; font-size: 16px; width: 26rem;')
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
     tr
       td(style="text-align: center;")
-        a(href=applicationUrl)
-          img(src=applicationUrl +'/logo_full.png' style='width: 26rem; padding: 1rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hi, #{recipientName}!
     tr
       td(style='text-align: center;')
-        div(style='margin: 0rem 1rem 1rem; font-size: 1.25em;')
-          span
-            | #{body}
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | #{body}
     tr
       td
-        div(style='box-sizing: border-box; margin: 0; width: 100%; color: #fff; border-radius: .75rem; padding: 1rem; border: 1px solid rgba(100, 100, 100, 1); background: linear-gradient(135deg, rgba(17, 24, 39, 0.47) 0%, rgb(17, 24, 39) 75%), url(' + imageUrl + ') center 25%/cover')
+        div(style='box-sizing: border-box; margin: 1.5rem 0 0; width: 100%; color: #fff; border-radius: .75rem; padding: 1rem; border: 1px solid rgb(100,100,100); background: linear-gradient(135deg, rgba(17,24,39,0.47) 0%, rgb(17,24,39) 75%), url(' + imageUrl + ') center 25%/cover')
           table(style='color: #fff; width: 100%;')
             tr
               td(style='vertical-align: top;')
@@ -76,6 +65,6 @@ div(style='display: block; background-color: #111827;')
     if actionUrl
       tr
         td
-          a(href=actionUrl style='display: block; margin: 1.5rem 3rem 2.5rem 3rem; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
-            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255, 255, 255, 0.2);')
+          a(href=actionUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
               | Open in #{applicationTitle}

--- a/server/templates/email/resetpassword/html.pug
+++ b/server/templates/email/resetpassword/html.pug
@@ -6,25 +6,6 @@ head
   meta(name='viewport' content='width=device-width, initial-scale=1')
   meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
   link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
-  //if mso
-    xml
-      o:officedocumentsettings
-        o:pixelsperinch 96
-    style.
-      td,
-      th,
-      div,
-      p,
-      a,
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-      font-family: 'Segoe UI', sans-serif;
-      mso-line-height-rule: exactly;
-      }
   style.
     .title:hover * {
     text-decoration: underline;
@@ -35,25 +16,35 @@ head
     width: 100% !important;
     }
     }
-div(style='display: block; background-color: #111827;')
-  table(style='margin: 0 auto; font-family: Inter, Arial, Sans-Serif; color: #fff; font-size: 16px; width: 26rem;')
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
     tr
       td(style="text-align: center;")
-        a(href=applicationUrl)
-          img(src=applicationUrl +'/logo_full.png' style='width: 26rem; padding: 1rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
-    tr
-      td(style='text-align: center;')
-        div(style='margin: 0rem 1rem 1rem; font-size: 1.25em;')
-          span
-            | Your #{applicationTitle} account password was requested to be reset. Click below to reset your password.
-    if resetPasswordLink
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName
       tr
-        td
-          a(href=resetPasswordLink style='display: block; margin: 1.5rem 3rem 2.5rem 3rem; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
-            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255, 255, 255, 0.2);')
-              | Reset Password
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hi, #{recipientName}!
     tr
       td(style='text-align: center;')
-        div(style='margin: 1rem; font-size: .85em;')
-          span
-            | If you did not request that your password be reset, you can safely ignore this email.
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | A request has been received to change the password for your #{applicationTitle} account.
+    tr
+      td
+        a(href=resetPasswordLink style='display: block; margin: 1.5rem 3rem; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+          span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+            | Reset Password
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | The above link will expire in 24 hours.
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 1rem 0; font-size: 1.25em;')
+          | If you did not initiate this request, you may safely disregard this message.

--- a/server/templates/email/test-email/html.pug
+++ b/server/templates/email/test-email/html.pug
@@ -6,25 +6,6 @@ head
   meta(name='viewport' content='width=device-width, initial-scale=1')
   meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
   link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
-  //if mso
-    xml
-      o:officedocumentsettings
-        o:pixelsperinch 96
-    style.
-      td,
-      th,
-      div,
-      p,
-      a,
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-      font-family: 'Segoe UI', sans-serif;
-      mso-line-height-rule: exactly;
-      }
   style.
     .title:hover * {
     text-decoration: underline;
@@ -35,20 +16,28 @@ head
     width: 100% !important;
     }
     }
-div(style='display: block; background-color: #111827;')
-  table(style='margin: 0 auto; font-family: Inter, Arial, Sans-Serif; color: #fff; font-size: 16px; width: 26rem;')
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
     tr
       td(style="text-align: center;")
-        a(href=applicationUrl)
-          img(src=applicationUrl +'/logo_full.png' style='width: 26rem; padding: 1rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hi, #{recipientName}!
     tr
       td(style='text-align: center;')
-        div(style='margin: 0rem 1rem 1rem; font-size: 1.25em;')
-          span
-            | #{body}
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | #{body}
     if applicationUrl
       tr
         td
-          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 2.5rem 3rem; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
-            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255, 255, 255, 0.2);')
+          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
               | Open #{applicationTitle}


### PR DESCRIPTION
#### Description

The new styling of the HTML email notifications is beautiful, but doesn't have a check for whether or not an application URL is configured for the logo header.

This PR:
- Modifies the email templates to display the application title instead of the logo image if an application URL is not configured
- Cleans up the templates a bit and fixes some styling inconsistencies
- Adds user display name when available to be used in the email templates
- Modifies the wording of the password reset email, in addition to adding a mention of the expiration time of the reset link
- Makes some style changes to the password generated email

#### Screenshot (if UI-related)

New password generated email:
![image](https://user-images.githubusercontent.com/52870424/134676413-72d38791-ca6e-49f5-b9b8-24d33d38a503.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A