### PR TITLE
fix: log level value should not be case sensitive

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -26,7 +26,7 @@ const hformat = winston.format.printf(
 );
 
 const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || 'debug',
+  level: process.env.LOG_LEVEL?.toLowerCase() || 'debug',
   format: winston.format.combine(
     winston.format.splat(),
     winston.format.timestamp(),


### PR DESCRIPTION
#### Description

Lowercases `LOG_LEVEL` value.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #2902
