### PR TITLE
fix(logs): handle log message nested extra properties

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
 import fs from 'fs';
-import { merge, omit, sortBy } from 'lodash';
+import { merge, omit, set, sortBy } from 'lodash';
 import { rescheduleJob } from 'node-schedule';
 import path from 'path';
 import { getRepository } from 'typeorm';
@@ -349,11 +349,7 @@ settingsRoutes.get(
             Object.keys(logMessage)
               .filter((prop) => !logMessageProperties.includes(prop))
               .forEach((prop) => {
-                Object.assign(logMessage, {
-                  data: {
-                    [prop]: logMessage[prop],
-                  },
-                });
+                set(logMessage, `data.${prop}`, logMessage[prop]);
               });
           }
 


### PR DESCRIPTION
#### Description
`Object.assign` only sets the object's property's value itself, and not its nested properties (if any), therefore log messages like the ones from the Plex Scan, where the TMDb ID, IMDB ID & TVDB ID are under the `mediaIds` property, did not have those added as extra "data" for the log message.
This replaces the usage of `Object.assign` with lodash's `set` method.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
