### PR TITLE
fix(ui): minor fixes

### DIFF
--- a/server/api/themoviedb/interfaces.ts
+++ b/server/api/themoviedb/interfaces.ts
@@ -372,7 +372,8 @@ export interface TmdbPersonCombinedCredits {
   crew: TmdbPersonCreditCrew[];
 }
 
-export interface TmdbSeasonWithEpisodes extends TmdbTvSeasonResult {
+export interface TmdbSeasonWithEpisodes
+  extends Omit<TmdbTvSeasonResult, 'episode_count'> {
   episodes: TmdbTvEpisodeResult[];
   external_ids: TmdbExternalIds;
 }

--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -63,7 +63,7 @@ export const startJobs = (): void => {
     id: 'plex-watchlist-sync',
     name: 'Plex Watchlist Sync',
     type: 'process',
-    interval: 'long',
+    interval: 'short',
     cronSchedule: jobs['plex-watchlist-sync'].schedule,
     job: schedule.scheduleJob(jobs['plex-watchlist-sync'].schedule, () => {
       logger.info('Starting scheduled job: Plex Watchlist Sync', {

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -50,7 +50,7 @@ interface Season {
   seasonNumber: number;
 }
 
-export interface SeasonWithEpisodes extends Season {
+export interface SeasonWithEpisodes extends Omit<Season, 'episodeCount'> {
   episodes: Episode[];
   externalIds: ExternalIds;
 }
@@ -141,7 +141,6 @@ export const mapSeasonWithEpisodes = (
   season: TmdbSeasonWithEpisodes
 ): SeasonWithEpisodes => ({
   airDate: season.air_date,
-  episodeCount: season.episodes.length,
   episodes: season.episodes.map(mapEpisodeResult),
   externalIds: mapExternalIds(season.external_ids),
   id: season.id,

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -141,7 +141,7 @@ export const mapSeasonWithEpisodes = (
   season: TmdbSeasonWithEpisodes
 ): SeasonWithEpisodes => ({
   airDate: season.air_date,
-  episodeCount: season.episode_count,
+  episodeCount: season.episodes.length,
   episodes: season.episodes.map(mapEpisodeResult),
   externalIds: mapExternalIds(season.external_ids),
   id: season.id,

--- a/server/routes/person.ts
+++ b/server/routes/person.ts
@@ -1,5 +1,7 @@
 import TheMovieDb from '@server/api/themoviedb';
+import { MediaStatus } from '@server/constants/media';
 import Media from '@server/entity/Media';
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import {
   mapCastCredits,
@@ -34,6 +36,7 @@ personRoutes.get('/:id', async (req, res, next) => {
 
 personRoutes.get('/:id/combined_credits', async (req, res, next) => {
   const tmdb = new TheMovieDb();
+  const settings = getSettings();
 
   try {
     const combinedCredits = await tmdb.getPersonCombinedCredits({
@@ -41,13 +44,29 @@ personRoutes.get('/:id/combined_credits', async (req, res, next) => {
       language: req.locale ?? (req.query.language as string),
     });
 
-    const castMedia = await Media.getRelatedMedia(
+    let castMedia = await Media.getRelatedMedia(
       combinedCredits.cast.map((result) => result.id)
     );
 
-    const crewMedia = await Media.getRelatedMedia(
+    let crewMedia = await Media.getRelatedMedia(
       combinedCredits.crew.map((result) => result.id)
     );
+
+    if (settings.main.hideAvailable) {
+      castMedia = castMedia.filter(
+        (media) =>
+          (media.mediaType === 'movie' || media.mediaType === 'tv') &&
+          media.status !== MediaStatus.AVAILABLE &&
+          media.status !== MediaStatus.PARTIALLY_AVAILABLE
+      );
+
+      crewMedia = crewMedia.filter(
+        (media) =>
+          (media.mediaType === 'movie' || media.mediaType === 'tv') &&
+          media.status !== MediaStatus.AVAILABLE &&
+          media.status !== MediaStatus.PARTIALLY_AVAILABLE
+      );
+    }
 
     return res.status(200).json({
       cast: combinedCredits.cast

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -204,6 +204,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
         <div className="media-title">
           <div className="media-status">
             <StatusBadge
+              enableTooltip={false}
               status={collectionStatus}
               inProgress={data.parts.some(
                 (part) => (part.mediaInfo?.downloadStatus ?? []).length > 0
@@ -217,6 +218,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
                 }
               ) && (
                 <StatusBadge
+                  enableTooltip={false}
                   status={collectionStatus4k}
                   is4k
                   inProgress={data.parts.some(

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -204,7 +204,6 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
         <div className="media-title">
           <div className="media-status">
             <StatusBadge
-              enableTooltip={false}
               status={collectionStatus}
               inProgress={data.parts.some(
                 (part) => (part.mediaInfo?.downloadStatus ?? []).length > 0
@@ -218,7 +217,6 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
                 }
               ) && (
                 <StatusBadge
-                  enableTooltip={false}
                   status={collectionStatus4k}
                   is4k
                   inProgress={data.parts.some(

--- a/src/components/Common/Tooltip/index.tsx
+++ b/src/components/Common/Tooltip/index.tsx
@@ -20,7 +20,7 @@ const Tooltip = ({ children, content, tooltipConfig }: TooltipProps) => {
   return (
     <>
       {React.cloneElement(children, { ref: setTriggerRef })}
-      {visible && (
+      {visible && content && (
         <div
           ref={setTooltipRef}
           {...getTooltipProps({

--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -309,7 +309,7 @@ const SettingsMain = () => {
                   </div>
                 </div>
                 <div className="form-row">
-                  <label htmlFor="csrfProtection" className="checkbox-label">
+                  <label htmlFor="cacheImages" className="checkbox-label">
                     <span className="mr-2">
                       {intl.formatMessage(messages.cacheImages)}
                     </span>

--- a/src/components/StatusBadge/index.tsx
+++ b/src/components/StatusBadge/index.tsx
@@ -23,7 +23,6 @@ interface StatusBadgeProps {
   serviceUrl?: string;
   tmdbId?: number;
   mediaType?: 'movie' | 'tv';
-  enableTooltip?: boolean;
 }
 
 const StatusBadge = ({
@@ -34,7 +33,6 @@ const StatusBadge = ({
   serviceUrl,
   tmdbId,
   mediaType,
-  enableTooltip = true,
 }: StatusBadgeProps) => {
   const intl = useIntl();
   const { hasPermission } = useUser();
@@ -80,7 +78,7 @@ const StatusBadge = ({
           mediaType === 'movie' ? globalMessages.movie : globalMessages.tvshow
         ),
       });
-    } else if (hasPermission(Permission.ADMIN)) {
+    } else if (hasPermission(Permission.ADMIN) && serviceUrl) {
       mediaLink = serviceUrl;
       mediaLinkDescription = intl.formatMessage(messages.openinarr, {
         arr: mediaType === 'movie' ? 'Radarr' : 'Sonarr',
@@ -151,12 +149,12 @@ const StatusBadge = ({
       break;
   }
 
-  // regardless of whether tooltip is enabled or not
+  // regardless of whether badge should have a tooltip
   if (selectedBadge === null) {
     return null;
   }
 
-  return enableTooltip ? (
+  return mediaLink ? (
     <Tooltip content={mediaLinkDescription}>{selectedBadge}</Tooltip>
   ) : (
     selectedBadge

--- a/src/components/StatusBadge/index.tsx
+++ b/src/components/StatusBadge/index.tsx
@@ -40,7 +40,6 @@ const StatusBadge = ({
 
   let mediaLink: string | undefined;
   let mediaLinkDescription: string | undefined;
-  let selectedBadge: JSX.Element | null;
 
   if (
     mediaType &&
@@ -88,77 +87,80 @@ const StatusBadge = ({
 
   switch (status) {
     case MediaStatus.AVAILABLE:
-      selectedBadge = (
-        <Badge badgeType="success" href={mediaLink}>
-          <div className="flex items-center">
-            <span>
-              {intl.formatMessage(is4k ? messages.status4k : messages.status, {
-                status: intl.formatMessage(globalMessages.available),
-              })}
-            </span>
-            {inProgress && <Spinner className="ml-1 h-3 w-3" />}
-          </div>
-        </Badge>
+      return (
+        <Tooltip content={mediaLinkDescription}>
+          <Badge badgeType="success" href={mediaLink}>
+            <div className="flex items-center">
+              <span>
+                {intl.formatMessage(
+                  is4k ? messages.status4k : messages.status,
+                  {
+                    status: intl.formatMessage(globalMessages.available),
+                  }
+                )}
+              </span>
+              {inProgress && <Spinner className="ml-1 h-3 w-3" />}
+            </div>
+          </Badge>
+        </Tooltip>
       );
-      break;
 
     case MediaStatus.PARTIALLY_AVAILABLE:
-      selectedBadge = (
-        <Badge badgeType="success" href={mediaLink}>
-          <div className="flex items-center">
-            <span>
-              {intl.formatMessage(is4k ? messages.status4k : messages.status, {
-                status: intl.formatMessage(globalMessages.partiallyavailable),
-              })}
-            </span>
-            {inProgress && <Spinner className="ml-1 h-3 w-3" />}
-          </div>
-        </Badge>
+      return (
+        <Tooltip content={mediaLinkDescription}>
+          <Badge badgeType="success" href={mediaLink}>
+            <div className="flex items-center">
+              <span>
+                {intl.formatMessage(
+                  is4k ? messages.status4k : messages.status,
+                  {
+                    status: intl.formatMessage(
+                      globalMessages.partiallyavailable
+                    ),
+                  }
+                )}
+              </span>
+              {inProgress && <Spinner className="ml-1 h-3 w-3" />}
+            </div>
+          </Badge>
+        </Tooltip>
       );
-      break;
 
     case MediaStatus.PROCESSING:
-      selectedBadge = (
-        <Badge badgeType="primary" href={mediaLink}>
-          <div className="flex items-center">
-            <span>
-              {intl.formatMessage(is4k ? messages.status4k : messages.status, {
-                status: inProgress
-                  ? intl.formatMessage(globalMessages.processing)
-                  : intl.formatMessage(globalMessages.requested),
-              })}
-            </span>
-            {inProgress && <Spinner className="ml-1 h-3 w-3" />}
-          </div>
-        </Badge>
+      return (
+        <Tooltip content={mediaLinkDescription}>
+          <Badge badgeType="primary" href={mediaLink}>
+            <div className="flex items-center">
+              <span>
+                {intl.formatMessage(
+                  is4k ? messages.status4k : messages.status,
+                  {
+                    status: inProgress
+                      ? intl.formatMessage(globalMessages.processing)
+                      : intl.formatMessage(globalMessages.requested),
+                  }
+                )}
+              </span>
+              {inProgress && <Spinner className="ml-1 h-3 w-3" />}
+            </div>
+          </Badge>
+        </Tooltip>
       );
-      break;
 
     case MediaStatus.PENDING:
-      selectedBadge = (
-        <Badge badgeType="warning" href={mediaLink}>
-          {intl.formatMessage(is4k ? messages.status4k : messages.status, {
-            status: intl.formatMessage(globalMessages.pending),
-          })}
-        </Badge>
+      return (
+        <Tooltip content={mediaLinkDescription}>
+          <Badge badgeType="warning" href={mediaLink}>
+            {intl.formatMessage(is4k ? messages.status4k : messages.status, {
+              status: intl.formatMessage(globalMessages.pending),
+            })}
+          </Badge>
+        </Tooltip>
       );
-      break;
 
     default:
-      selectedBadge = null;
-      break;
+      return null;
   }
-
-  // regardless of whether badge should have a tooltip
-  if (selectedBadge === null) {
-    return null;
-  }
-
-  return mediaLink ? (
-    <Tooltip content={mediaLinkDescription}>{selectedBadge}</Tooltip>
-  ) : (
-    selectedBadge
-  );
 };
 
 export default StatusBadge;

--- a/src/components/StatusBadge/index.tsx
+++ b/src/components/StatusBadge/index.tsx
@@ -23,6 +23,7 @@ interface StatusBadgeProps {
   serviceUrl?: string;
   tmdbId?: number;
   mediaType?: 'movie' | 'tv';
+  enableTooltip?: boolean;
 }
 
 const StatusBadge = ({
@@ -33,6 +34,7 @@ const StatusBadge = ({
   serviceUrl,
   tmdbId,
   mediaType,
+  enableTooltip = true,
 }: StatusBadgeProps) => {
   const intl = useIntl();
   const { hasPermission } = useUser();
@@ -40,6 +42,7 @@ const StatusBadge = ({
 
   let mediaLink: string | undefined;
   let mediaLinkDescription: string | undefined;
+  let selectedBadge: JSX.Element | null;
 
   if (
     mediaType &&
@@ -87,80 +90,77 @@ const StatusBadge = ({
 
   switch (status) {
     case MediaStatus.AVAILABLE:
-      return (
-        <Tooltip content={mediaLinkDescription}>
-          <Badge badgeType="success" href={mediaLink}>
-            <div className="flex items-center">
-              <span>
-                {intl.formatMessage(
-                  is4k ? messages.status4k : messages.status,
-                  {
-                    status: intl.formatMessage(globalMessages.available),
-                  }
-                )}
-              </span>
-              {inProgress && <Spinner className="ml-1 h-3 w-3" />}
-            </div>
-          </Badge>
-        </Tooltip>
+      selectedBadge = (
+        <Badge badgeType="success" href={mediaLink}>
+          <div className="flex items-center">
+            <span>
+              {intl.formatMessage(is4k ? messages.status4k : messages.status, {
+                status: intl.formatMessage(globalMessages.available),
+              })}
+            </span>
+            {inProgress && <Spinner className="ml-1 h-3 w-3" />}
+          </div>
+        </Badge>
       );
+      break;
 
     case MediaStatus.PARTIALLY_AVAILABLE:
-      return (
-        <Tooltip content={mediaLinkDescription}>
-          <Badge badgeType="success" href={mediaLink}>
-            <div className="flex items-center">
-              <span>
-                {intl.formatMessage(
-                  is4k ? messages.status4k : messages.status,
-                  {
-                    status: intl.formatMessage(
-                      globalMessages.partiallyavailable
-                    ),
-                  }
-                )}
-              </span>
-              {inProgress && <Spinner className="ml-1 h-3 w-3" />}
-            </div>
-          </Badge>
-        </Tooltip>
+      selectedBadge = (
+        <Badge badgeType="success" href={mediaLink}>
+          <div className="flex items-center">
+            <span>
+              {intl.formatMessage(is4k ? messages.status4k : messages.status, {
+                status: intl.formatMessage(globalMessages.partiallyavailable),
+              })}
+            </span>
+            {inProgress && <Spinner className="ml-1 h-3 w-3" />}
+          </div>
+        </Badge>
       );
+      break;
 
     case MediaStatus.PROCESSING:
-      return (
-        <Tooltip content={mediaLinkDescription}>
-          <Badge badgeType="primary" href={mediaLink}>
-            <div className="flex items-center">
-              <span>
-                {intl.formatMessage(
-                  is4k ? messages.status4k : messages.status,
-                  {
-                    status: inProgress
-                      ? intl.formatMessage(globalMessages.processing)
-                      : intl.formatMessage(globalMessages.requested),
-                  }
-                )}
-              </span>
-              {inProgress && <Spinner className="ml-1 h-3 w-3" />}
-            </div>
-          </Badge>
-        </Tooltip>
+      selectedBadge = (
+        <Badge badgeType="primary" href={mediaLink}>
+          <div className="flex items-center">
+            <span>
+              {intl.formatMessage(is4k ? messages.status4k : messages.status, {
+                status: inProgress
+                  ? intl.formatMessage(globalMessages.processing)
+                  : intl.formatMessage(globalMessages.requested),
+              })}
+            </span>
+            {inProgress && <Spinner className="ml-1 h-3 w-3" />}
+          </div>
+        </Badge>
       );
+      break;
 
     case MediaStatus.PENDING:
-      return (
-        <Tooltip content={mediaLinkDescription}>
-          <Badge badgeType="warning" href={mediaLink}>
-            {intl.formatMessage(is4k ? messages.status4k : messages.status, {
-              status: intl.formatMessage(globalMessages.pending),
-            })}
-          </Badge>
-        </Tooltip>
+      selectedBadge = (
+        <Badge badgeType="warning" href={mediaLink}>
+          {intl.formatMessage(is4k ? messages.status4k : messages.status, {
+            status: intl.formatMessage(globalMessages.pending),
+          })}
+        </Badge>
       );
+      break;
 
     default:
-      return null;
+      selectedBadge = null;
+      break;
   }
+
+  // regardless of whether tooltip is enabled or not
+  if (selectedBadge === null) {
+    return null;
+  }
+
+  return enableTooltip ? (
+    <Tooltip content={mediaLinkDescription}>{selectedBadge}</Tooltip>
+  ) : (
+    selectedBadge
+  );
 };
 
 export default StatusBadge;

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -6,6 +6,7 @@ import useSWR from 'swr';
 
 const messages = defineMessages({
   somethingwentwrong: 'Something went wrong while retrieving season data.',
+  noepisodes: 'Episodes list unavailable',
 });
 
 type SeasonProps = {
@@ -29,34 +30,38 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
 
   return (
     <div className="flex flex-col justify-center divide-y divide-gray-700">
-      {data.episodes
-        .slice()
-        .reverse()
-        .map((episode) => {
-          return (
-            <div
-              className="flex flex-col space-y-4 py-4 xl:flex-row xl:space-y-4 xl:space-x-4"
-              key={`season-${seasonNumber}-episode-${episode.episodeNumber}`}
-            >
-              <div className="flex-1">
-                <div className="flex flex-col space-y-2 xl:flex-row xl:items-center xl:space-y-0 xl:space-x-2">
-                  <h3 className="text-lg">{episode.name}</h3>
-                  {episode.airDate && (
-                    <AirDateBadge airDate={episode.airDate} />
-                  )}
+      {data.episodeCount === 0 ? (
+        <p>{intl.formatMessage(messages.noepisodes)}</p>
+      ) : (
+        data.episodes
+          .slice()
+          .reverse()
+          .map((episode) => {
+            return (
+              <div
+                className="flex flex-col space-y-4 py-4 xl:flex-row xl:space-y-4 xl:space-x-4"
+                key={`season-${seasonNumber}-episode-${episode.episodeNumber}`}
+              >
+                <div className="flex-1">
+                  <div className="flex flex-col space-y-2 xl:flex-row xl:items-center xl:space-y-0 xl:space-x-2">
+                    <h3 className="text-lg">{episode.name}</h3>
+                    {episode.airDate && (
+                      <AirDateBadge airDate={episode.airDate} />
+                    )}
+                  </div>
+                  {episode.overview && <p>{episode.overview}</p>}
                 </div>
-                {episode.overview && <p>{episode.overview}</p>}
+                {episode.stillPath && (
+                  <img
+                    className="h-auto w-full rounded-lg xl:h-32 xl:w-auto"
+                    src={`https://image.tmdb.org/t/p/original/${episode.stillPath}`}
+                    alt=""
+                  />
+                )}
               </div>
-              {episode.stillPath && (
-                <img
-                  className="h-auto w-full rounded-lg xl:h-32 xl:w-auto"
-                  src={`https://image.tmdb.org/t/p/original/${episode.stillPath}`}
-                  alt=""
-                />
-              )}
-            </div>
-          );
-        })}
+            );
+          })
+      )}
     </div>
   );
 };

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -6,7 +6,7 @@ import useSWR from 'swr';
 
 const messages = defineMessages({
   somethingwentwrong: 'Something went wrong while retrieving season data.',
-  noepisodes: 'Episode list unavailable',
+  noepisodes: 'Episode list unavailable.',
 });
 
 type SeasonProps = {
@@ -30,7 +30,7 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
 
   return (
     <div className="flex flex-col justify-center divide-y divide-gray-700">
-      {data.episodeCount === 0 ? (
+      {data.episodes.length === 0 ? (
         <p>{intl.formatMessage(messages.noepisodes)}</p>
       ) : (
         data.episodes

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -6,7 +6,7 @@ import useSWR from 'swr';
 
 const messages = defineMessages({
   somethingwentwrong: 'Something went wrong while retrieving season data.',
-  noepisodes: 'Episodes list unavailable',
+  noepisodes: 'Episode list unavailable',
 });
 
 type SeasonProps = {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -881,7 +881,7 @@
   "components.TitleCard.mediaerror": "{mediaType} Not Found",
   "components.TitleCard.tmdbid": "TMDB ID",
   "components.TitleCard.tvdbid": "TheTVDB ID",
-  "components.TvDetails.Season.noepisodes": "Episodes list unavailable",
+  "components.TvDetails.Season.noepisodes": "Episode list unavailable",
   "components.TvDetails.Season.somethingwentwrong": "Something went wrong while retrieving season data.",
   "components.TvDetails.TvCast.fullseriescast": "Full Series Cast",
   "components.TvDetails.TvCrew.fullseriescrew": "Full Series Crew",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -881,7 +881,7 @@
   "components.TitleCard.mediaerror": "{mediaType} Not Found",
   "components.TitleCard.tmdbid": "TMDB ID",
   "components.TitleCard.tvdbid": "TheTVDB ID",
-  "components.TvDetails.Season.noepisodes": "Episode list unavailable",
+  "components.TvDetails.Season.noepisodes": "Episode list unavailable.",
   "components.TvDetails.Season.somethingwentwrong": "Something went wrong while retrieving season data.",
   "components.TvDetails.TvCast.fullseriescast": "Full Series Cast",
   "components.TvDetails.TvCrew.fullseriescrew": "Full Series Crew",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -881,6 +881,7 @@
   "components.TitleCard.mediaerror": "{mediaType} Not Found",
   "components.TitleCard.tmdbid": "TMDB ID",
   "components.TitleCard.tvdbid": "TheTVDB ID",
+  "components.TvDetails.Season.noepisodes": "Episodes list unavailable",
   "components.TvDetails.Season.somethingwentwrong": "Something went wrong while retrieving season data.",
   "components.TvDetails.TvCast.fullseriescast": "Full Series Cast",
   "components.TvDetails.TvCrew.fullseriescrew": "Full Series Crew",


### PR DESCRIPTION
#### Description

- Hide available media when the setting "Hide Available Media" is enabled on the `person` page
- Fixed a copy-paste error for the label for the new image cache setting
- Fixed bug that would show tooltips on the `collection` page (that badge doesn't open anything when clicked nor would the tooltip have any description)
- Replaced a weird empty space when there are no episodes in a season and the episodes list is expanded - preventing the episodes list from expanding would be unexpected for the user since there'd be nothing to indicate that it shouldn't be expandable (picture below)
- Set Plex Watchlist Sync job to short interval

#### Screenshot (if UI-related)
Before:
<img width="185" alt="image" src="https://user-images.githubusercontent.com/20923978/191126277-3623b436-1eb7-4396-90a4-5f22b1ea55af.png">

After:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/20923978/191125947-b156c221-e035-4b9d-98b6-52a422a0f93e.png">



#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #3025 
