### PR TITLE
docs(notif): add missing link for gotify

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Email](using-overseerr/notifications/email.md)
   - [Web Push](using-overseerr/notifications/webpush.md)
   - [Discord](using-overseerr/notifications/discord.md)
+  - [Gotify](using-overseerr/notifications/gotify.md)
   - [LunaSea](using-overseerr/notifications/lunasea.md)
   - [Pushbullet](using-overseerr/notifications/pushbullet.md)
   - [Pushover](using-overseerr/notifications/pushover.md)


### PR DESCRIPTION
#### Description

On Gitbook, the link to the Gotify page would point to a markdown file in the repository instead of
the page on Gitbook.

#### Screenshot (if UI-related)
N/A

#### To-Dos
None

#### Issues Fixed or Closed

- Fixes none
