### PR TITLE
feat(api): add additional request counts

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4422,21 +4422,22 @@ paths:
               schema:
                 type: object
                 properties:
+                  total:
+                    type: number
+                  movie:
+                    type: number
+                  tv:
+                    type: number
                   pending:
                     type: number
-                    example: 0
                   approved:
                     type: number
-                    example: 10
+                  declined:
+                    type: number
                   processing:
                     type: number
-                    example: 4
                   available:
                     type: number
-                    example: 6
-                required:
-                  - pending
-                  - approved
   /request/{requestId}:
     get:
       summary: Get MediaRequest

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -444,6 +444,20 @@ requestRoutes.get('/count', async (_req, res, next) => {
       .createQueryBuilder('request')
       .leftJoinAndSelect('request.media', 'media');
 
+    const totalCount = await query.getCount();
+
+    const movieCount = await query
+      .where('request.type = :requestType', {
+        requestType: MediaType.MOVIE,
+      })
+      .getCount();
+
+    const tvCount = await query
+      .where('request.type = :requestType', {
+        requestType: MediaType.TV,
+      })
+      .getCount();
+
     const pendingCount = await query
       .where('request.status = :requestStatus', {
         requestStatus: MediaRequestStatus.PENDING,
@@ -456,12 +470,18 @@ requestRoutes.get('/count', async (_req, res, next) => {
       })
       .getCount();
 
+    const declinedCount = await query
+      .where('request.status = :requestStatus', {
+        requestStatus: MediaRequestStatus.DECLINED,
+      })
+      .getCount();
+
     const processingCount = await query
       .where('request.status = :requestStatus', {
         requestStatus: MediaRequestStatus.APPROVED,
       })
       .andWhere(
-        '(request.is4k = false AND media.status != :availableStatus) OR (request.is4k = true AND media.status4k != :availableStatus)',
+        '((request.is4k = false AND media.status != :availableStatus) OR (request.is4k = true AND media.status4k != :availableStatus))',
         {
           availableStatus: MediaStatus.AVAILABLE,
         }
@@ -473,7 +493,7 @@ requestRoutes.get('/count', async (_req, res, next) => {
         requestStatus: MediaRequestStatus.APPROVED,
       })
       .andWhere(
-        '(request.is4k = false AND media.status = :availableStatus) OR (request.is4k = true AND media.status4k = :availableStatus)',
+        '((request.is4k = false AND media.status = :availableStatus) OR (request.is4k = true AND media.status4k = :availableStatus))',
         {
           availableStatus: MediaStatus.AVAILABLE,
         }
@@ -481,13 +501,21 @@ requestRoutes.get('/count', async (_req, res, next) => {
       .getCount();
 
     return res.status(200).json({
+      total: totalCount,
+      movie: movieCount,
+      tv: tvCount,
       pending: pendingCount,
       approved: approvedCount,
+      declined: declinedCount,
       processing: processingCount,
       available: availableCount,
     });
   } catch (e) {
-    next({ status: 500, message: e.message });
+    logger.error('Something went wrong retrieving request counts', {
+      label: 'API',
+      errorMessage: e.message,
+    });
+    next({ status: 500, message: 'Unable to retrieve request counts.' });
   }
 });
 


### PR DESCRIPTION
#### Description

Adds additional request count data to the `/request/count` API endpoint.

#### Screenshot (if UI-related)

![image](https://user-images.githubusercontent.com/52870424/149635848-8ff39c40-feb9-476a-98a4-b40f86471f2a.png)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A