### PR TITLE
docs: add Overseerr Assistant to third-party integrations

### DIFF
--- a/docs/extending-overseerr/third-party.md
+++ b/docs/extending-overseerr/third-party.md
@@ -1,7 +1,7 @@
 # Third-Party Integrations
 
 {% hint style="warning" %}
-We do not officially support these third-party integrations. If you run into any issues, please seek help on the appropriate support channels for the integration itself!
+**We do not officially support these third-party integrations.** If you run into any issues, please seek help on the appropriate support channels for the integration itself!
 {% endhint %}
 
 - [Organizr](https://organizr.app/), a HTPC/homelab services organizer
@@ -9,6 +9,7 @@ We do not officially support these third-party integrations. If you run into any
 - [LunaSea](https://docs.lunasea.app/modules/overseerr), a self-hosted controller for mobile and macOS
 - [Requestrr](https://github.com/darkalfx/requestrr/wiki/Configuring-Overseerr), a Discord chatbot
 - [Doplarr](https://github.com/kiranshila/Doplarr), a Discord request bot
+- [Overseerr Assistant](https://github.com/RemiRigal/Overseerr-Assistant), a browser extension for requesting directly from TMDb and IMDb
 - [ha-overseerr](https://github.com/vaparr/ha-overseerr), a custom Home Assistant component
 - [OverCLIrr](https://github.com/WillFantom/OverCLIrr), a command-line tool
 - [Overseerr Exporter](https://github.com/WillFantom/overseerr-exporter), a Prometheus exporter


### PR DESCRIPTION
#### Description

Adds [RemiRigal/Overseerr-Assistant](https://github.com/RemiRigal/Overseerr-Assistant) to the list of third-party integrations.

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A