### PR TITLE
docs(proxy): update `sub_filter` for subfolder [skip ci]

### DIFF
--- a/docs/extending-overseerr/reverse-proxy.md
+++ b/docs/extending-overseerr/reverse-proxy.md
@@ -138,6 +138,7 @@ location ^~ /overseerr {
     sub_filter 'href="/"' 'href="/$app"';
     sub_filter 'href="/login"' 'href="/$app/login"';
     sub_filter 'href:"/"' 'href:"/$app"';
+    sub_filter '\/_next' '\/$app\/_next';
     sub_filter '/_next' '/$app/_next';
     sub_filter '/api/v1' '/$app/api/v1';
     sub_filter '/login/plex/loading' '/$app/login/plex/loading';


### PR DESCRIPTION
#### Description

The updated `next.js` dependency has a new regex match in the code for `/^\/_next\/data\//`.

The current `sub_filter` creates invalid regex `/^\/overseerr/_next\/data\//`.
```nginx
    sub_filter '/_next' '/$app/_next';
```
It needs to be updated to substitute the correct the regex `/^\/overseerr\/_next\/data\//`.
```nginx
    sub_filter '\/_next' '\/$app\/_next';
    sub_filter '/_next' '/$app/_next';
```

Note: Remember to clear your browser cache (and other caches e.g. Cloudflare) after updating your Nginx config.

#### Issues Fixed or Closed

- Fixes #3042
