### PR TITLE
fix(search): use correct param to filter movies by year

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -129,7 +129,13 @@ class TheMovieDb extends ExternalAPI {
   }: SingleSearchOptions): Promise<TmdbSearchMovieResponse> => {
     try {
       const data = await this.get<TmdbSearchMovieResponse>('/search/movie', {
-        params: { query, page, include_adult: includeAdult, language, year },
+        params: {
+          query,
+          page,
+          include_adult: includeAdult,
+          language,
+          primary_release_year: year,
+        },
       });
 
       return data;


### PR DESCRIPTION
#### Description

This fix changes the movie search API call to use the `primary_release_year` query param instead of the `year` param since the later would return movies not initially released in the year specified.

#### Screenshot (if UI-related)
Before: 
![image](https://user-images.githubusercontent.com/20923978/166107886-4638ad26-0eb8-4908-be81-61fbb5890d18.png)

After:
![image](https://user-images.githubusercontent.com/20923978/166107893-3417c330-4577-4f86-8acb-2d42c1bd159a.png)




#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
