### PR TITLE
fix: handle Plex library settings migration failure gracefully

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -67,22 +67,8 @@ app
           label: 'Settings',
         });
 
-        try {
-          const plexapi = new PlexAPI({ plexToken: admin.plexToken });
-          await plexapi.syncLibraries();
-
-          logger.info('Plex library migration completed successfully', {
-            label: 'Settings',
-          });
-        } catch (e) {
-          logger.error('Failed to fetch Plex libraries', {
-            label: 'Settings',
-            message: e.message,
-          });
-
-          settings.plex.libraries = [];
-          settings.save();
-        }
+        const plexapi = new PlexAPI({ plexToken: admin.plexToken });
+        await plexapi.syncLibraries();
       }
     }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,11 +63,26 @@ app
       });
 
       if (admin) {
-        const plexapi = new PlexAPI({ plexToken: admin.plexToken });
-        await plexapi.syncLibraries();
-        logger.info('Migrating libraries to include media type', {
+        logger.info('Migrating Plex libraries to include media type', {
           label: 'Settings',
         });
+
+        try {
+          const plexapi = new PlexAPI({ plexToken: admin.plexToken });
+          await plexapi.syncLibraries();
+
+          logger.info('Plex library migration completed successfully', {
+            label: 'Settings',
+          });
+        } catch (e) {
+          logger.error('Failed to fetch Plex libraries', {
+            label: 'Settings',
+            message: e.message,
+          });
+
+          settings.plex.libraries = [];
+          settings.save();
+        }
       }
     }
 


### PR DESCRIPTION
#### Description

Overseerr should not fail to start if the Plex library settings migration fails.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #2253