### PR TITLE
fix(ui): hide invalid dates in episodes list

### DIFF
--- a/server/api/themoviedb/interfaces.ts
+++ b/server/api/themoviedb/interfaces.ts
@@ -191,7 +191,7 @@ export interface TmdbVideo {
 
 export interface TmdbTvEpisodeResult {
   id: number;
-  air_date: string;
+  air_date: string | null;
   episode_number: number;
   name: string;
   overview: string;

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -29,7 +29,7 @@ import type { Video } from './Movie';
 interface Episode {
   id: number;
   name: string;
-  airDate: string;
+  airDate: string | null;
   episodeNumber: number;
   overview: string;
   productionCode: string;

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -41,7 +41,9 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
               <div className="flex-1">
                 <div className="flex flex-col space-y-2 xl:flex-row xl:items-center xl:space-y-0 xl:space-x-2">
                   <h3 className="text-lg">{episode.name}</h3>
-                  <AirDateBadge airDate={episode.airDate} />
+                  {episode.airDate && (
+                    <AirDateBadge airDate={episode.airDate} />
+                  )}
                 </div>
                 {episode.overview && <p>{episode.overview}</p>}
               </div>

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -829,6 +829,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
               </div>
             )}
             {data.nextEpisodeToAir &&
+              data.nextEpisodeToAir.airDate &&
               data.nextEpisodeToAir.airDate !== data.firstAirDate && (
                 <div className="media-fact">
                   <span>{intl.formatMessage(messages.nextAirDate)}</span>


### PR DESCRIPTION
#### Description

This fixes the air date being displayed as "January 1, 1970" in the episode list when it's not available.

#### Screenshot (if UI-related)
Before:
<img width="263" alt="image" src="https://user-images.githubusercontent.com/20923978/191062662-41f63f37-858e-46d4-bb4b-d641959f282a.png">


After:
<img width="261" alt="image" src="https://user-images.githubusercontent.com/20923978/191062211-4bfce97f-bd67-45bb-9963-9851cce13604.png">


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
