### PR TITLE
fix: update Discord ID regex to include 19 digit IDs

### DIFF
--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -80,7 +80,7 @@ const UserGeneralSettings: React.FC = () => {
   const UserGeneralSettingsSchema = Yup.object().shape({
     discordId: Yup.string()
       .nullable()
-      .matches(/^\d{17,18,19}$/, intl.formatMessage(messages.validationDiscordId)),
+      .matches(/^\d{17,19}$/, intl.formatMessage(messages.validationDiscordId)),
   });
 
   useEffect(() => {

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -80,7 +80,7 @@ const UserGeneralSettings: React.FC = () => {
   const UserGeneralSettingsSchema = Yup.object().shape({
     discordId: Yup.string()
       .nullable()
-      .matches(/^\d{17,18}$/, intl.formatMessage(messages.validationDiscordId)),
+      .matches(/^\d{17,18,19}$/, intl.formatMessage(messages.validationDiscordId)),
   });
 
   useEffect(() => {

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
@@ -46,7 +46,7 @@ const UserNotificationsDiscord: React.FC = () => {
           .required(intl.formatMessage(messages.validationDiscordId)),
         otherwise: Yup.string().nullable(),
       })
-      .matches(/^\d{17,18}$/, intl.formatMessage(messages.validationDiscordId)),
+      .matches(/^\d{17,18,19}$/, intl.formatMessage(messages.validationDiscordId)),
   });
 
   if (!data && !error) {

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
@@ -46,7 +46,7 @@ const UserNotificationsDiscord: React.FC = () => {
           .required(intl.formatMessage(messages.validationDiscordId)),
         otherwise: Yup.string().nullable(),
       })
-      .matches(/^\d{17,18,19}$/, intl.formatMessage(messages.validationDiscordId)),
+      .matches(/^\d{17,19}$/, intl.formatMessage(messages.validationDiscordId)),
   });
 
   if (!data && !error) {


### PR DESCRIPTION
#### Description
From July 22 onwards, new Discord accounts will have 19 digit Discord IDs (https://snowsta.mp/?l=en-us&z=6&f=atx10uuark-7ps), this is similar to #971 in terms of how it changes the regex.

#### Screenshot (if UI-related)
NA

#### To-Dos
NA

#### Issues Fixed or Closed
No such issue reported yet as the bug could only occur after July 22 at the earliest
