### PR TITLE
fix(ui): remove 'all' badge from request cards

### DIFF
--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -357,20 +357,13 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
                       : request.seasons.length,
                 })}
               </span>
-              {title.seasons.filter((season) => season.seasonNumber !== 0)
-                .length === request.seasons.length ? (
-                <span className="mr-2 uppercase">
-                  <Badge>{intl.formatMessage(globalMessages.all)}</Badge>
-                </span>
-              ) : (
-                <div className="hide-scrollbar overflow-x-scroll">
-                  {request.seasons.map((season) => (
-                    <span key={`season-${season.id}`} className="mr-2">
-                      <Badge>{season.seasonNumber}</Badge>
-                    </span>
-                  ))}
-                </div>
-              )}
+              <div className="hide-scrollbar overflow-x-scroll">
+                {request.seasons.map((season) => (
+                  <span key={`season-${season.id}`} className="mr-2">
+                    <Badge>{season.seasonNumber}</Badge>
+                  </span>
+                ))}
+              </div>
             </div>
           )}
           <div className="mt-2 flex items-center text-sm sm:mt-1">

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -420,20 +420,13 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                           : request.seasons.length,
                     })}
                   </span>
-                  {title.seasons.filter((season) => season.seasonNumber !== 0)
-                    .length === request.seasons.length ? (
-                    <span className="mr-2 uppercase">
-                      <Badge>{intl.formatMessage(globalMessages.all)}</Badge>
-                    </span>
-                  ) : (
-                    <div className="hide-scrollbar flex flex-nowrap overflow-x-scroll">
-                      {request.seasons.map((season) => (
-                        <span key={`season-${season.id}`} className="mr-2">
-                          <Badge>{season.seasonNumber}</Badge>
-                        </span>
-                      ))}
-                    </div>
-                  )}
+                  <div className="hide-scrollbar flex flex-nowrap overflow-x-scroll">
+                    {request.seasons.map((season) => (
+                      <span key={`season-${season.id}`} className="mr-2">
+                        <Badge>{season.seasonNumber}</Badge>
+                      </span>
+                    ))}
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Updates both RequestList/RequestItem and RequestCard components to no longer show `ALL` if all seasons are requested.

Originally, the number of requested seasons was added onto the `ALL` request (ie `ALL - 4`). After some discussion, it was decided to remove the `ALL` badge to keep the requests consistent. 

#### Description
When viewing the request list / request cards, if `ALL` seasons are requested, it will show each of the seasons requested, compared to the `ALL` badge that would show before.

<details>
  <summary>Original PR</summary>
Updates both RequestList/RequestItem and RequestCard components to contain number of seasons if 'ALL' seasons are requested

#### Description
When viewing the request list / request cards, if `ALL` seasons are requested, this will include the number of seasons in the badge. If scrolling through the list of requests, the user no longer needs to open the details in a new tab to see how many seasons have been requested

#### Screenshot (if UI-related)
Request List:

<img width="391" alt="Screen Shot 2022-08-28 at 1 50 46 PM" src="https://user-images.githubusercontent.com/36162221/187097326-012c079f-d609-4115-8470-1bab6d5cf19b.png">

becomes:

<img width="318" alt="Screen Shot 2022-08-28 at 1 51 17 PM" src="https://user-images.githubusercontent.com/36162221/187097358-d5c100ef-732f-408a-899a-ce0eb724631a.png">

Request Card:

<img width="391" alt="Screen Shot 2022-08-28 at 1 52 17 PM" src="https://user-images.githubusercontent.com/36162221/187097402-946f017f-f8ef-4acb-b557-ccd7b87955cf.png">

becomes:

<img width="396" alt="Screen Shot 2022-08-28 at 1 51 56 PM" src="https://user-images.githubusercontent.com/36162221/187097387-2fc02221-779d-4212-b518-5683a54e6fb0.png">


#### To-Dos

- [X] Successful build `yarn build`

Note: While this isn't technically a bug, I chose `fix` over `feat`, as I didn't think it really qualified as a feature. Also, first time contributing, so hope this PR is up to standards 😄 
</details>
