### PR TITLE
Fix/recommendations scroll

### DIFF
--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import { MediaStatus } from '../../server/constants/media';
 import useSettings from './useSettings';
@@ -66,13 +65,9 @@ const useDiscover = <T extends BaseMedia, S = Record<string, never>>(
       typeof data[size - 1] === 'undefined' &&
       isValidating);
 
-  const fetchMore = useCallback(() => {
-    if (!!data && (data[data?.length - 1]?.totalResults ?? 0) > 40) {
-      setSize((size) => {
-        return size + 1;
-      });
-    }
-  }, [data, setSize]);
+  const fetchMore = () => {
+    setSize(size + 1);
+  };
 
   let titles = (data ?? []).reduce((a, v) => [...a, ...v.results], [] as T[]);
 
@@ -87,7 +82,9 @@ const useDiscover = <T extends BaseMedia, S = Record<string, never>>(
 
   const isEmpty = !isLoadingInitialData && titles?.length === 0;
   const isReachingEnd =
-    isEmpty || (!!data && (data[data?.length - 1]?.results.length ?? 0) < 20);
+    isEmpty ||
+    (!!data && (data[data?.length - 1]?.results.length ?? 0) < 20) ||
+    (!!data && (data[data?.length - 1]?.totalResults ?? 0) < 41);
 
   return {
     isLoadingInitialData,

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import { MediaStatus } from '../../server/constants/media';
 import useSettings from './useSettings';
@@ -65,9 +66,13 @@ const useDiscover = <T extends BaseMedia, S = Record<string, never>>(
       typeof data[size - 1] === 'undefined' &&
       isValidating);
 
-  const fetchMore = () => {
-    setSize(size + 1);
-  };
+  const fetchMore = useCallback(() => {
+    if (!!data && (data[data?.length - 1]?.totalResults ?? 0) > 40) {
+      setSize((size) => {
+        return size + 1;
+      });
+    }
+  }, [data, setSize]);
 
   let titles = (data ?? []).reduce((a, v) => [...a, ...v.results], [] as T[]);
 


### PR DESCRIPTION
#### Description
TMDB API limits the total results for recommendations to 40. This would cause an infinite amount of network requests on the recommendations page as it was expecting a higher number of results. The API will now only be called if the total results is greater than 40.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #2710 
