### PR TITLE
Availability sync job

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -1,7 +1,7 @@
 import logger from '../../logger';
 import ServarrBase from './base';
 
-interface SonarrSeason {
+export interface SonarrSeason {
   seasonNumber: number;
   monitored: boolean;
   statistics?: {

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -1,0 +1,317 @@
+import { getRepository } from 'typeorm';
+import Media from '../entity/Media';
+import { MediaStatus } from '../constants/media';
+import { User } from '../entity/User';
+import type { PlexMetadata } from '../api/plexapi';
+import PlexAPI from '../api/plexapi';
+import logger from '../logger';
+import Season from '../entity/Season';
+import RadarrAPI from '../api/servarr/radarr';
+import type { RadarrSettings, SonarrSettings } from './settings';
+import { getSettings } from './settings';
+import type { SonarrSeason } from '../api/servarr/sonarr';
+import SonarrAPI from '../api/servarr/sonarr';
+
+class AvailabilitySync {
+  public running = false;
+  private plexClient: PlexAPI;
+  private plexSeasonsCache: Record<string, PlexMetadata[]> = {};
+  private sonarrSeasonsCache: Record<string, SonarrSeason[]> = {};
+  private radarrServers: RadarrSettings[];
+  private sonarrServers: SonarrSettings[];
+
+  async run() {
+    const settings = getSettings();
+    this.running = true;
+    this.plexSeasonsCache = {};
+    this.sonarrSeasonsCache = {};
+    this.radarrServers = settings.radarr.filter((server) => server.syncEnabled);
+    this.sonarrServers = settings.sonarr.filter((server) => server.syncEnabled);
+    await this.initPlexClient();
+
+    if (!this.plexClient) {
+      return;
+    }
+
+    logger.debug(`Starting availability sync...`, {
+      label: 'AvailabilitySync',
+    });
+
+    try {
+      const mediaRepository = getRepository(Media);
+      const seasonRepository = getRepository(Season);
+      const availableMedia = await mediaRepository.find({
+        where: [
+          {
+            status: MediaStatus.AVAILABLE,
+          },
+          {
+            status: MediaStatus.PARTIALLY_AVAILABLE,
+          },
+          {
+            status4k: MediaStatus.AVAILABLE,
+          },
+          {
+            status4k: MediaStatus.PARTIALLY_AVAILABLE,
+          },
+        ],
+      });
+
+      for (const media of availableMedia) {
+        if (!this.running) {
+          throw new Error('Job aborted');
+        }
+
+        const mediaExists = await this.mediaExists(media);
+
+        if (!mediaExists) {
+          logger.debug(
+            `Removing media id: ${media.tmdbId} because it doesn't appear in any of the libraries anymore`,
+            {
+              label: 'AvailabilitySync',
+            }
+          );
+          await mediaRepository.delete(media.id);
+          continue;
+        }
+
+        if (media.mediaType === 'tv') {
+          // ok, the show itself exists, but do all it's seasons?
+
+          const seasons = await seasonRepository.find({
+            where: [
+              { media, status: MediaStatus.AVAILABLE },
+              { media, status4k: MediaStatus.AVAILABLE },
+            ],
+          });
+
+          let didDeleteSeasons = false;
+          for (const season of seasons) {
+            const seasonExists = await this.seasonExists(media, season);
+
+            if (!seasonExists) {
+              logger.debug(
+                `Removing ${season.seasonNumber} for media id: ${media.tmdbId} because it doesn't appear in any of the libraries anymore`,
+                {
+                  label: 'AvailabilitySync',
+                }
+              );
+              await seasonRepository.delete(season.id);
+              didDeleteSeasons = true;
+            }
+          }
+
+          if (didDeleteSeasons) {
+            if (
+              media.status === MediaStatus.AVAILABLE ||
+              media.status4k === MediaStatus.AVAILABLE
+            ) {
+              logger.debug(
+                `Marking media id: ${media.tmdbId} as PARTIALLY_AVAILABLE because we deleted some of it's seasons`,
+                {
+                  label: 'AvailabilitySync',
+                }
+              );
+              if (media.status === MediaStatus.AVAILABLE) {
+                await mediaRepository.update(media.id, {
+                  status: MediaStatus.PARTIALLY_AVAILABLE,
+                });
+              }
+              if (media.status4k === MediaStatus.AVAILABLE) {
+                await mediaRepository.update(media.id, {
+                  status4k: MediaStatus.PARTIALLY_AVAILABLE,
+                });
+              }
+            }
+          }
+        }
+      }
+    } catch (ex) {
+      logger.error('Failed to complete availability sync', {
+        errorMessage: ex.message,
+        label: 'AvailabilitySync',
+      });
+    } finally {
+      logger.debug(`Availability sync complete`, {
+        label: 'AvailabilitySync',
+      });
+      this.running = false;
+    }
+  }
+
+  private async mediaExists(media: Media): Promise<boolean> {
+    if (await this.mediaExistsInPlex(media)) {
+      return true;
+    }
+
+    if (media.mediaType === 'movie') {
+      const existsInRadarr = await this.mediaExistsInRadarr(media);
+      if (existsInRadarr) {
+        logger.warn(
+          `${media.tmdbId} exists in radarr (${media.serviceUrl}) but is missing from plex, so we'll assume it's still supposed to exist.`,
+          {
+            label: 'AvailabilitySync',
+          }
+        );
+        return true;
+      }
+    }
+
+    if (media.mediaType === 'tv') {
+      const existsInSonarr = await this.mediaExistsInSonarr(media);
+      if (existsInSonarr) {
+        logger.warn(
+          `${media.tvdbId} exists in sonarr (${media.serviceUrl}) but is missing from plex, so we'll assume it's still supposed to exist.`,
+          {
+            label: 'AvailabilitySync',
+          }
+        );
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async seasonExists(media: Media, season: Season): Promise<boolean> {
+    if (await this.seasonExistsInPlex(media, season)) {
+      return true;
+    }
+
+    const existsInSonarr = await this.seasonExistsInSonarr(media, season);
+    if (existsInSonarr) {
+      logger.warn(
+        `${media.tvdbId}, season: ${season.seasonNumber} exists in sonarr (${media.serviceUrl}) but is missing from plex, so we'll assume it's still supposed to exist.`,
+        {
+          label: 'AvailabilitySync',
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private async mediaExistsInRadarr(media: Media): Promise<boolean> {
+    for (const server of this.radarrServers) {
+      const api = new RadarrAPI({
+        apiKey: server.apiKey,
+        url: RadarrAPI.buildUrl(server, '/api/v3'),
+      });
+      const meta = await api.getMovieByTmdbId(media.tmdbId);
+      if (meta.id) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private async mediaExistsInSonarr(media: Media): Promise<boolean> {
+    if (!media.tvdbId) {
+      return false;
+    }
+
+    for (const server of this.sonarrServers) {
+      const api = new SonarrAPI({
+        apiKey: server.apiKey,
+        url: SonarrAPI.buildUrl(server, '/api/v3'),
+      });
+      const meta = await api.getSeriesByTvdbId(media.tvdbId);
+      this.sonarrSeasonsCache[`${server.id}-${media.tvdbId}`] = meta.seasons;
+      if (meta.id && meta.monitored) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private async mediaExistsInPlex(media: Media): Promise<boolean> {
+    const ratingKey = media.ratingKey ?? media.ratingKey4k;
+
+    if (!ratingKey) {
+      return false;
+    }
+
+    try {
+      const meta = await this.plexClient?.getMetadata(ratingKey);
+      return !!meta;
+    } catch (ex) {
+      // TODO: oof, not the nicest way of handling this, but plex-api does not leave us with any other options...
+      if (!ex.message.includes('response code: 404')) {
+        throw ex;
+      }
+
+      return false;
+    }
+  }
+
+  private async seasonExistsInPlex(media: Media, season: Season) {
+    const ratingKey = media.ratingKey ?? media.ratingKey4k;
+
+    if (!ratingKey) {
+      return false;
+    }
+
+    const children =
+      this.plexSeasonsCache[ratingKey] ??
+      (await this.plexClient?.getChildrenMetadata(ratingKey)) ??
+      [];
+    this.plexSeasonsCache[ratingKey] = children;
+
+    const seasonMeta = children.find(
+      (child) => child.index === season.seasonNumber
+    );
+
+    return !!seasonMeta;
+  }
+
+  private async seasonExistsInSonarr(media: Media, season: Season) {
+    if (!media.tvdbId) {
+      return false;
+    }
+
+    for (const server of this.sonarrServers) {
+      const api = new SonarrAPI({
+        apiKey: server.apiKey,
+        url: SonarrAPI.buildUrl(server, '/api/v3'),
+      });
+      const seasons =
+        this.sonarrSeasonsCache[`${server.id}-${media.tvdbId}`] ??
+        (await api.getSeriesByTvdbId(media.tvdbId)).seasons;
+      this.sonarrSeasonsCache[`${server.id}-${media.tvdbId}`] = seasons;
+
+      const hasMonitoredSeason = seasons.find(
+        ({ monitored, seasonNumber }) =>
+          monitored && season.seasonNumber === seasonNumber
+      );
+      if (hasMonitoredSeason) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async initPlexClient() {
+    const userRepository = getRepository(User);
+    const admin = await userRepository.findOne({
+      select: ['id', 'plexToken'],
+      order: { id: 'ASC' },
+    });
+
+    if (!admin) {
+      logger.warning(
+        'No plex admin configured. Availability sync will not be ran'
+      );
+      return;
+    }
+
+    this.plexClient = new PlexAPI({ plexToken: admin.plexToken });
+  }
+
+  public cancel() {
+    this.running = false;
+  }
+}
+
+const availabilitySync = new AvailabilitySync();
+export default availabilitySync;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -246,7 +246,8 @@ export type JobId =
   | 'radarr-scan'
   | 'sonarr-scan'
   | 'download-sync'
-  | 'download-sync-reset';
+  | 'download-sync-reset'
+  | 'availability-sync';
 
 interface AllSettings {
   clientId: string;
@@ -403,6 +404,9 @@ class Settings {
         },
         'sonarr-scan': {
           schedule: '0 30 4 * * *',
+        },
+        'availability-sync': {
+          schedule: '0 0 5 * * *',
         },
         'download-sync': {
           schedule: '0 * * * * *',

--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -47,6 +47,7 @@ const messages: { [messageName: string]: MessageDescriptor } = defineMessages({
   unknownJob: 'Unknown Job',
   'plex-recently-added-scan': 'Plex Recently Added Scan',
   'plex-full-scan': 'Plex Full Library Scan',
+  'availability-sync': 'Media availability sync',
   'radarr-scan': 'Radarr Scan',
   'sonarr-scan': 'Sonarr Scan',
   'download-sync': 'Download Sync',

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -581,6 +581,7 @@
   "components.Settings.SettingsAbout.totalrequests": "Total Requests",
   "components.Settings.SettingsAbout.uptodate": "Up to Date",
   "components.Settings.SettingsAbout.version": "Version",
+  "components.Settings.SettingsJobsCache.availability-sync": "Media availability sync",
   "components.Settings.SettingsJobsCache.cache": "Cache",
   "components.Settings.SettingsJobsCache.cacheDescription": "Overseerr caches requests to external API endpoints to optimize performance and avoid making unnecessary API calls.",
   "components.Settings.SettingsJobsCache.cacheflushed": "{cachename} cache flushed.",

--- a/src/i18n/locale/nl.json
+++ b/src/i18n/locale/nl.json
@@ -566,6 +566,7 @@
   "components.Settings.SettingsJobsCache.radarr-scan": "Radarr-scan",
   "components.Settings.SettingsJobsCache.plex-recently-added-scan": "Plex recent toegevoegde scan",
   "components.Settings.SettingsJobsCache.plex-full-scan": "Plex volledige bibliotheekscan",
+  "components.Settings.SettingsJobsCache.availability-sync": "Volledige beschikbaarheidsscan",
   "components.Settings.Notifications.validationUrl": "Je moet een geldige URL opgeven",
   "components.Settings.Notifications.botAvatarUrl": "URL bot-avatar",
   "components.RequestList.RequestItem.requested": "Aangevraagd",


### PR DESCRIPTION
#### Description

This adds a new job called 'availability sync', suggested by @sct in [an earlier PR that attempted to solve this](https://github.com/sct/overseerr/pull/1397#issuecomment-817232061).  
The job will run every 24h, after all the scanners have completed.

---

###### How it works:

The job will loop through every media item with a status of either `AVAILABLE` or `PARTIALLY_AVAILABLE`.  

For each item:
- It will then check with the Plex API if it still exists, using the item's `ratingKey`.  
- If Plex reports it is not available, we will check with Sonarr (if TV show) if it is available (= existance of an `id`) and monitored.  
- ... we check with Radarr (if movie) if it is available (= existance of an `id`) and monitored.  

When we encounter a TV show that is still available, we also loop through each of it's seasons, and check with Plex and Sonarr if every season is still available (and monitored if Sonarr).  
If we delete any of it's seasons, we mark it as `PARTIALLY_AVAILABLE` (yes, also if we deleted all of it's seasons, read below)

---

I have tested this with my own medium-sized media library (300-400 items) and have personally reviewed most of the decisions it has made (which it logs on debug level), which I deem correct.  
Nevertheless, I personally don't use any of the 4k functionality stuff in overseerr, so there's a potentiality for mistakes there.


#### To discuss / outstanding questions

I think the best way to test this is just ['dogfooding'](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) it ourselves, so please try this out yourself (with a backed up database) and let me know if you find any inconsistencies.  
Lastly, I still have a few questions to the rest of the team:

- Should this maybe be behind a setting? It's new behavior after all that does actually **deletes things**.  
  However, judging from people's feedback on the issue, it is behavior people kind of expect to be in place already.
- What to do with TV shows that had all their seasons removed, but are still monitored? It feels 'wrong' removing these from overseerr (which is why I decided against doing this in the end), because if it's monitored, it means new seasons will get added when they release.  
 But Overseerr's UI will start looking a bit funky in this case, e.g. the 'report issue' dialog [having no selectable seasons](https://i.imgur.com/4DtF8p0.png), and `PARTIALLY_AVAILABLE` being... well, wrong, because none of the seasons are actually available, but new ones will be.

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #377
