### PR TITLE
chore(github): add stalebot-exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,7 @@ exemptLabels:
   - dependencies
   - never-stale
   - priority:high
+  - priority:medium
 
 # Label to use when marking as stale
 staleLabel: stale


### PR DESCRIPTION
#### Description

Adds `never-stale` and `priority:high` to list of stalebot-exempt labels.

Also updates stalebot comment for pull requests.

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

- Fixes #1845