### PR TITLE
fix(issues): only allow edit of own comments & do not allow non-admin delete of issues with comments

### DIFF
--- a/server/routes/issue.ts
+++ b/server/routes/issue.ts
@@ -302,7 +302,7 @@ issueRoutes.delete('/:issueId', async (req, res, next) => {
 
     if (
       !req.user?.hasPermission(Permission.MANAGE_ISSUES) &&
-      issue.createdBy.id !== req.user?.id
+      (issue.createdBy.id !== req.user?.id || issue.comments.length > 1)
     ) {
       return next({
         status: 401,

--- a/server/routes/issueComment.ts
+++ b/server/routes/issueComment.ts
@@ -68,13 +68,10 @@ issueCommentRoutes.put<
         where: { id: Number(req.params.commentId) },
       });
 
-      if (
-        !req.user?.hasPermission([Permission.MANAGE_ISSUES], { type: 'or' }) &&
-        comment.user.id !== req.user?.id
-      ) {
+      if (comment.user.id !== req.user?.id) {
         return next({
           status: 403,
-          message: 'You do not have permission to edit this comment.',
+          message: 'You can only edit your own comments.',
         });
       }
 

--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -39,7 +39,7 @@ const IssueComment: React.FC<IssueCommentProps> = ({
   const intl = useIntl();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const { user, hasPermission } = useUser();
+  const { hasPermission } = useUser();
 
   const EditCommentSchema = Yup.object().shape({
     newMessage: Yup.string().required(
@@ -58,8 +58,6 @@ const IssueComment: React.FC<IssueCommentProps> = ({
       }
     }
   };
-
-  const belongsToUser = comment.user.id === user?.id;
 
   return (
     <div
@@ -98,7 +96,7 @@ const IssueComment: React.FC<IssueCommentProps> = ({
       </Link>
       <div className="relative flex-1">
         <div className="w-full rounded-md shadow ring-1 ring-gray-500">
-          {(belongsToUser || hasPermission(Permission.MANAGE_ISSUES)) && (
+          {(isActiveUser || hasPermission(Permission.MANAGE_ISSUES)) && (
             <Menu
               as="div"
               className="absolute z-40 inline-block text-left top-2 right-1"
@@ -129,20 +127,22 @@ const IssueComment: React.FC<IssueCommentProps> = ({
                       className="absolute right-0 w-56 mt-2 origin-top-right bg-gray-700 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                     >
                       <div className="py-1">
-                        <Menu.Item>
-                          {({ active }) => (
-                            <button
-                              onClick={() => setIsEditing(true)}
-                              className={`block w-full text-left px-4 py-2 text-sm ${
-                                active
-                                  ? 'bg-gray-600 text-white'
-                                  : 'text-gray-100'
-                              }`}
-                            >
-                              {intl.formatMessage(messages.edit)}
-                            </button>
-                          )}
-                        </Menu.Item>
+                        {isActiveUser && (
+                          <Menu.Item>
+                            {({ active }) => (
+                              <button
+                                onClick={() => setIsEditing(true)}
+                                className={`block w-full text-left px-4 py-2 text-sm ${
+                                  active
+                                    ? 'bg-gray-600 text-white'
+                                    : 'text-gray-100'
+                                }`}
+                              >
+                                {intl.formatMessage(messages.edit)}
+                              </button>
+                            )}
+                          </Menu.Item>
+                        )}
                         <Menu.Item>
                           {({ active }) => (
                             <button

--- a/src/components/IssueDetails/IssueDescription/index.tsx
+++ b/src/components/IssueDetails/IssueDescription/index.tsx
@@ -15,20 +15,22 @@ const messages = defineMessages({
 });
 
 interface IssueDescriptionProps {
-  issueId: number;
   description: string;
+  belongsToUser: boolean;
+  commentCount: number;
   onEdit: (newDescription: string) => void;
   onDelete: () => void;
 }
 
 const IssueDescription: React.FC<IssueDescriptionProps> = ({
-  issueId,
   description,
+  belongsToUser,
+  commentCount,
   onEdit,
   onDelete,
 }) => {
   const intl = useIntl();
-  const { user, hasPermission } = useUser();
+  const { hasPermission } = useUser();
   const [isEditing, setIsEditing] = useState(false);
 
   return (
@@ -37,7 +39,7 @@ const IssueDescription: React.FC<IssueDescriptionProps> = ({
         <div className="font-semibold text-gray-100 lg:text-xl">
           {intl.formatMessage(messages.description)}
         </div>
-        {(hasPermission(Permission.MANAGE_ISSUES) || user?.id === issueId) && (
+        {(hasPermission(Permission.MANAGE_ISSUES) || belongsToUser) && (
           <Menu as="div" className="relative inline-block text-left">
             {({ open }) => (
               <>
@@ -63,35 +65,39 @@ const IssueDescription: React.FC<IssueDescriptionProps> = ({
                     className="absolute right-0 w-56 mt-2 origin-top-right bg-gray-700 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                   >
                     <div className="py-1">
-                      <Menu.Item>
-                        {({ active }) => (
-                          <button
-                            onClick={() => setIsEditing(true)}
-                            className={`block w-full text-left px-4 py-2 text-sm ${
-                              active
-                                ? 'bg-gray-600 text-white'
-                                : 'text-gray-100'
-                            }`}
-                          >
-                            {intl.formatMessage(messages.edit)}
-                          </button>
-                        )}
-                      </Menu.Item>
-
-                      <Menu.Item>
-                        {({ active }) => (
-                          <button
-                            onClick={() => onDelete()}
-                            className={`block w-full text-left px-4 py-2 text-sm ${
-                              active
-                                ? 'bg-gray-600 text-white'
-                                : 'text-gray-100'
-                            }`}
-                          >
-                            {intl.formatMessage(messages.deleteissue)}
-                          </button>
-                        )}
-                      </Menu.Item>
+                      {belongsToUser && (
+                        <Menu.Item>
+                          {({ active }) => (
+                            <button
+                              onClick={() => setIsEditing(true)}
+                              className={`block w-full text-left px-4 py-2 text-sm ${
+                                active
+                                  ? 'bg-gray-600 text-white'
+                                  : 'text-gray-100'
+                              }`}
+                            >
+                              {intl.formatMessage(messages.edit)}
+                            </button>
+                          )}
+                        </Menu.Item>
+                      )}
+                      {(hasPermission(Permission.MANAGE_ISSUES) ||
+                        !commentCount) && (
+                        <Menu.Item>
+                          {({ active }) => (
+                            <button
+                              onClick={() => onDelete()}
+                              className={`block w-full text-left px-4 py-2 text-sm ${
+                                active
+                                  ? 'bg-gray-600 text-white'
+                                  : 'text-gray-100'
+                              }`}
+                            >
+                              {intl.formatMessage(messages.deleteissue)}
+                            </button>
+                          )}
+                        </Menu.Item>
+                      )}
                     </div>
                   </Menu.Items>
                 </Transition>

--- a/src/components/IssueDetails/index.tsx
+++ b/src/components/IssueDetails/index.tsx
@@ -260,7 +260,7 @@ const IssueDetails: React.FC = () => {
               username: (
                 <Link
                   href={
-                    issueData.createdBy.id === currentUser?.id
+                    belongsToUser
                       ? '/profile'
                       : `/users/${issueData.createdBy.id}`
                   }
@@ -294,8 +294,9 @@ const IssueDetails: React.FC = () => {
       <div className="relative z-10 flex mt-6 text-gray-300">
         <div className="flex-1 lg:pr-4">
           <IssueDescription
-            issueId={issueData.id}
             description={firstComment.message}
+            belongsToUser={belongsToUser}
+            commentCount={otherComments.length}
             onEdit={(newMessage) => {
               editFirstComment(newMessage);
             }}


### PR DESCRIPTION
#### Description

Non-admin users should not be permitted to delete issues that have been commented on.

Also, all users should only be permitted to edit their own comments.

Additionally, fixes bug where the user ID is being checked against the issue ID rather than the ID of the issue creator.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A