### PR TITLE
ci(snap): fix typo in app name

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,7 @@ parts:
     prime: [.next, ./*]
 
 apps:
-  deamon:
+  daemon:
     command: /bin/sh -c "cd $SNAP && node dist/index.js"
     daemon: simple
     restart-condition: on-failure


### PR DESCRIPTION
#### Description
The snap's app name is `deamon` instead of `daemon`.

#### Screenshot (if UI-related)
N/A

#### To-Dos
None

#### Issues Fixed or Closed

- Fixes none
