### PR TITLE
feat(notif): add Pushbullet channel tag

### DIFF
--- a/docs/using-overseerr/notifications/pushbullet.md
+++ b/docs/using-overseerr/notifications/pushbullet.md
@@ -11,3 +11,7 @@ User notifications are separate from system notifications, and the available not
 ### Access Token
 
 [Create an access token](https://www.pushbullet.com/#settings) and set it here to grant Overseerr access to the Pushbullet API.
+
+### Channel Tag (optional)
+
+Optionally, [create a channel](https://www.pushbullet.com/my-channel) to allow other users to follow the notification feed using the specified channel tag.

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1239,6 +1239,9 @@ components:
           properties:
             accessToken:
               type: string
+            channelTag:
+              type: string
+              nullable: true
     PushoverSettings:
       type: object
       properties:

--- a/server/lib/notifications/agents/pushbullet.ts
+++ b/server/lib/notifications/agents/pushbullet.ts
@@ -19,6 +19,7 @@ interface PushbulletPayload {
   type: string;
   title: string;
   body: string;
+  channel_tag?: string;
 }
 
 class PushbulletAgent

--- a/server/lib/notifications/agents/pushbullet.ts
+++ b/server/lib/notifications/agents/pushbullet.ts
@@ -117,11 +117,15 @@ class PushbulletAgent
       });
 
       try {
-        await axios.post(endpoint, notificationPayload, {
-          headers: {
-            'Access-Token': settings.options.accessToken,
-          },
-        });
+        await axios.post(
+          endpoint,
+          { ...notificationPayload, channel_tag: settings.options.channelTag },
+          {
+            headers: {
+              'Access-Token': settings.options.accessToken,
+            },
+          }
+        );
       } catch (e) {
         logger.error('Error sending Pushbullet notification', {
           label: 'Notifications',
@@ -189,8 +193,9 @@ class PushbulletAgent
           .map(async (user) => {
             if (
               user.settings?.pushbulletAccessToken &&
-              user.settings.pushbulletAccessToken !==
-                settings.options.accessToken
+              (settings.options.channelTag ||
+                user.settings.pushbulletAccessToken !==
+                  settings.options.accessToken)
             ) {
               logger.debug('Sending Pushbullet notification', {
                 label: 'Notifications',

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -181,6 +181,7 @@ export interface NotificationAgentTelegram extends NotificationAgentConfig {
 export interface NotificationAgentPushbullet extends NotificationAgentConfig {
   options: {
     accessToken: string;
+    channelTag?: string;
   };
 }
 

--- a/src/components/Settings/Notifications/NotificationsPushbullet/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushbullet/index.tsx
@@ -18,6 +18,7 @@ const messages = defineMessages({
   accessTokenTip:
     'Create a token from your <PushbulletSettingsLink>Account Settings</PushbulletSettingsLink>',
   validationAccessTokenRequired: 'You must provide an access token',
+  channelTag: 'Channel Tag',
   pushbulletSettingsSaved:
     'Pushbullet notification settings saved successfully!',
   pushbulletSettingsFailed: 'Pushbullet notification settings failed to save.',
@@ -57,6 +58,7 @@ const NotificationsPushbullet: React.FC = () => {
         enabled: data?.enabled,
         types: data?.types,
         accessToken: data?.options.accessToken,
+        channelTag: data.options.channelTag,
       }}
       validationSchema={NotificationsPushbulletSchema}
       onSubmit={async (values) => {
@@ -66,6 +68,7 @@ const NotificationsPushbullet: React.FC = () => {
             types: values.types,
             options: {
               accessToken: values.accessToken,
+              channelTag: values.channelTag,
             },
           });
           addToast(intl.formatMessage(messages.pushbulletSettingsSaved), {
@@ -110,6 +113,7 @@ const NotificationsPushbullet: React.FC = () => {
               types: values.types,
               options: {
                 accessToken: values.accessToken,
+                channelTag: values.channelTag,
               },
             });
 
@@ -179,6 +183,16 @@ const NotificationsPushbullet: React.FC = () => {
                 {errors.accessToken && touched.accessToken && (
                   <div className="error">{errors.accessToken}</div>
                 )}
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="channelTag" className="text-label">
+                {intl.formatMessage(messages.channelTag)}
+              </label>
+              <div className="form-input">
+                <div className="form-input-field">
+                  <Field id="channelTag" name="channelTag" type="text" />
+                </div>
               </div>
             </div>
             <NotificationTypeSelector

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -401,6 +401,7 @@
   "components.Settings.Notifications.NotificationsPushbullet.accessToken": "Access Token",
   "components.Settings.Notifications.NotificationsPushbullet.accessTokenTip": "Create a token from your <PushbulletSettingsLink>Account Settings</PushbulletSettingsLink>",
   "components.Settings.Notifications.NotificationsPushbullet.agentEnabled": "Enable Agent",
+  "components.Settings.Notifications.NotificationsPushbullet.channelTag": "Channel Tag",
   "components.Settings.Notifications.NotificationsPushbullet.pushbulletSettingsFailed": "Pushbullet notification settings failed to save.",
   "components.Settings.Notifications.NotificationsPushbullet.pushbulletSettingsSaved": "Pushbullet notification settings saved successfully!",
   "components.Settings.Notifications.NotificationsPushbullet.toastPushbulletTestFailed": "Pushbullet test notification failed to send.",


### PR DESCRIPTION
#### Description
This adds the ability to specify a channel tag when using the Pushbullet notification agent in the server settings.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2087
