### PR TITLE
feat(search): close search bar when hitting return

### DIFF
--- a/src/components/Layout/SearchInput/index.tsx
+++ b/src/components/Layout/SearchInput/index.tsx
@@ -27,13 +27,18 @@ const SearchInput: React.FC = () => {
             className="block w-full py-2 pl-10 text-white placeholder-gray-300 bg-gray-900 border border-gray-600 rounded-full bg-opacity-80 focus:bg-opacity-100 focus:border-gray-500 hover:border-gray-500 focus:outline-none focus:ring-0 focus:placeholder-gray-400 sm:text-base"
             placeholder={intl.formatMessage(messages.searchPlaceholder)}
             type="search"
-            inputMode="search"
             value={searchValue}
             onChange={(e) => setSearchValue(e.target.value)}
             onFocus={() => setIsOpen(true)}
             onBlur={() => {
               if (searchValue === '') {
                 setIsOpen(false);
+              }
+            }}
+            onKeyUp={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                (e.target as HTMLInputElement).blur();
               }
             }}
           />


### PR DESCRIPTION
#### Description

Right now, hitting return when focused on the search bar does not close the keyboard. This adds a keyup handler so that hitting return blurs the search input field and thus closes the keyboard.

#### Screenshot (if UI-related)

https://user-images.githubusercontent.com/20923978/140329958-2d84a6a0-dc74-4796-9aee-bf05fd977d20.mp4



#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
