### PR TITLE
fix(plex): add container-size header to recently added api call

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -232,6 +232,10 @@ class PlexAPI {
       uri: `/library/sections/${id}/all?sort=addedAt%3Adesc&addedAt>>=${Math.floor(
         options.addedAt / 1000
       )}`,
+      extraHeaders: {
+        'X-Plex-Container-Start': `0`,
+        'X-Plex-Container-Size': `500`,
+      },
     });
 
     return response.MediaContainer.Metadata;


### PR DESCRIPTION
#### Description

The "Recently added" API request will now include the `X-Plex-Container-Size` header. It will always ask for 500 items even though it's unlikely there will ever be that many. In any odd case where someone adds 500 items at once they should be performing a full scan anyways.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2865 
