### PR TITLE
fix(ui): don't show 0 playcount in slideover

### DIFF
--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -210,7 +210,7 @@ const ManageSlideOver: React.FC<
         {hasPermission(Permission.ADMIN) &&
           (data.mediaInfo?.serviceUrl ||
             data.mediaInfo?.tautulliUrl ||
-            watchData?.data?.playCount) && (
+            !!watchData?.data?.playCount) && (
             <div>
               <h3 className="mb-2 text-xl font-bold">
                 {intl.formatMessage(messages.manageModalMedia)}
@@ -325,7 +325,7 @@ const ManageSlideOver: React.FC<
         {hasPermission(Permission.ADMIN) &&
           (data.mediaInfo?.serviceUrl4k ||
             data.mediaInfo?.tautulliUrl4k ||
-            watchData?.data4k?.playCount) && (
+            !!watchData?.data4k?.playCount) && (
             <div>
               <h3 className="mb-2 text-xl font-bold">
                 {intl.formatMessage(messages.manageModalMedia4k)}


### PR DESCRIPTION
#### Description
The playcount being 0 was displayed above the "Advanced" heading instead of being coerced into a boolean and used to evaluate a condition.

#### Screenshot (if UI-related)
<img width="410" alt="Screen Shot 2022-04-25 at 10 21 55 PM" src="https://user-images.githubusercontent.com/20923978/165152188-1c2f3cf3-e2e0-4ee2-a0d5-6bfb91226973.png">

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
