### PR TITLE
feat(plextv): add custom applicationTitle to Plex OAuth

### DIFF
--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import Bowser from 'bowser';
+import config from '../../config/settings.json';
 
 interface PlexHeaders extends Record<string, string> {
   Accept: string;
@@ -54,11 +55,11 @@ class PlexOAuth {
       localStorage.setItem('plex-client-id', uuid);
       clientId = uuid;
     }
-
+    const applicationTitle = config.main.applicationTitle;
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {
       Accept: 'application/json',
-      'X-Plex-Product': 'Overseerr',
+      'X-Plex-Product': applicationTitle,
       'X-Plex-Version': 'Plex OAuth',
       'X-Plex-Client-Identifier': clientId,
       'X-Plex-Model': 'Plex OAuth',


### PR DESCRIPTION
#### Description
When using the custom application title from the settings the Plex OAuth flow still uses the old one (as seen [here](https://github.com/sct/overseerr/issues/404#issuecomment-1199953428). This change makes it so that the applicationTitle is read from the settings.json file on disk. 

I initially tried to read from `server/lib/settings.ts` but I did not succeed. Maybe someone else has better luck, this solution does however work.

#### Issues Fixed or Closed
- Fixes additional issue in comments on #404.