### PR TITLE
fix(sonarr): monitor existing series upon request approval

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -149,6 +149,7 @@ class SonarrAPI extends ServarrBase<{ seriesId: number; episodeId: number }> {
 
       // If the series already exists, we will simply just update it
       if (series.id) {
+        series.monitored = options.monitored ?? series.monitored;
         series.tags = options.tags ?? series.tags;
         series.seasons = this.buildSeasonList(options.seasons, series.seasons);
 


### PR DESCRIPTION
#### Description

Existing series are not being monitored in Sonarr (only the requested seasons are) upon request approval.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes [issue reported on Discord](https://discord.com/channels/783137440809746482/785475034725482498/943513886970236958)