### PR TITLE
fix(docker): explicitly install python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 
 RUN \
   case "${TARGETPLATFORM}" in \
-    'linux/arm64') apk add --no-cache python make g++ ;; \
-    'linux/arm/v7') apk add --no-cache python make g++ ;; \
+    'linux/arm64' | 'linux/arm/v7') \
+      apk add --no-cache python3 make g++ && \
+      ln -s /usr/bin/python3 /usr/bin/python \
+      ;; \
   esac
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
#### Description

It appears that `python` was finally removed from the Alpine Linux package repositories, so we need to install `python3` instead.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful local build

#### Issues Fixed or Closed

N/A