### PR TITLE
build(docker): reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN yarn build
 # remove development dependencies
 RUN yarn install --production --ignore-scripts --prefer-offline
 
-RUN rm -rf src server
+RUN rm -rf src server .next/cache
 
 RUN touch config/DOCKER
 
@@ -37,7 +37,7 @@ FROM node:14.18-alpine
 
 WORKDIR /app
 
-RUN apk add --no-cache tzdata tini
+RUN apk add --no-cache tzdata tini && rm -rf /tmp/*
 
 # copy from build image
 COPY --from=BUILD_IMAGE /app ./


### PR DESCRIPTION
#### Description

Removes contents of `/app/.next/cache` and `/tmp` from the built Docker image.  Results in ~145 MB reduction in size of the uncompressed image.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `docker build`

#### Issues Fixed or Closed

N/A