### PR TITLE
fix: update API docs to allow 'all' seasons value

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4585,9 +4585,13 @@ paths:
                   type: number
                   example: 123
                 seasons:
-                  type: array
-                  items:
-                    type: number
+                  oneOf:
+                    - type: array
+                      items:
+                        type: number
+                        minimum: 1
+                    - type: string
+                      enum: [all]
                 is4k:
                   type: boolean
                   example: false
@@ -4666,7 +4670,7 @@ paths:
                 $ref: '#/components/schemas/MediaRequest'
     put:
       summary: Update MediaRequest
-      description: Updates a specific media request and returns the request in a JSON object.. Requires the `MANAGE_REQUESTS` permission.
+      description: Updates a specific media request and returns the request in a JSON object. Requires the `MANAGE_REQUESTS` permission.
       tags:
         - request
       parameters:
@@ -4677,6 +4681,37 @@ paths:
           example: '1'
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mediaType:
+                  type: string
+                  enum: [movie, tv]
+                seasons:
+                  type: array
+                  items:
+                    type: number
+                    minimum: 1
+                is4k:
+                  type: boolean
+                  example: false
+                serverId:
+                  type: number
+                profileId:
+                  type: number
+                rootFolder:
+                  type: string
+                languageProfileId:
+                  type: number
+                userId:
+                  type: number
+                  nullable: true
+              required:
+                - mediaType
       responses:
         '200':
           description: Succesfully updated request


### PR DESCRIPTION
#### Description

The request endpoint now accepts `all` in lieu of an array of season numbers, and the API spec needs to be updated to reflect this.

Also defines request body schema for updating requests.

#### To-Dos

- [x] Successful build `yarn build`
