### PR TITLE
feat(manage slideover): show more request override details

### DIFF
--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -26,6 +26,7 @@ const messages = defineMessages({
   server: 'Destination Server',
   profilechanged: 'Quality Profile',
   rootfolder: 'Root Folder',
+  languageprofile: 'Language Profile',
 });
 
 interface RequestBlockProps {
@@ -38,7 +39,8 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
   const intl = useIntl();
   const [isUpdating, setIsUpdating] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
-  const { profile, rootFolder, server } = useRequestOverride(request);
+  const { profile, rootFolder, server, languageProfile } =
+    useRequestOverride(request);
 
   const updateRequest = async (type: 'approve' | 'decline'): Promise<void> => {
     setIsUpdating(true);
@@ -237,6 +239,14 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                     {intl.formatMessage(messages.rootfolder)}
                   </span>
                   <span>{rootFolder}</span>
+                </li>
+              )}
+              {languageProfile && (
+                <li className="flex justify-between px-1 py-2">
+                  <span className="mr-2 font-bold">
+                    {intl.formatMessage(messages.languageprofile)}
+                  </span>
+                  <span>ID {languageProfile}</span>
                 </li>
               )}
             </ul>

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -211,7 +211,7 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
             </div>
           </div>
         )}
-        {(server || profile !== null || rootFolder) && (
+        {(server || profile || rootFolder || languageProfile) && (
           <>
             <div className="mt-4 mb-1 text-sm">
               {intl.formatMessage(messages.requestoverrides)}
@@ -225,12 +225,12 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                   <span>{server}</span>
                 </li>
               )}
-              {profile !== null && (
+              {profile && (
                 <li className="flex justify-between px-1 py-2">
                   <span className="font-bold">
                     {intl.formatMessage(messages.profilechanged)}
                   </span>
-                  <span>ID {profile}</span>
+                  <span>{profile}</span>
                 </li>
               )}
               {rootFolder && (
@@ -246,7 +246,7 @@ const RequestBlock: React.FC<RequestBlockProps> = ({ request, onUpdate }) => {
                   <span className="mr-2 font-bold">
                     {intl.formatMessage(messages.languageprofile)}
                   </span>
-                  <span>ID {languageProfile}</span>
+                  <span>{languageProfile}</span>
                 </li>
               )}
             </ul>

--- a/src/hooks/useRequestOverride.ts
+++ b/src/hooks/useRequestOverride.ts
@@ -6,6 +6,7 @@ interface OverrideStatus {
   server: string | null;
   profile: number | null;
   rootFolder: string | null;
+  languageProfile: number | null;
 }
 
 const useRequestOverride = (request: MediaRequest): OverrideStatus => {
@@ -18,6 +19,7 @@ const useRequestOverride = (request: MediaRequest): OverrideStatus => {
       server: null,
       profile: null,
       rootFolder: null,
+      languageProfile: null,
     };
   }
 
@@ -39,6 +41,11 @@ const useRequestOverride = (request: MediaRequest): OverrideStatus => {
     rootFolder:
       defaultServer?.activeDirectory !== request.rootFolder
         ? request.rootFolder
+        : null,
+    languageProfile:
+      request.type === 'tv' &&
+      defaultServer?.activeLanguageProfileId !== request.languageProfileId
+        ? request.languageProfileId
         : null,
   };
 };

--- a/src/hooks/useRequestOverride.ts
+++ b/src/hooks/useRequestOverride.ts
@@ -1,52 +1,61 @@
 import useSWR from 'swr';
 import { MediaRequest } from '../../server/entity/MediaRequest';
-import { ServiceCommonServer } from '../../server/interfaces/api/serviceInterfaces';
+import {
+  ServiceCommonServer,
+  ServiceCommonServerWithDetails,
+} from '../../server/interfaces/api/serviceInterfaces';
 
 interface OverrideStatus {
-  server: string | null;
-  profile: number | null;
-  rootFolder: string | null;
-  languageProfile: number | null;
+  server?: string;
+  profile?: string;
+  rootFolder?: string;
+  languageProfile?: string;
 }
 
 const useRequestOverride = (request: MediaRequest): OverrideStatus => {
-  const { data } = useSWR<ServiceCommonServer[]>(
+  const { data: allServers } = useSWR<ServiceCommonServer[]>(
     `/api/v1/service/${request.type === 'movie' ? 'radarr' : 'sonarr'}`
   );
 
-  if (!data) {
-    return {
-      server: null,
-      profile: null,
-      rootFolder: null,
-      languageProfile: null,
-    };
+  const { data } = useSWR<ServiceCommonServerWithDetails>(
+    `/api/v1/service/${request.type === 'movie' ? 'radarr' : 'sonarr'}/${
+      request.serverId
+    }`
+  );
+
+  if (!data || !allServers) {
+    return {};
   }
 
-  const defaultServer = data.find(
+  const defaultServer = allServers.find(
     (server) => server.is4k === request.is4k && server.isDefault
   );
 
-  const activeServer = data.find((server) => server.id === request.serverId);
+  const activeServer = allServers.find(
+    (server) => server.id === request.serverId
+  );
 
   return {
     server:
       activeServer && request.serverId !== defaultServer?.id
         ? activeServer.name
-        : null,
+        : undefined,
     profile:
       defaultServer?.activeProfileId !== request.profileId
-        ? request.profileId
-        : null,
+        ? data.profiles.find((profile) => profile.id === request.profileId)
+            ?.name
+        : undefined,
     rootFolder:
       defaultServer?.activeDirectory !== request.rootFolder
         ? request.rootFolder
-        : null,
+        : undefined,
     languageProfile:
       request.type === 'tv' &&
       defaultServer?.activeLanguageProfileId !== request.languageProfileId
-        ? request.languageProfileId
-        : null,
+        ? data.languageProfiles?.find(
+            (profile) => profile.id === request.languageProfileId
+          )?.name
+        : undefined,
   };
 };
 

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -269,6 +269,7 @@
   "components.QuotaSelector.unlimited": "Unlimited",
   "components.RegionSelector.regionDefault": "All Regions",
   "components.RegionSelector.regionServerDefault": "Default ({region})",
+  "components.RequestBlock.languageprofile": "Language Profile",
   "components.RequestBlock.profilechanged": "Quality Profile",
   "components.RequestBlock.requestoverrides": "Request Overrides",
   "components.RequestBlock.rootfolder": "Root Folder",


### PR DESCRIPTION
#### Description

This adds the missing language profile overrides for TV shows and displays the names of the quality profile/language profile overrides for the request instead of their ID.

#### Screenshot (if UI-related)
Example:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/20923978/169721719-ed2f23dd-1814-45bf-bc49-3ee00a868494.png">


#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #2757
