### PR TITLE
fix(api): lookup show using english title whenever possible

### DIFF
--- a/server/routes/service.ts
+++ b/server/routes/service.ts
@@ -194,7 +194,9 @@ serviceRoutes.get<{ tmdbId: string }>(
         language: req.locale ?? (req.query.language as string),
       });
 
-      const response = await sonarr.getSeriesByTitle(tv.name);
+      const response = await sonarr.getSeriesByTitle(
+        tv.original_language === 'en' ? tv.original_name : tv.name
+      );
 
       return res.status(200).json(response);
     } catch (e) {


### PR DESCRIPTION
#### Description

Looking up a show that has a missing TVDB ID from Sonarr seems to very rarely yield relevant results when searching with a non-english title compared to with an english title, regardless of whether the show uses english as it's main spoken language or not. This makes the Sonarr show lookup use the english title whenever available.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #2801
