### PR TITLE
fix(api): add rate limiter to TMDb requests to hopefully deal with 429s

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tanem/react-nprogress": "^4.0.10",
     "ace-builds": "^1.4.14",
     "axios": "^0.26.1",
+    "axios-rate-limit": "^1.3.0",
     "bcrypt": "^5.0.1",
     "bowser": "^2.11.0",
     "connect-typeorm": "^1.1.4",

--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import rateLimit from 'axios-rate-limit';
 import NodeCache from 'node-cache';
 
 // 5 minute default TTL (in seconds)
@@ -10,6 +11,10 @@ const DEFAULT_ROLLING_BUFFER = 10000;
 interface ExternalAPIOptions {
   nodeCache?: NodeCache;
   headers?: Record<string, unknown>;
+  rateLimit?: {
+    maxRPS: number;
+    maxRequests: number;
+  };
 }
 
 class ExternalAPI {
@@ -31,6 +36,14 @@ class ExternalAPI {
         ...options.headers,
       },
     });
+
+    if (options.rateLimit) {
+      this.axios = rateLimit(this.axios, {
+        maxRequests: options.rateLimit.maxRequests,
+        maxRPS: options.rateLimit.maxRPS,
+      });
+    }
+
     this.baseUrl = baseUrl;
     this.cache = options.nodeCache;
   }

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -92,6 +92,10 @@ class TheMovieDb extends ExternalAPI {
       },
       {
         nodeCache: cacheManager.getCache('tmdb').data,
+        rateLimit: {
+          maxRequests: 20,
+          maxRPS: 1,
+        },
       }
     );
     this.region = region;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,6 +3256,11 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios-rate-limit@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz#03241d24c231c47432dab6e8234cfde819253c2e"
+  integrity sha512-cKR5wTbU/CeeyF1xVl5hl6FlYsmzDVqxlN4rGtfO5x7J83UxKDckudsW0yW21/ZJRcO0Qrfm3fUFbhEbWTLayw==
+
 axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"


### PR DESCRIPTION
#### Description

Trying to reduce the number of 429s we have recently been experiencing from TMDb with a rate limit on outbound TMDb requests.

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2853
