### PR TITLE
build(docker): skip cypress install & bump node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     name: Lint & Test Build
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-20.04
-    container: node:16.14-alpine
+    container: node:16.17-alpine
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dependencies
         env:
-          HUSKY_SKIP_INSTALL: 1
+          HUSKY: 0
         run: yarn
       - name: Lint
         run: yarn lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-alpine AS BUILD_IMAGE
+FROM node:16.17-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN \
   esac
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --network-timeout 1000000
+RUN CYPRESS_INSTALL_BINARY=0 yarn install --frozen-lockfile --network-timeout 1000000
 
 COPY . ./
 
@@ -33,7 +33,7 @@ RUN touch config/DOCKER
 RUN echo "{\"commitTag\": \"${COMMIT_TAG}\"}" > committag.json
 
 
-FROM node:16.14-alpine
+FROM node:16.17-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:16.14-alpine
+FROM node:16.17-alpine
 
 COPY . /app
 WORKDIR /app

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 parts:
   overseerr:
     plugin: nodejs
-    nodejs-version: '16.14.0'
+    nodejs-version: '16.17.0'
     nodejs-package-manager: 'yarn'
     nodejs-yarn-version: v1.22.17
     build-packages:


### PR DESCRIPTION
#### Description

`arm` builds are currently failing because cypress fails to install.

#### To-Dos

- [x] Successful build `docker build --platform linux/arm/v7,linux/arm64,linux/amd64 .`