### PR TITLE
feat(logs): skip invalid json in log file

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -320,29 +320,33 @@ settingsRoutes.get(
         .forEach((line) => {
           if (!line.length) return;
 
-          const logMessage = JSON.parse(line);
+          try {
+            const logMessage = JSON.parse(line);
 
-          if (!filter.includes(logMessage.level)) {
-            return;
-          }
+            if (!filter.includes(logMessage.level)) {
+              return;
+            }
 
-          if (
-            !Object.keys(logMessage).every((key) =>
-              logMessageProperties.includes(key)
-            )
-          ) {
-            Object.keys(logMessage)
-              .filter((prop) => !logMessageProperties.includes(prop))
-              .forEach((prop) => {
-                Object.assign(logMessage, {
-                  data: {
-                    [prop]: logMessage[prop],
-                  },
+            if (
+              !Object.keys(logMessage).every((key) =>
+                logMessageProperties.includes(key)
+              )
+            ) {
+              Object.keys(logMessage)
+                .filter((prop) => !logMessageProperties.includes(prop))
+                .forEach((prop) => {
+                  Object.assign(logMessage, {
+                    data: {
+                      [prop]: logMessage[prop],
+                    },
+                  });
                 });
-              });
-          }
+            }
 
-          logs.push(logMessage);
+            logs.push(logMessage);
+          } catch (error) {
+            // skip line silently
+          }
         });
 
       const displayedLogs = logs.reverse().slice(skip, skip + pageSize);


### PR DESCRIPTION
#### Description
As discussed, this silently skips any invalid JSON when parsing the log file to display in the log viewer since logging the problematic lines would spam the logs.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
