### PR TITLE
fix(lang): consistent cache names

### DIFF
--- a/server/lib/cache.ts
+++ b/server/lib/cache.ts
@@ -40,7 +40,7 @@ class Cache {
 
 class CacheManager {
   private availableCaches: Record<AvailableCacheIds, Cache> = {
-    tmdb: new Cache('tmdb', 'TMDb API', {
+    tmdb: new Cache('tmdb', 'The Movie Database API', {
       stdTtl: 21600,
       checkPeriod: 60 * 30,
     }),


### PR DESCRIPTION
#### Description

None of the other cache names include the word "Cache" at the end.  Also, "Rotten Tomatoes" is not abbreviated, while "The Movie Database" is abbreviated as "TMDb."

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A