### PR TITLE
fix(tautulli): fetch additional user history as necessary to return 20 unique media

### DIFF
--- a/server/api/tautulli.ts
+++ b/server/api/tautulli.ts
@@ -251,6 +251,7 @@ class TautulliAPI {
               order_column: 'date',
               order_dir: 'desc',
               user_id: user.plexId,
+              media_type: 'movie,episode',
               length: take,
               start,
             },

--- a/server/api/tautulli.ts
+++ b/server/api/tautulli.ts
@@ -232,7 +232,7 @@ class TautulliAPI {
   public async getUserWatchHistory(
     user: User
   ): Promise<TautulliHistoryRecord[]> {
-    let records: TautulliHistoryRecord[] = [];
+    let results: TautulliHistoryRecord[] = [];
 
     try {
       if (!user.plexId) {
@@ -242,7 +242,7 @@ class TautulliAPI {
       const take = 100;
       let start = 0;
 
-      while (records.length < 20) {
+      while (results.length < 20) {
         const tautulliData = (
           await this.axios.get<TautulliHistoryResponse>('/api/v2', {
             params: {
@@ -258,10 +258,10 @@ class TautulliAPI {
         ).data.response.data.data;
 
         if (!tautulliData.length) {
-          return records;
+          return results;
         }
 
-        records = uniqWith(records.concat(tautulliData), (recordA, recordB) =>
+        results = uniqWith(results.concat(tautulliData), (recordA, recordB) =>
           recordA.grandparent_rating_key && recordB.grandparent_rating_key
             ? recordA.grandparent_rating_key === recordB.grandparent_rating_key
             : recordA.parent_rating_key && recordB.parent_rating_key
@@ -272,7 +272,7 @@ class TautulliAPI {
         start += take;
       }
 
-      return records.slice(0, 20);
+      return results.slice(0, 20);
     } catch (e) {
       logger.error(
         'Something went wrong fetching user watch history from Tautulli',

--- a/server/api/tautulli.ts
+++ b/server/api/tautulli.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { uniqWith } from 'lodash';
 import { User } from '../entity/User';
 import { TautulliSettings } from '../lib/settings';
 import logger from '../logger';
@@ -231,23 +232,47 @@ class TautulliAPI {
   public async getUserWatchHistory(
     user: User
   ): Promise<TautulliHistoryRecord[]> {
+    let records: TautulliHistoryRecord[] = [];
+
     try {
       if (!user.plexId) {
         throw new Error('User does not have an associated Plex ID');
       }
 
-      return (
-        await this.axios.get<TautulliHistoryResponse>('/api/v2', {
-          params: {
-            cmd: 'get_history',
-            grouping: 1,
-            order_column: 'date',
-            order_dir: 'desc',
-            user_id: user.plexId,
-            length: 100,
-          },
-        })
-      ).data.response.data.data;
+      const take = 100;
+      let start = 0;
+
+      while (records.length < 20) {
+        const tautulliData = (
+          await this.axios.get<TautulliHistoryResponse>('/api/v2', {
+            params: {
+              cmd: 'get_history',
+              grouping: 1,
+              order_column: 'date',
+              order_dir: 'desc',
+              user_id: user.plexId,
+              length: take,
+              start,
+            },
+          })
+        ).data.response.data.data;
+
+        if (!tautulliData.length) {
+          return records;
+        }
+
+        records = uniqWith(records.concat(tautulliData), (recordA, recordB) =>
+          recordA.grandparent_rating_key && recordB.grandparent_rating_key
+            ? recordA.grandparent_rating_key === recordB.grandparent_rating_key
+            : recordA.parent_rating_key && recordB.parent_rating_key
+            ? recordA.parent_rating_key === recordB.parent_rating_key
+            : recordA.rating_key === recordB.rating_key
+        );
+
+        start += take;
+      }
+
+      return records.slice(0, 20);
     } catch (e) {
       logger.error(
         'Something went wrong fetching user watch history from Tautulli',

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -559,15 +559,15 @@ router.get<{ id: string }, UserWatchDataResponse>(
               watchHistory,
               (record) =>
                 (!!media.ratingKey &&
-                  (record.media_type === 'movie'
-                    ? record.rating_key === parseInt(media.ratingKey)
-                    : record.grandparent_rating_key ===
-                      parseInt(media.ratingKey))) ||
+                  parseInt(media.ratingKey) ===
+                    (record.media_type === 'movie'
+                      ? record.rating_key
+                      : record.grandparent_rating_key)) ||
                 (!!media.ratingKey4k &&
-                  (record.media_type === 'movie'
-                    ? record.rating_key === parseInt(media.ratingKey4k)
-                    : record.grandparent_rating_key ===
-                      parseInt(media.ratingKey4k)))
+                  parseInt(media.ratingKey4k) ===
+                    (record.media_type === 'movie'
+                      ? record.rating_key
+                      : record.grandparent_rating_key))
             ),
         ]
       );

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -544,8 +544,24 @@ router.get<{ id: string }, UserWatchDataResponse>(
               ),
             },
             {
+              mediaType: MediaType.MOVIE,
+              ratingKey4k: In(
+                watchHistory
+                  .filter((record) => record.media_type === 'movie')
+                  .map((record) => record.rating_key)
+              ),
+            },
+            {
               mediaType: MediaType.TV,
               ratingKey: In(
+                watchHistory
+                  .filter((record) => record.media_type === 'episode')
+                  .map((record) => record.grandparent_rating_key)
+              ),
+            },
+            {
+              mediaType: MediaType.TV,
+              ratingKey4k: In(
                 watchHistory
                   .filter((record) => record.media_type === 'episode')
                   .map((record) => record.grandparent_rating_key)

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -536,20 +536,15 @@ router.get<{ id: string }, UserWatchDataResponse>(
       const recentlyWatched = sortBy(
         await qb
           .where(
-            '(media.mediaType = :movie AND (media.ratingKey IN (:...ratingKeys) or media.ratingKey4k IN (:...ratingKeys)))',
+            '(media.mediaType = :movie AND (media.ratingKey IN (:...movieRatingKeys) OR media.ratingKey4k IN (:...movieRatingKeys))) OR (media.mediaType = :tv AND (media.ratingKey IN (:...tvRatingKeys) OR media.ratingKey4k IN (:...tvRatingKeys)))',
             {
               movie: MediaType.MOVIE,
-              ratingKeys: watchHistory
-                .filter((record) => record.media_type == 'movie')
+              movieRatingKeys: watchHistory
+                .filter((record) => record.media_type === 'movie')
                 .map((record) => record.rating_key),
-            }
-          )
-          .orWhere(
-            '(media.mediaType = :tv AND (media.ratingKey IN (:...ratingKeys) or media.ratingKey4k IN (:...ratingKeys)))',
-            {
               tv: MediaType.TV,
-              ratingKeys: watchHistory
-                .filter((record) => record.media_type == 'episode')
+              tvRatingKeys: watchHistory
+                .filter((record) => record.media_type === 'episode')
                 .map((record) => record.grandparent_rating_key),
             }
           )


### PR DESCRIPTION
#### Description

Currently, the user "recently watched" results are the result of deduping a single Tautulli `get_history` API call.  This PR changes the behavior to fetch additional results until there are 20 unique media, in case a user watches a lot of TV shows (especially long-running series with many episodes).

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

N/A