### PR TITLE
fix(plex): correctly generate uuid for Safari

### DIFF
--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -20,6 +20,19 @@ export interface PlexPin {
   code: string;
 }
 
+const uuidv4 = (): string => {
+  return ((1e7).toString() + -1e3 + -4e3 + -8e3 + -1e11).replace(
+    /[018]/g,
+    function (c) {
+      return (
+        parseInt(c) ^
+        (window.crypto.getRandomValues(new Uint8Array(1))[0] &
+          (15 >> (parseInt(c) / 4)))
+      ).toString(16);
+    }
+  );
+};
+
 class PlexOAuth {
   private plexHeaders?: PlexHeaders;
 
@@ -37,11 +50,7 @@ class PlexOAuth {
 
     let clientId = localStorage.getItem('overseerrPlexClientId');
     if (!clientId) {
-      const uuid = crypto.randomUUID && crypto.randomUUID();
-      if (!uuid) {
-        throw new Error('Could not generate client ID');
-      }
-
+      const uuid = uuidv4();
       localStorage.setItem('overseerrPlexClientId', uuid);
       clientId = uuid;
     }


### PR DESCRIPTION
#### Description
This replaces the usage of `crypto.randomUUID` that's only available in version 15.4 of Safari that's still in Preview on MacOS with a function to generate a UUID, very much like [Tautulli does](https://github.com/Tautulli/Tautulli/blob/cfd1bf445f7f5332b9183d98ea8893f325c5ca92/data/interfaces/default/js/script.js#L605-L610).

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
