### PR TITLE
docs: add contribution, support and install clarifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,9 @@ All help is welcome and greatly appreciated! If you would like to contribute to 
 
 - If you are taking on an existing bug or feature ticket, please comment on the [issue](https://github.com/sct/overseerr/issues) to avoid multiple people working on the same thing.
 - All commits **must** follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-  - It is okay to squash your pull request down into a single commit that fits this standard.
   - Pull requests with commits not following this standard will **not** be merged.
-- Please make meaningful commits, or squash them.
+- Please make meaningful commits, or squash them prior to opening a pull request.
+  - Do not squash commits once people have begun reviewing your changes.
 - Always rebase your commit to the latest `develop` branch. Do **not** merge `develop` into your branch.
 - It is your responsibility to keep your branch up-to-date. Your work will **not** be merged unless it is rebased off the latest `develop` branch.
 - You can create a "draft" pull request early to get feedback on your work.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -143,7 +143,7 @@ or the Docker Desktop app:
 Then, create and start the Overseerr container:
 
 ```bash
-docker run -d -e LOG_LEVEL=debug -e TZ=Asia/Tokyo -p 5055:5055 -v "overseerr-data:/app/config" --restart unless-stopped sctx/overseerr
+docker run -d --name overseerr -e LOG_LEVEL=debug -e TZ=Asia/Tokyo -p 5055:5055 -v "overseerr-data:/app/config" --restart unless-stopped sctx/overseerr:latest
 ```
 
 If using a named volume like above, you can safely ignore the warning about the `/app/config` folder being incorrectly mounted on the setup page.

--- a/docs/support/need-help.md
+++ b/docs/support/need-help.md
@@ -19,6 +19,8 @@ Please try to include as much information as possible. A vague statement like "i
 
 Try to answer the following questions:
 
+- What version of Overseerr do you have installed?
+- How do you have Overseerr installed?
 - What were you trying to do, and how did you attempt it?
   - What command did you enter?
   - What did you click on?


### PR DESCRIPTION
#### Description

- Clarifies when to squash commits in the contribution guide; mostly so that contributors don't squash commits while people are reviewing the PR.
- Also ask for how Overseerr is installed, and what version is, when asking for support.
- Specify container name and the `latest` tag in the Windows installation docs so that upgrading is a smoother process.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
