### PR TITLE
fix(requests): do not fail request edits if acting user lacks Manage Users permission

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -549,11 +549,11 @@ requestRoutes.put<{ requestId: string }>(
         });
       }
 
-      let requestUser = req.user;
+      let requestUser = request.requestedBy;
 
       if (
         req.body.userId &&
-        req.body.userId !== req.user?.id &&
+        req.body.userId !== request.requestedBy.id &&
         !req.user?.hasPermission([
           Permission.MANAGE_USERS,
           Permission.MANAGE_REQUESTS,

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -111,7 +111,7 @@ const Modal: React.FC<ModalProps> = ({
           }}
         >
           {backdrop && (
-            <div className="absolute top-0 left-0 right-0 z-0 w-full h-64">
+            <div className="absolute top-0 left-0 right-0 z-0 w-full h-64 max-h-full">
               <CachedImage
                 alt=""
                 src={backdrop}

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -267,7 +267,17 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
     );
   }
 
-  if ((!data || selectedServer === null) && !selectedUser) {
+  if (
+    (!data ||
+      selectedServer === null ||
+      (data.filter((server) => server.is4k === is4k).length < 2 &&
+        (!serverData ||
+          (serverData.profiles.length < 2 &&
+            serverData.rootFolders.length < 2 &&
+            (serverData.languageProfiles ?? []).length < 2 &&
+            !serverData.tags?.length)))) &&
+    (!selectedUser || (userData?.results ?? []).length < 2)
+  ) {
     return null;
   }
 
@@ -503,7 +513,8 @@ const AdvancedRequester: React.FC<AdvancedRequesterProps> = ({
             </div>
           )}
         {hasPermission([Permission.MANAGE_REQUESTS, Permission.MANAGE_USERS]) &&
-          selectedUser && (
+          selectedUser &&
+          (userData?.results ?? []).length > 1 && (
             <Listbox
               as="div"
               value={selectedUser}


### PR DESCRIPTION
#### Description

For request edits, we should be checking if the request user has _changed_, instead of if it is the acting user.  (This differs from when requests are submitted, and users can only request for themselves if they lack the Manage Users permission.  When editing requests, users can only _alter_ the request user if they have the permission.)

Also fixes a minor UI bug where an empty Advanced Options box will appear in the request modal.

#### Screenshot (if UI-related)


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes ##2331