### PR TITLE
fix(auth): resolve local/password authentication issues

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -217,7 +217,7 @@ authRoutes.post('/local', async (req, res, next) => {
           account.$.email.toLowerCase() === user.email.toLowerCase()
       )?.$;
 
-      if (account) {
+      if (account && (await mainPlexTv.checkUserAccess(parseInt(account.id)))) {
         logger.info('Found matching Plex user; updating user with Plex data', {
           label: 'API',
           ip: req.ip,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -210,30 +210,43 @@ authRoutes.post('/local', async (req, res, next) => {
     const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
 
     if (!user.plexId) {
-      const plexUsersResponse = await mainPlexTv.getUsers();
-      const account = plexUsersResponse.MediaContainer.User.find(
-        (account) =>
-          account.$.email &&
-          account.$.email.toLowerCase() === user.email.toLowerCase()
-      )?.$;
+      try {
+        const plexUsersResponse = await mainPlexTv.getUsers();
+        const account = plexUsersResponse.MediaContainer.User.find(
+          (account) =>
+            account.$.email &&
+            account.$.email.toLowerCase() === user.email.toLowerCase()
+        )?.$;
 
-      if (account && (await mainPlexTv.checkUserAccess(parseInt(account.id)))) {
-        logger.info('Found matching Plex user; updating user with Plex data', {
+        if (
+          account &&
+          (await mainPlexTv.checkUserAccess(parseInt(account.id)))
+        ) {
+          logger.info(
+            'Found matching Plex user; updating user with Plex data',
+            {
+              label: 'API',
+              ip: req.ip,
+              email: body.email,
+              userId: user.id,
+              plexId: account.id,
+              plexUsername: account.username,
+            }
+          );
+
+          user.plexId = parseInt(account.id);
+          user.avatar = account.thumb;
+          user.email = account.email;
+          user.plexUsername = account.username;
+          user.userType = UserType.PLEX;
+
+          await userRepository.save(user);
+        }
+      } catch (e) {
+        logger.error('Something went wrong fetching Plex users', {
           label: 'API',
-          ip: req.ip,
-          email: body.email,
-          userId: user.id,
-          plexId: account.id,
-          plexUsername: account.username,
+          errorMessage: e.message,
         });
-
-        user.plexId = parseInt(account.id);
-        user.avatar = account.thumb;
-        user.email = account.email;
-        user.plexUsername = account.username;
-        user.userType = UserType.PLEX;
-
-        await userRepository.save(user);
       }
     }
 


### PR DESCRIPTION
#### Description

- Only upgrade user to Plex user after verifying server access (the returned list of users can include users without access to the linked server)
- Do not fail local auth if unable to fetch users from plex.tv

Unfortunately, in cases where users have already had their Plex IDs added to the DB, this will require manual modification of the DB, or deletion and recreation of the user.

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #2675
- Fixes #2676