### PR TITLE
fix(radarr): correctly check for existing movies

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -27,7 +27,6 @@ export interface RadarrMovie {
   profileId: number;
   qualityProfileId: number;
   added: string;
-  downloaded: boolean;
   hasFile: boolean;
 }
 
@@ -85,7 +84,7 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
     try {
       const movie = await this.getMovieByTmdbId(options.tmdbId);
 
-      if (movie.downloaded) {
+      if (movie.hasFile) {
         logger.info(
           'Title already exists and is available. Skipping add and returning success',
           {

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -73,7 +73,7 @@ class RadarrScanner
   }
 
   private async processRadarrMovie(radarrMovie: RadarrMovie): Promise<void> {
-    if (!radarrMovie.monitored && !radarrMovie.downloaded) {
+    if (!radarrMovie.monitored && !radarrMovie.hasFile) {
       this.log(
         'Title is unmonitored and has not been downloaded. Skipping item.',
         'debug',
@@ -92,7 +92,7 @@ class RadarrScanner
         externalServiceId: radarrMovie.id,
         externalServiceSlug: radarrMovie.titleSlug,
         title: radarrMovie.title,
-        processing: !radarrMovie.downloaded,
+        processing: !radarrMovie.hasFile,
       });
     } catch (e) {
       this.log('Failed to process Radarr media', 'error', {


### PR DESCRIPTION
#### Description

This uses the `hasFile` property instead of the `downloaded` property to check if a movie is available in Radarr.
I'm not sure when the `downloaded` property has been deprecated, but I can't seem to find references to it from a quick search on the Radarr repo. 

Reference: [`getMovie`](https://radarr.video/docs/api/#/Movie/getMovie).

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
