### PR TITLE
docs: add missing param to reset password endpoint

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -3162,6 +3162,13 @@ paths:
       security: []
       tags:
         - users
+      parameters:
+        - in: path
+          name: guid
+          required: true
+          schema:
+            type: number
+            example: 1
       responses:
         '200':
           description: OK


### PR DESCRIPTION
#### Description

This adds the missing parameter `guid` in the openapi spec for the `/auth/reset-password/{guid}` endpoint.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
