### PR TITLE
Update semantic-release to use proper arg for commit tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
       {
         "path": "semantic-release-docker-buildx",
         "buildArgs": {
-          "COMMIT_TAG": "$GITHUB_SHA"
+          "COMMIT_TAG": "$GIT_SHA"
         },
         "imageNames": [
           "sctx/overseerr",


### PR DESCRIPTION
#### Description
Update semantic-release to use `GIT_SHA` instead of `GITHUB_SHA` as per [the build arguments documentation on semantic-release](https://github.com/esatterwhite/semantic-release-docker#build-arguments)

#### Screenshot (if UI-related)

#### To-Dos

- [N/A] Successful build `yarn build`
- [N/A] Translation keys `yarn i18n:extract`
- [N/A] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2820 
