### PR TITLE
chore: gitignore gzipped JSON logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ config/settings.json
 config/logs/*.log*
 config/logs/*.json
 config/logs/*.log.gz
+config/logs/*.json.gz
 config/logs/*-audit.json
 
 # anidb mapping file


### PR DESCRIPTION
#### Description

Was working on some changes today and noticed a gzipped JSON log that wasn't ignored by `git`.  I believe we are only supposed to retain a single JSON log file though, so this shouldn't affect prod envs where Overseerr is running when the log rotation happens.

#### Screenshot (if UI-related)

N/A

#### To-Dos

N/A

#### Issues Fixed or Closed

N/A