### PR TITLE
build(deps): bump node to 14.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Lint & Test Build
     runs-on: ubuntu-20.04
-    container: node:14.17-alpine
+    container: node:14.18-alpine
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: Lint & Test Build
     runs-on: ubuntu-20.04
-    container: node:14.17-alpine
+    container: node:14.18-alpine
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Lint & Test Build
     needs: jobs
     runs-on: ubuntu-20.04
-    container: node:14.17-alpine
+    container: node:14.18-alpine
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine AS BUILD_IMAGE
+FROM node:14.18-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
@@ -31,7 +31,7 @@ RUN touch config/DOCKER
 RUN echo "{\"commitTag\": \"${COMMIT_TAG}\"}" > committag.json
 
 
-FROM node:14.17-alpine
+FROM node:14.18-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine
+FROM node:14.18-alpine
 
 COPY . /app
 WORKDIR /app

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 parts:
   overseerr:
     plugin: nodejs
-    nodejs-version: '14.17.0'
+    nodejs-version: '14.18.1'
     nodejs-package-manager: 'yarn'
     nodejs-yarn-version: v1.22.10
     build-packages:


### PR DESCRIPTION
#### Description

Bumps Node.js to `14.18.1`.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A