### PR TITLE
feat: add option to verify Plex server access

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -96,6 +96,7 @@ export interface MainSettings {
   hideAvailable: boolean;
   localLogin: boolean;
   newPlexLogin: boolean;
+  verifyPlexLogin: boolean;
   region: string;
   originalLanguage: string;
   trustProxy: boolean;
@@ -289,6 +290,7 @@ class Settings {
         hideAvailable: false,
         localLogin: true,
         newPlexLogin: true,
+        verifyPlexLogin: true,
         region: '',
         originalLanguage: '',
         trustProxy: false,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -71,7 +71,8 @@ authRoutes.post('/plex', async (req, res, next) => {
 
       if (
         account.id === mainUser.plexId ||
-        (await mainPlexTv.checkUserAccess(account.id))
+        ((await mainPlexTv.checkUserAccess(account.id)) &&
+          settings.main.verifyPlexLogin)
       ) {
         if (user) {
           if (!user.plexId) {
@@ -134,6 +135,24 @@ authRoutes.post('/plex', async (req, res, next) => {
 
           await userRepository.save(user);
         }
+      } else if (user && !settings.main.verifyPlexLogin) {
+        logger.info(
+          'Sign-in attempt from Plex user without access to the media server',
+          {
+            label: 'API',
+            ip: req.ip,
+            email: account.email,
+            plexId: account.id,
+            plexUsername: account.username,
+          }
+        );
+        user.plexToken = body.authToken;
+        user.plexId = account.id;
+        user.avatar = account.thumb;
+        user.email = account.email;
+        user.plexUsername = account.username;
+
+        await userRepository.save(user);
       } else {
         logger.warn(
           'Failed sign-in attempt by Plex user without access to the media server',

--- a/src/components/Settings/SettingsUsers/index.tsx
+++ b/src/components/Settings/SettingsUsers/index.tsx
@@ -23,6 +23,9 @@ const messages = defineMessages({
     'Allow users to sign in using their email address and password, instead of Plex OAuth',
   newPlexLogin: 'Enable New Plex Sign-In',
   newPlexLoginTip: 'Allow Plex users to sign in without first being imported',
+  verifyPlexLogin: 'Verify Plex access',
+  verifyPlexLoginTip:
+    'Allow Plex users to sign in only if they still have server access',
   movieRequestLimitLabel: 'Global Movie Request Limit',
   tvRequestLimitLabel: 'Global Series Request Limit',
   defaultPermissions: 'Default Permissions',
@@ -61,6 +64,7 @@ const SettingsUsers = () => {
           initialValues={{
             localLogin: data?.localLogin,
             newPlexLogin: data?.newPlexLogin,
+            verifyPlexLogin: data?.verifyPlexLogin,
             movieQuotaLimit: data?.defaultQuotas.movie.quotaLimit ?? 0,
             movieQuotaDays: data?.defaultQuotas.movie.quotaDays ?? 7,
             tvQuotaLimit: data?.defaultQuotas.tv.quotaLimit ?? 0,
@@ -73,6 +77,7 @@ const SettingsUsers = () => {
               await axios.post('/api/v1/settings/main', {
                 localLogin: values.localLogin,
                 newPlexLogin: values.newPlexLogin,
+                verifyPlexLogin: values.verifyPlexLogin,
                 defaultQuotas: {
                   movie: {
                     quotaLimit: values.movieQuotaLimit,
@@ -136,6 +141,27 @@ const SettingsUsers = () => {
                       name="newPlexLogin"
                       onChange={() => {
                         setFieldValue('newPlexLogin', !values.newPlexLogin);
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="verifyPlexLogin" className="checkbox-label">
+                    {intl.formatMessage(messages.verifyPlexLogin)}
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.verifyPlexLoginTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <Field
+                      type="checkbox"
+                      id="verifyPlexLogin"
+                      name="verifyPlexLogin"
+                      onChange={() => {
+                        setFieldValue(
+                          'verifyPlexLogin',
+                          !values.verifyPlexLogin
+                        );
                       }}
                     />
                   </div>


### PR DESCRIPTION
#### Description

[#2458](https://github.com/sct/overseerr/pull/2458) introduced verification Plex server access during auth for existing users, which is great. This PR added an option to enable or disable it from settings.

#### Screenshot (if UI-related)

<img width="779" alt="image" src="https://user-images.githubusercontent.com/37960108/190490881-b8e97b39-baac-45f1-a6bc-7013ebebf273.png">


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

