### PR TITLE
perf(discovery): improve discovery first page performance above the fold

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "17.0.2",
     "react-intersection-observer": "^8.33.1",
     "react-intl": "5.24.6",
+    "react-lazy-hydration": "0.1.0",
     "react-markdown": "^8.0.0",
     "react-select": "^5.2.2",
     "react-spring": "^9.4.2",

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -2,6 +2,7 @@ import { ArrowCircleRightIcon } from '@heroicons/react/outline';
 import Link from 'next/link';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import LazyHydrate from 'react-lazy-hydration';
 import useSWR from 'swr';
 import type { MediaResultsResponse } from '../../../server/interfaces/api/mediaInterfaces';
 import type { RequestResultsResponse } from '../../../server/interfaces/api/requestInterfaces';
@@ -82,39 +83,49 @@ const Discover: React.FC = () => {
         placeholder={<RequestCard.Placeholder />}
         emptyMessage={intl.formatMessage(messages.noRequests)}
       />
-      <MediaSlider
-        sliderKey="trending"
-        title={intl.formatMessage(messages.trending)}
-        url="/api/v1/discover/trending"
-        linkUrl="/discover/trending"
-      />
-      <MediaSlider
-        sliderKey="popular-movies"
-        title={intl.formatMessage(messages.popularmovies)}
-        url="/api/v1/discover/movies"
-        linkUrl="/discover/movies"
-      />
+      <LazyHydrate whenVisible>
+        <MediaSlider
+          sliderKey="trending"
+          title={intl.formatMessage(messages.trending)}
+          url="/api/v1/discover/trending"
+          linkUrl="/discover/trending"
+        />
+      </LazyHydrate>
+      <LazyHydrate whenVisible>
+        <MediaSlider
+          sliderKey="popular-movies"
+          title={intl.formatMessage(messages.popularmovies)}
+          url="/api/v1/discover/movies"
+          linkUrl="/discover/movies"
+        />
+      </LazyHydrate>
       <MovieGenreSlider />
-      <MediaSlider
-        sliderKey="upcoming"
-        title={intl.formatMessage(messages.upcoming)}
-        linkUrl="/discover/movies/upcoming"
-        url="/api/v1/discover/movies/upcoming"
-      />
+      <LazyHydrate whenVisible>
+        <MediaSlider
+          sliderKey="upcoming"
+          title={intl.formatMessage(messages.upcoming)}
+          linkUrl="/discover/movies/upcoming"
+          url="/api/v1/discover/movies/upcoming"
+        />
+      </LazyHydrate>
       <StudioSlider />
-      <MediaSlider
-        sliderKey="popular-tv"
-        title={intl.formatMessage(messages.populartv)}
-        url="/api/v1/discover/tv"
-        linkUrl="/discover/tv"
-      />
+      <LazyHydrate whenVisible>
+        <MediaSlider
+          sliderKey="popular-tv"
+          title={intl.formatMessage(messages.populartv)}
+          url="/api/v1/discover/tv"
+          linkUrl="/discover/tv"
+        />
+      </LazyHydrate>
       <TvGenreSlider />
-      <MediaSlider
-        sliderKey="upcoming-tv"
-        title={intl.formatMessage(messages.upcomingtv)}
-        url="/api/v1/discover/tv/upcoming"
-        linkUrl="/discover/tv/upcoming"
-      />
+      <LazyHydrate whenVisible>
+        <MediaSlider
+          sliderKey="upcoming-tv"
+          title={intl.formatMessage(messages.upcomingtv)}
+          url="/api/v1/discover/tv/upcoming"
+          linkUrl="/discover/tv/upcoming"
+        />
+      </LazyHydrate>
       <NetworkSlider />
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,7 +973,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.16.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.16.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -9356,6 +9356,13 @@ react-is@^17.0.0:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-lazy-hydration@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/react-lazy-hydration/-/react-lazy-hydration-0.1.0.tgz#7ebca1b783d2a6b81360724704ec0c47b53611aa"
+  integrity sha512-TyQ55cxsvheS7ZGFH8zcrLrnfrpXy23wo0I0dtB3p3n8+VhpQE6vbULc7T8ikSOig2gbcS1CZUrti0U/8zZVZQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 react-markdown@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
#### Description

This change aims to improve discovery page performance by
only hydrating above the fold content. The general use case
for machines that load this page tend not to show anything below
"trending". This change leans on intersection observer to
lazy hydrate the page. This means that as the user scrolls through
the discovery page, the content below the fold (the unrendered part
of the app) will fire the SWR requests and fetch data.

This change is aimed to free up network congestion that stalls the page
render. A secondary improvement, not in this diff, is to play with
the Recently Requested component as that may also be slowing down page
load.

#### Screenshot (if UI-related)

Coming... (need to take before and after)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed
 N/A
