### PR TITLE
fix(plex): use unique client identifier

### DIFF
--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -39,7 +39,7 @@ class PlexOAuth {
     if (!clientId) {
       const uuid = crypto.randomUUID && crypto.randomUUID();
       if (!uuid) {
-        throw new Error('Could not generate client id');
+        throw new Error('Could not generate client ID');
       }
 
       localStorage.setItem('overseerrPlexClientId', uuid);

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -34,12 +34,24 @@ class PlexOAuth {
         'Window is not defined. Are you calling this in the browser?'
       );
     }
+
+    let clientId = localStorage.getItem('overseerrPlexClientId');
+    if (!clientId) {
+      const uuid = crypto.randomUUID && crypto.randomUUID();
+      if (!uuid) {
+        throw new Error('Could not generate client id');
+      }
+
+      localStorage.setItem('overseerrPlexClientId', uuid);
+      clientId = uuid;
+    }
+
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {
       Accept: 'application/json',
       'X-Plex-Product': 'Overseerr',
       'X-Plex-Version': '2.0',
-      'X-Plex-Client-Identifier': '7f9de3ba-e12b-11ea-87d0-0242ac130003',
+      'X-Plex-Client-Identifier': clientId,
       'X-Plex-Model': 'Plex OAuth',
       'X-Plex-Platform': browser.getOSName(),
       'X-Plex-Platform-Version': browser.getOSVersion(),


### PR DESCRIPTION
#### Description

As noted by SwiftPanda each client needs a unique identifier
https://discord.com/channels/783137440809746482/793885156569514046/950083089575583824

#### Screenshot (if UI-related)

Correctly shows up as to different clients in plex:
https://cln.sh/8WVXeHKYHsrbDqut0ycg

#### To-Dos

- [x] Successful build `yarn build`
