### PR TITLE
feat(search): filter search results by year

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -128,7 +128,7 @@ class TheMovieDb extends ExternalAPI {
     year,
   }: SingleSearchOptions): Promise<TmdbSearchMovieResponse> => {
     try {
-      const data = await this.get<TmdbSearchMovieResponse>('/search/movies', {
+      const data = await this.get<TmdbSearchMovieResponse>('/search/movie', {
         params: { query, page, include_adult: includeAdult, language, year },
       });
 

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -28,6 +28,10 @@ interface SearchOptions {
   language?: string;
 }
 
+interface SingleSearchOptions extends SearchOptions {
+  year?: number;
+}
+
 interface DiscoverMovieOptions {
   page?: number;
   includeAdult?: boolean;
@@ -103,6 +107,58 @@ class TheMovieDb extends ExternalAPI {
     try {
       const data = await this.get<TmdbSearchMultiResponse>('/search/multi', {
         params: { query, page, include_adult: includeAdult, language },
+      });
+
+      return data;
+    } catch (e) {
+      return {
+        page: 1,
+        results: [],
+        total_pages: 1,
+        total_results: 0,
+      };
+    }
+  };
+
+  public searchMovies = async ({
+    query,
+    page = 1,
+    includeAdult = false,
+    language = 'en',
+    year,
+  }: SingleSearchOptions): Promise<TmdbSearchMovieResponse> => {
+    try {
+      const data = await this.get<TmdbSearchMovieResponse>('/search/movies', {
+        params: { query, page, include_adult: includeAdult, language, year },
+      });
+
+      return data;
+    } catch (e) {
+      return {
+        page: 1,
+        results: [],
+        total_pages: 1,
+        total_results: 0,
+      };
+    }
+  };
+
+  public searchTvShows = async ({
+    query,
+    page = 1,
+    includeAdult = false,
+    language = 'en',
+    year,
+  }: SingleSearchOptions): Promise<TmdbSearchTvResponse> => {
+    try {
+      const data = await this.get<TmdbSearchTvResponse>('/search/tv', {
+        params: {
+          query,
+          page,
+          include_adult: includeAdult,
+          language,
+          first_air_date_year: year,
+        },
       });
 
       return data;

--- a/server/lib/search.ts
+++ b/server/lib/search.ts
@@ -4,7 +4,9 @@ import {
   TmdbMovieResult,
   TmdbPersonDetails,
   TmdbPersonResult,
+  TmdbSearchMovieResponse,
   TmdbSearchMultiResponse,
+  TmdbSearchTvResponse,
   TmdbTvDetails,
   TmdbTvResult,
 } from '../api/themoviedb/interfaces';
@@ -13,14 +15,19 @@ import {
   mapPersonDetailsToResult,
   mapTvDetailsToResult,
 } from '../models/Search';
-import { isMovieDetails, isTvDetails } from '../utils/typeHelpers';
-
-type SearchProviderId = 'TMDb' | 'IMDb' | 'TVDB';
+import { isMovie, isMovieDetails, isTvDetails } from '../utils/typeHelpers';
 
 interface SearchProvider {
-  id: SearchProviderId;
   pattern: RegExp;
-  search: (id: string, language?: string) => Promise<TmdbSearchMultiResponse>;
+  search: ({
+    id,
+    language,
+    query,
+  }: {
+    id: string;
+    language?: string;
+    query?: string;
+  }) => Promise<TmdbSearchMultiResponse>;
 }
 
 const searchProviders: SearchProvider[] = [];
@@ -32,12 +39,8 @@ export const findSearchProvider = (
 };
 
 searchProviders.push({
-  id: 'TMDb',
   pattern: new RegExp(/(?<=tmdb:)\d+/),
-  search: async (
-    id: string,
-    language?: string
-  ): Promise<TmdbSearchMultiResponse> => {
+  search: async ({ id, language }) => {
     const tmdb = new TheMovieDb();
 
     const moviePromise = tmdb.getMovie({ movieId: parseInt(id), language });
@@ -85,12 +88,8 @@ searchProviders.push({
 });
 
 searchProviders.push({
-  id: 'IMDb',
   pattern: new RegExp(/(?<=imdb:)(tt|nm)\d+/),
-  search: async (
-    id: string,
-    language?: string
-  ): Promise<TmdbSearchMultiResponse> => {
+  search: async ({ id, language }) => {
     const tmdb = new TheMovieDb();
 
     const responses = await tmdb.getByExternalId({
@@ -127,12 +126,8 @@ searchProviders.push({
 });
 
 searchProviders.push({
-  id: 'TVDB',
   pattern: new RegExp(/(?<=tvdb:)\d+/),
-  search: async (
-    id: string,
-    language?: string
-  ): Promise<TmdbSearchMultiResponse> => {
+  search: async ({ id, language }) => {
     const tmdb = new TheMovieDb();
 
     const responses = await tmdb.getByExternalId({
@@ -158,6 +153,54 @@ searchProviders.push({
         media_type: 'person',
       })) as TmdbPersonResult[])
     );
+
+    return {
+      page: 1,
+      total_pages: 1,
+      total_results: results.length,
+      results,
+    };
+  },
+});
+
+searchProviders.push({
+  pattern: new RegExp(/(?<=year:)\d+/),
+  search: async ({ id: year, query }) => {
+    const tmdb = new TheMovieDb();
+
+    const moviesPromise = tmdb.searchMovies({
+      query: query?.replace(new RegExp(/year:\d+/), '') ?? '',
+      year: parseInt(year),
+    });
+    const tvShowsPromise = tmdb.searchTvShows({
+      query: query?.replace(new RegExp(/year:\d+/), '') ?? '',
+      year: parseInt(year),
+    });
+
+    const responses = await Promise.allSettled([moviesPromise, tvShowsPromise]);
+
+    const successfulResponses = responses.filter(
+      (r) => r.status === 'fulfilled'
+    ) as
+      | (
+          | PromiseFulfilledResult<TmdbSearchMovieResponse>
+          | PromiseFulfilledResult<TmdbSearchTvResponse>
+        )[];
+
+    const results: (TmdbMovieResult | TmdbTvResult)[] = [];
+
+    if (successfulResponses.length) {
+      successfulResponses.forEach((response) => {
+        response.value.results.forEach((result) =>
+          // set the media_type here since the search endpoints don't return it
+          results.push(
+            isMovie(result)
+              ? { ...result, media_type: 'movie' }
+              : { ...result, media_type: 'tv' }
+          )
+        );
+      });
+    }
 
     return {
       page: 1,

--- a/server/lib/search.ts
+++ b/server/lib/search.ts
@@ -164,16 +164,16 @@ searchProviders.push({
 });
 
 searchProviders.push({
-  pattern: new RegExp(/(?<=year:)\d+/),
+  pattern: new RegExp(/(?<=year:)\d{4}/),
   search: async ({ id: year, query }) => {
     const tmdb = new TheMovieDb();
 
     const moviesPromise = tmdb.searchMovies({
-      query: query?.replace(new RegExp(/year:\d+/), '') ?? '',
+      query: query?.replace(new RegExp(/year:\d{4}/), '') ?? '',
       year: parseInt(year),
     });
     const tvShowsPromise = tmdb.searchTvShows({
-      query: query?.replace(new RegExp(/year:\d+/), '') ?? '',
+      query: query?.replace(new RegExp(/year:\d{4}/), '') ?? '',
       year: parseInt(year),
     });
 

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -18,11 +18,11 @@ searchRoutes.get('/', async (req, res, next) => {
       const [id] = queryString
         .toLowerCase()
         .match(searchProvider.pattern) as RegExpMatchArray;
-    results = await searchProvider.search({
-      id,
-      language: req.locale ?? (req.query.language as string),
-      query: queryString,
-    });
+      results = await searchProvider.search({
+        id,
+        language: req.locale ?? (req.query.language as string),
+        query: queryString,
+      });
     } else {
       const tmdb = new TheMovieDb();
 

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -18,10 +18,11 @@ searchRoutes.get('/', async (req, res, next) => {
       const [id] = queryString
         .toLowerCase()
         .match(searchProvider.pattern) as RegExpMatchArray;
-      results = await searchProvider.search(
-        id,
-        req.locale ?? (req.query.language as string)
-      );
+    results = await searchProvider.search({
+      id,
+      language: req.locale ?? (req.query.language as string),
+      query: queryString,
+    });
     } else {
       const tmdb = new TheMovieDb();
 


### PR DESCRIPTION
#### Description

Similarly to #2082, this adds the ability to make a search for "chris year:2005" and only get results (movies & shows) that were released in the year 2005 and have "chris" in the title.
Also removed the `SearchProvider`'s IDs since they weren't of any use.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
