### PR TITLE
ci: don't lint/test in snap publish workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -12,30 +12,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
-  test:
-    name: Lint & Test Build
-    needs: jobs
-    runs-on: ubuntu-20.04
-    container: node:16.16-alpine
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          HUSKY_SKIP_INSTALL: 1
-        run: yarn
-      - name: Lint
-        run: yarn lint
-      - name: Build
-        run: yarn build
-
   build-snap:
     name: Build Snap Package (${{ matrix.architecture }})
-    needs: test
+    needs: jobs
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
#### Description

We already lint/test PRs, so it isn't necessary to perform this step again when building the snap images. See #2437

Also bumps `styfle/cancel-workflow-action`.