### PR TITLE
fix(ui): replace Yup.url test with URL regex from RFC3986

### DIFF
--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -43,7 +43,10 @@ const NotificationsDiscord: React.FC = () => {
   const NotificationsDiscordSchema = Yup.object().shape({
     botAvatarUrl: Yup.string()
       .nullable()
-      .url(intl.formatMessage(messages.validationUrl)),
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationUrl)
+      ),
     webhookUrl: Yup.string()
       .when('enabled', {
         is: true,
@@ -52,7 +55,10 @@ const NotificationsDiscord: React.FC = () => {
           .required(intl.formatMessage(messages.validationUrl)),
         otherwise: Yup.string().nullable(),
       })
-      .url(intl.formatMessage(messages.validationUrl)),
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationUrl)
+      ),
   });
 
   if (!data && !error) {

--- a/src/components/Settings/Notifications/NotificationsLunaSea/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsLunaSea/index.tsx
@@ -46,7 +46,10 @@ const NotificationsLunaSea: React.FC = () => {
           .required(intl.formatMessage(messages.validationWebhookUrl)),
         otherwise: Yup.string().nullable(),
       })
-      .url(intl.formatMessage(messages.validationWebhookUrl)),
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationWebhookUrl)
+      ),
   });
 
   if (!data && !error) {

--- a/src/components/Settings/Notifications/NotificationsSlack/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsSlack/index.tsx
@@ -44,7 +44,10 @@ const NotificationsSlack: React.FC = () => {
           .required(intl.formatMessage(messages.validationWebhookUrl)),
         otherwise: Yup.string().nullable(),
       })
-      .url(intl.formatMessage(messages.validationWebhookUrl)),
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationWebhookUrl)
+      ),
   });
 
   if (!data && !error) {

--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -132,7 +132,10 @@ const RadarrModal: React.FC<RadarrModalProps> = ({
       intl.formatMessage(messages.validationMinimumAvailabilityRequired)
     ),
     externalUrl: Yup.string()
-      .url(intl.formatMessage(messages.validationApplicationUrl))
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationApplicationUrl)
+      )
       .test(
         'no-trailing-slash',
         intl.formatMessage(messages.validationApplicationUrlTrailingSlash),

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -79,7 +79,10 @@ const SettingsMain: React.FC = () => {
       intl.formatMessage(messages.validationApplicationTitle)
     ),
     applicationUrl: Yup.string()
-      .url(intl.formatMessage(messages.validationApplicationUrl))
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationApplicationUrl)
+      )
       .test(
         'no-trailing-slash',
         intl.formatMessage(messages.validationApplicationUrlTrailingSlash),

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -142,7 +142,10 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
       .required(intl.formatMessage(messages.validationPortRequired)),
     webAppUrl: Yup.string()
       .nullable()
-      .url(intl.formatMessage(messages.validationUrl)),
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationUrl)
+      ),
   });
 
   const TautulliSettingsSchema = Yup.object().shape(
@@ -188,7 +191,10 @@ const SettingsPlex: React.FC<SettingsPlexProps> = ({ onComplete }) => {
         otherwise: Yup.string().nullable(),
       }),
       tautulliExternalUrl: Yup.string()
-        .url(intl.formatMessage(messages.validationUrl))
+        .matches(
+          /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+          intl.formatMessage(messages.validationUrl)
+        )
         .test(
           'no-trailing-slash',
           intl.formatMessage(messages.validationUrlTrailingSlash),

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -140,7 +140,10 @@ const SonarrModal: React.FC<SonarrModalProps> = ({
       intl.formatMessage(messages.validationLanguageProfileRequired)
     ),
     externalUrl: Yup.string()
-      .url(intl.formatMessage(messages.validationApplicationUrl))
+      .matches(
+        /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
+        intl.formatMessage(messages.validationApplicationUrl)
+      )
       .test(
         'no-trailing-slash',
         intl.formatMessage(messages.validationApplicationUrlTrailingSlash),


### PR DESCRIPTION
#### Description
This replaces the `Yup.url()` validation checks with a regex check again `/^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/`, which is the `<‍input type="url" /‍>` regex from [IETF RFC3986](https://www.ietf.org/rfc/rfc3986.txt). This broadens the scope of the allowed urls, which for my specific use case, allows me to use [Tailscale's MagicDNS](https://tailscale.com/kb/1081/magicdns/), and also closes a number of other issues. It'd be nice if this could be addressed directly in Yup, as [it](https://github.com/jquense/yup/pull/1594) [seems](https://github.com/jquense/yup/issues/1271) [to](https://github.com/jquense/yup/issues/1492) [be](https://github.com/jquense/yup/issues/800) [a](https://github.com/jquense/yup/issues/794) [commonly](https://github.com/jquense/yup/pull/1619) [requested](https://github.com/jquense/yup/issues/672) [issue](https://github.com/jquense/yup/pull/1619), but in the meantime this should do the trick.

To use a more concrete example: the current validation fails on `http://my-server:7878`, when that should be a perfect usable URL.

#### Screenshot (if UI-related)
N/A (no point in showing this; this PR is simply a validation logic change and doesn't change any UI styling)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract` _no change_
- [ ] Database migration (if required) _not required_

#### Issues Fixed or Closed

- As far as I can tell, none aside from this
