### PR TITLE
fix(logs): handle unexpected log messages

### DIFF
--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -3,7 +3,7 @@ import type { PaginatedResponse } from './common';
 export type LogMessage = {
   timestamp: string;
   level: string;
-  label: string;
+  label?: string;
   message: string;
   data?: Record<string, unknown>;
 };

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -258,25 +258,29 @@ settingsRoutes.get(
     try {
       fs.readFileSync(logFile)
         .toString()
-        .split('\n')
+        .split(/(?=\n\d{4}-\d{2})/g)
         .forEach((line) => {
           if (!line.length) return;
 
-          const timestamp = line.match(new RegExp(/^.{24}/)) || [];
-          const level = line.match(new RegExp(/\s\[\w+\]/)) || [];
-          const label = line.match(new RegExp(/\]\[.+?\]/)) || [];
-          const message = line.match(new RegExp(/:\s([^{}]+)({.*})?/)) || [];
+          const jsonRegexp = new RegExp(
+            /[{[]{1}([,:{}[\]0-9.\-+Eaeflnr-u \n\r\t]|".*?")+[}\]]{1}/
+          );
 
-          if (level.length && filter.includes(level[0].slice(2, -1))) {
+          const timestamp = line.match(new RegExp(/.{24}/)) || [];
+          const level = line.match(new RegExp(/(?<=.{24}\s\[).+?(?=\])/)) || [];
+          const label =
+            line.match(new RegExp(/(?<=.{24}\s\[.+\]\[).+(?=\])/)) || [];
+          const message =
+            line.match(new RegExp(/(?<=\[.+\]:\s)[\s\S][^\r]+/)) || [];
+          const data = message[0].match(jsonRegexp) || [];
+
+          if (level.length && filter.includes(level[0])) {
             logs.push({
               timestamp: timestamp[0],
-              level: level.length ? level[0].slice(2, -1) : '',
-              label: label.length ? label[0].slice(2, -1) : '',
-              message: message.length && message[1] ? message[1] : '',
-              data:
-                message.length && message[2]
-                  ? JSON.parse(message[2])
-                  : undefined,
+              level: level[0],
+              label: label[0],
+              message: message[0].replace(jsonRegexp, ''),
+              data: data.length ? JSON.parse(data[0]) : undefined,
             });
           }
         });

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -263,7 +263,7 @@ settingsRoutes.get(
           if (!line.length) return;
 
           const jsonRegexp = new RegExp(
-            /[{[]{1}([,:{}[\]0-9.\-+Eaeflnr-u \n\r\t]|".*?")+[}\]]{1}/
+            /[{[]{1}([,:{}[\]0-9.\-+Eaeflnr-u \n\r\t]|"[^"\n]*?")+[}\]]{1}/
           );
 
           const timestamp = line.match(new RegExp(/.{24}/)) || [];

--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -321,7 +321,9 @@ const SettingsLogs: React.FC = () => {
                       {row.level.toUpperCase()}
                     </Badge>
                   </Table.TD>
-                  <Table.TD className="text-gray-300">{row.label}</Table.TD>
+                  <Table.TD className="text-gray-300">
+                    {row.label ?? ''}
+                  </Table.TD>
                   <Table.TD className="text-gray-300">{row.message}</Table.TD>
                   <Table.TD className="flex flex-wrap items-center justify-end -m-1">
                     {row.data && (


### PR DESCRIPTION
#### Description

This mostly changes the regexp that's used to parse logs messages for the log viewer.
It's now stricter and more specific. The log file is split right at the newline followed by the timestamp instead of just the newline since unexpected log messages like errors from Typeorm span more than just one line like:
```
2021-11-21T17:47:24.460Z [error]: Could not find any entity of type "MediaRequest" matching: {
    "where": {
        "id": 1391
    },
    "relations": [
        "requestedBy",
        "modifiedBy"
    ]
}
```
The better regexp also doesn't break when encountering titles like below which would incorrectly match the regexp for the JSON structured data in the log message:
```
2021-11-21T17:57:08.979Z [debug][Plex Scan]: Updating existing title: Lord El-Melloi II's Case Files {Rail Zeppelin} Grace note
```

#### Screenshot (if UI-related)
N/A

#### To-Dos
N/A

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
