### PR TITLE
fix(ui): hide available media on person page

### DIFF
--- a/server/routes/person.ts
+++ b/server/routes/person.ts
@@ -1,5 +1,7 @@
 import TheMovieDb from '@server/api/themoviedb';
+import { MediaStatus } from '@server/constants/media';
 import Media from '@server/entity/Media';
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import {
   mapCastCredits,
@@ -34,6 +36,7 @@ personRoutes.get('/:id', async (req, res, next) => {
 
 personRoutes.get('/:id/combined_credits', async (req, res, next) => {
   const tmdb = new TheMovieDb();
+  const settings = getSettings();
 
   try {
     const combinedCredits = await tmdb.getPersonCombinedCredits({
@@ -41,13 +44,29 @@ personRoutes.get('/:id/combined_credits', async (req, res, next) => {
       language: req.locale ?? (req.query.language as string),
     });
 
-    const castMedia = await Media.getRelatedMedia(
+    let castMedia = await Media.getRelatedMedia(
       combinedCredits.cast.map((result) => result.id)
     );
 
-    const crewMedia = await Media.getRelatedMedia(
+    let crewMedia = await Media.getRelatedMedia(
       combinedCredits.crew.map((result) => result.id)
     );
+
+    if (settings.main.hideAvailable) {
+      castMedia = castMedia.filter(
+        (media) =>
+          (media.mediaType === 'movie' || media.mediaType === 'tv') &&
+          media.status !== MediaStatus.AVAILABLE &&
+          media.status !== MediaStatus.PARTIALLY_AVAILABLE
+      );
+
+      crewMedia = crewMedia.filter(
+        (media) =>
+          (media.mediaType === 'movie' || media.mediaType === 'tv') &&
+          media.status !== MediaStatus.AVAILABLE &&
+          media.status !== MediaStatus.PARTIALLY_AVAILABLE
+      );
+    }
 
     return res.status(200).json({
       cast: combinedCredits.cast


### PR DESCRIPTION
#### Description

This fixes available media being hidden on all the discover pages but not on the person page if the "Hide Available Media" setting is on.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3025
