### PR TITLE
feat(ui): add episode shorthand to tv details UI (SxxExx)

### DIFF
--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -44,7 +44,9 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
               >
                 <div className="flex-1">
                   <div className="flex flex-col space-y-2 xl:flex-row xl:items-center xl:space-y-0 xl:space-x-2">
-                    <h3 className="text-lg">{episode.name}</h3>
+                    <h3 className="text-lg">
+                      {episode.episodeNumber} - {episode.name}
+                    </h3>
                     {episode.airDate && (
                       <AirDateBadge airDate={episode.airDate} />
                     )}


### PR DESCRIPTION
#### Description
To provide the user more information concisely when viewing TV Details, this includes a "shorthand" for the episode `SxxExx`.  In the future, I'd like to add an on hover that shows the _absolute_ episode number. 

#### Screenshot (if UI-related)
As it currently stands:
<img width="1096" alt="Screen Shot 2022-10-17 at 5 23 31 PM" src="https://user-images.githubusercontent.com/36162221/196288315-ebcdf935-352f-4b0e-b3c7-81526c583075.png">

With the shorthand badge:
<img width="1097" alt="Screen Shot 2022-10-17 at 5 21 49 PM" src="https://user-images.githubusercontent.com/36162221/196288397-50e3140d-8bde-400e-87fa-81bd96018202.png">

#### To-Dos

- [X] Successful build `yarn build`
- [X] Translation keys `yarn i18n:extract`

#### References
[Here's](https://discord.com/channels/783137440809746482/1027318650409062450) the discord discussion thread

#### Potential Issues
While testing a few other TV Shows, sometimes it shows the absolute number. I've so far only found 1 show where this happens, so it might be limited to just it. 
When viewing One Piece, it shows the _absolute_ episode number, instead of the episode number for just that season.
Example:
<img width="1101" alt="Screen Shot 2022-10-17 at 5 28 33 PM" src="https://user-images.githubusercontent.com/36162221/196290292-ad919dd6-c658-49f2-b414-c88502edb17d.png">
While it's not the end of the world, it's not desired (I think an on hover for absolute episode number would be best).

Additionally, it's not currently padding the episode or season number. That would require additional information to be returned to the UI, or significantly more logic. I _could_ setup padding on the episode number within the season, but not between seasons. 