### PR TITLE
fix(servarr): handle baseurl error when testing connection

### DIFF
--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -46,13 +46,10 @@ radarrRoutes.post<
       url: RadarrAPI.buildUrl(req.body, '/api/v3'),
     });
 
-    const urlBase =
-      req.body.baseUrl && req.body.baseUrl !== '/'
-        ? req.body.baseUrl
-        : await radarr
-            .getSystemStatus()
-            .then((value) => value.urlBase)
-            .catch(() => undefined);
+    const urlBase = await radarr
+      .getSystemStatus()
+      .then((value) => value.urlBase)
+      .catch(() => req.body.baseUrl);
     const profiles = await radarr.getProfiles();
     const folders = await radarr.getRootFolders();
     const tags = await radarr.getTags();

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -46,7 +46,13 @@ radarrRoutes.post<
       url: RadarrAPI.buildUrl(req.body, '/api/v3'),
     });
 
-    const { urlBase } = await radarr.getSystemStatus();
+    const urlBase =
+      req.body.baseUrl && req.body.baseUrl !== '/'
+        ? req.body.baseUrl
+        : await radarr
+            .getSystemStatus()
+            .then((value) => value.urlBase)
+            .catch(() => undefined);
     const profiles = await radarr.getProfiles();
     const folders = await radarr.getRootFolders();
     const tags = await radarr.getTags();
@@ -58,10 +64,7 @@ radarrRoutes.post<
         path: folder.path,
       })),
       tags,
-      urlBase:
-        req.body.baseUrl && req.body.baseUrl !== '/'
-          ? req.body.baseUrl
-          : urlBase,
+      urlBase,
     });
   } catch (e) {
     logger.error('Failed to test Radarr', {

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -42,13 +42,10 @@ sonarrRoutes.post('/test', async (req, res, next) => {
       url: SonarrAPI.buildUrl(req.body, '/api/v3'),
     });
 
-    const urlBase =
-      req.body.baseUrl && req.body.baseUrl !== '/'
-        ? req.body.baseUrl
-        : await sonarr
-            .getSystemStatus()
-            .then((value) => value.urlBase)
-            .catch(() => undefined);
+    const urlBase = await sonarr
+      .getSystemStatus()
+      .then((value) => value.urlBase)
+      .catch(() => req.body.baseUrl);
     const profiles = await sonarr.getProfiles();
     const folders = await sonarr.getRootFolders();
     const languageProfiles = await sonarr.getLanguageProfiles();

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -42,7 +42,13 @@ sonarrRoutes.post('/test', async (req, res, next) => {
       url: SonarrAPI.buildUrl(req.body, '/api/v3'),
     });
 
-    const { urlBase } = await sonarr.getSystemStatus();
+    const urlBase =
+      req.body.baseUrl && req.body.baseUrl !== '/'
+        ? req.body.baseUrl
+        : await sonarr
+            .getSystemStatus()
+            .then((value) => value.urlBase)
+            .catch(() => undefined);
     const profiles = await sonarr.getProfiles();
     const folders = await sonarr.getRootFolders();
     const languageProfiles = await sonarr.getLanguageProfiles();
@@ -56,10 +62,7 @@ sonarrRoutes.post('/test', async (req, res, next) => {
       })),
       languageProfiles,
       tags,
-      urlBase:
-        req.body.baseUrl && req.body.baseUrl !== '/'
-          ? req.body.baseUrl
-          : urlBase,
+      urlBase,
     });
   } catch (e) {
     logger.error('Failed to test Sonarr', {


### PR DESCRIPTION
#### Description

When testing the connection to a Radarr/Sonarr server using a base URL, if the base URL cannot be fetched, the test fails even when the base URL input by the user is valid in an attempt to auto fill the base URL for the user.

This PR makes it so that the base URL is only fetched from Radarr/Sonarr if the user has not input one. Errors when fetching the base URL from Radarr/Sonarr are also handled.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
