### PR TITLE
fix: cacheImages label had incorrect for attribute

### DIFF
--- a/src/components/Settings/SettingsMain.tsx
+++ b/src/components/Settings/SettingsMain.tsx
@@ -309,7 +309,7 @@ const SettingsMain = () => {
                   </div>
                 </div>
                 <div className="form-row">
-                  <label htmlFor="csrfProtection" className="checkbox-label">
+                  <label htmlFor="cacheImages" className="checkbox-label">
                     <span className="mr-2">
                       {intl.formatMessage(messages.cacheImages)}
                     </span>


### PR DESCRIPTION
#### Description
cacheImages `<label>` tag "for" attribute is incorrectly set to the csrfProtection control.

#### Screenshot (if UI-related)
n/a

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed
No issue on Github exists for this.