### PR TITLE
fix(frontend): disable autocomplete on search field

### DIFF
--- a/src/components/Layout/SearchInput/index.tsx
+++ b/src/components/Layout/SearchInput/index.tsx
@@ -27,6 +27,7 @@ const SearchInput: React.FC = () => {
             className="block w-full rounded-full border border-gray-600 bg-gray-900 bg-opacity-80 py-2 pl-10 text-white placeholder-gray-300 hover:border-gray-500 focus:border-gray-500 focus:bg-opacity-100 focus:placeholder-gray-400 focus:outline-none focus:ring-0 sm:text-base"
             placeholder={intl.formatMessage(messages.searchPlaceholder)}
             type="search"
+            autoComplete="off"
             value={searchValue}
             onChange={(e) => setSearchValue(e.target.value)}
             onFocus={() => setIsOpen(true)}


### PR DESCRIPTION
#### Description

Disables autocomplete on main search field.

Autocomplete can clutter the UI with your past searches which are no longer relevant.


#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
