### PR TITLE
fix: scroll restoration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,4 +17,7 @@ module.exports = {
 
     return config;
   },
+  experimental: {
+    scrollRestoration: true,
+  },
 };


### PR DESCRIPTION
#### Description

For some reason, in NextJS 12.2, scroll restoration no longer works as it used to.

There is a new experimental flag `scrollRestoration` in the configuration we can enable though to restore the scroll restoration to the way it used to be.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
