### PR TITLE
chore(github): desired-behavior field should be textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -15,7 +15,7 @@ body:
       description: Is your feature request related to a problem? If so, please provide a clear and concise description of the problem; e.g., "I'm always frustrated when [...]."
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: desired-behavior
     attributes:
       label: Desired Behavior


### PR DESCRIPTION
#### Description

Accidentally set this to `input` instead of `textarea`.

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A