### PR TITLE
feat(discover): add Paramount+ to network slider

### DIFF
--- a/src/components/Discover/NetworkSlider/index.tsx
+++ b/src/components/Discover/NetworkSlider/index.tsx
@@ -111,6 +111,12 @@ const networks: Network[] = [
     url: '/discover/tv/network/16',
   },
   {
+    name: 'Paramount+',
+    image:
+      'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/fi83B1oztoS47xxcemFdPMhIzK.png',
+    url: '/discover/tv/network/4330',
+  },
+  {
     name: 'BBC One',
     image:
       'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/mVn7xESaTNmjBUyUtGNvDQd3CT1.png',


### PR DESCRIPTION
#### Description

Adds Paramount+ to the network slider. (@sct any thoughts on the position of it within the slider?)

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Closes #2521