### PR TITLE
fix: slideover close button placement when using PWA

### DIFF
--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -120,7 +120,7 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
             >
               <>
                 <div className="sidebar relative flex h-full w-full max-w-xs flex-1 flex-col bg-gray-800">
-                  <div className="sidebar-close-button absolute top-0 right-0 -mr-14 p-1">
+                  <div className="sidebar-close-button absolute right-0 -mr-14 p-1">
                     <button
                       className="flex h-12 w-12 items-center justify-center rounded-full focus:bg-gray-600 focus:outline-none"
                       aria-label="Close sidebar"


### PR DESCRIPTION
#### Description

Safe area inset on top placement was being overridden by top placed on the component. This would only affect the slideover when using the PWA version.

 - Added !important to prevent this issue again.

#### Screenshot (if UI-related)

![IMG_5056](https://user-images.githubusercontent.com/8635678/191814148-75a59b88-b3c9-4bb8-8a20-34996771b6ff.PNG) ![IMG_5055](https://user-images.githubusercontent.com/8635678/191814129-329dd12a-e2ac-413f-a68d-af479f138a00.PNG)


#### To-Dos

- [x] Successful build `yarn build`
