### PR TITLE
fix(api): use correct path param type in openapi spec

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -3170,8 +3170,8 @@ paths:
           name: guid
           required: true
           schema:
-            type: number
-            example: 1
+            type: string
+            example: '9afef5a7-ec89-4d5f-9397-261e96970b50'
       responses:
         '200':
           description: OK


### PR DESCRIPTION
#### Description

Attempting to reset a password is met with a 400 error ("request.params.guid should be number") thrown by the OpenAPI validator middleware because the spec expects a number as the `guid` but a string is used instead.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #2864
