### PR TITLE
fix(scripts): update migration scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "lint": "eslint \"./server/**/*.{ts,tsx}\" \"./src/**/*.{ts,tsx}\"",
     "start": "NODE_ENV=production node dist/index.js",
     "i18n:extract": "extract-messages -l=en -o src/i18n/locale -d en --flat true --overwriteDefault true \"./src/**/!(*.test).{ts,tsx}\"",
-    "migration:generate": "ts-node --project server/tsconfig.json ./node_modules/.bin/typeorm migration:generate",
-    "migration:create": "ts-node --project server/tsconfig.json ./node_modules/.bin/typeorm migration:create",
-    "migration:run": "ts-node --project server/tsconfig.json ./node_modules/.bin/typeorm migration:run",
+    "migration:generate": "ts-node --project server/tsconfig.json ./node_modules/typeorm/cli.js migration:generate",
+    "migration:create": "ts-node --project server/tsconfig.json ./node_modules/typeorm/cli.js migration:create",
+    "migration:run": "ts-node --project server/tsconfig.json ./node_modules/typeorm/cli.js migration:run",
     "format": "prettier --write ."
   },
   "license": "MIT",


### PR DESCRIPTION
#### Description

Right now the migration scripts can't be ran on a Windows machine, but using the command like in the TypeORM migrations [documentation](https://typeorm.io/#migrations/running-and-reverting-migrations) fixes that.

#### Screenshot (if UI-related)
N/A

#### To-Dos
None

#### Issues Fixed or Closed

- Fixes none
