### PR TITLE
Run nodejs with the node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ RUN apk add --no-cache tzdata tini && rm -rf /tmp/*
 
 # copy from build image
 COPY --from=BUILD_IMAGE /app ./
+RUN chown node:node /app/config -R
 
+USER node
 ENTRYPOINT [ "/sbin/tini", "--" ]
 CMD [ "yarn", "start" ]
 


### PR DESCRIPTION
#### Description

This is a small change to follow the [best practices](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user) and run nodejs as a non-root user.

By default the Nodejs Docker image [provides](https://github.com/nodejs/docker-node/blob/main/Dockerfile-alpine.template#L5-L6) a `node` user that we can use in this case.

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Running as root is [not recommended](https://docs.bitnami.com/tutorials/why-non-root-containers-are-important-for-security) if the app doesn't truly need it to function
- Some environments actively prevent containers to gain root privileges (e.g. k8s clusters using Gatekeeper)
