### PR TITLE
fix(logs): handle log parsing errors

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -269,7 +269,7 @@ settingsRoutes.get(
           const timestamp = line.match(new RegExp(/.{24}/)) || [];
           const level = line.match(new RegExp(/(?<=.{24}\s\[).+?(?=\])/)) || [];
           const label =
-            line.match(new RegExp(/(?<=.{24}\s\[.+\]\[).+(?=\])/)) || [];
+            line.match(new RegExp(/(?<=.{24}\s\[.+\]\[).+?(?=\])/)) || [];
           const message =
             line.match(new RegExp(/(?<=\[.+\]:\s)[\s\S][^\r]+/)) || [];
           const data = message[0].match(jsonRegexp) || [];


### PR DESCRIPTION
#### Description
Log messages with `]` in the error message would result in the label of the log message being incorrectly parsed as everything from the actual label to that ending square bracket. This is fixed by lazily searching for the closing bracket the label is inside of in the log message.


#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
