### PR TITLE
fix: pull to refresh compatibility issue with safari

### DIFF
--- a/src/components/PullToRefresh/index.tsx
+++ b/src/components/PullToRefresh/index.tsx
@@ -12,18 +12,22 @@ const PullToRefresh: React.FC = () => {
         Router.reload();
       },
       iconArrow: ReactDOMServer.renderToString(
-        <RefreshIcon className="z-50 m-auto h-9 w-9 rounded-full border-4 border-gray-800 bg-gray-800 text-indigo-500 ring-1 ring-gray-700" />
+        <div className="p-2">
+          <RefreshIcon className="z-50 m-auto h-9 w-9 rounded-full border-4 border-gray-800 bg-gray-800 text-indigo-500 ring-1 ring-gray-700" />
+        </div>
       ),
       iconRefreshing: ReactDOMServer.renderToString(
-        <RefreshIcon
-          className="z-50 m-auto h-9 w-9 animate-spin rounded-full border-4 border-gray-800 bg-gray-800 text-indigo-500 ring-1 ring-gray-700"
+        <div
+          className="animate-spin p-2"
           style={{ animationDirection: 'reverse' }}
-        />
+        >
+          <RefreshIcon className="z-50 m-auto h-9 w-9 rounded-full border-4 border-gray-800 bg-gray-800 text-indigo-500 ring-1 ring-gray-700" />
+        </div>
       ),
       instructionsPullToRefresh: ReactDOMServer.renderToString(<div />),
       instructionsReleaseToRefresh: ReactDOMServer.renderToString(<div />),
       instructionsRefreshing: ReactDOMServer.renderToString(<div />),
-      distReload: 55,
+      distReload: 60,
     });
     return () => {
       PR.destroyAll();

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -470,6 +470,6 @@
   z-index: 30 !important;
 }
 
-.ptr--ptr .ptr--box {
+.ptr--box {
   margin-bottom: -13px !important;
 }


### PR DESCRIPTION
#### Description

Compatibility issues with animation-spin and ring utility being used on Safari. I placed the animation on the outer div to solve this.

  - Icon would render as a square on animation causing clipping on the outer edges of the ring.
  - Added a slight amount of padding to outer divs.

  ![IMG_5026](https://user-images.githubusercontent.com/8635678/189984173-7e09137b-607e-400d-8352-249dfb2a619e.PNG)

  ![IMG_5029](https://user-images.githubusercontent.com/8635678/189984190-2fdd5d22-8a91-47d6-9989-ff622dd15afd.PNG)


#### To-Dos

- [x] Successful build `yarn build`
