### PR TITLE
fix: improved PTR scrolling performance

### DIFF
--- a/src/components/PullToRefresh/index.tsx
+++ b/src/components/PullToRefresh/index.tsx
@@ -1,15 +1,17 @@
 import { RefreshIcon } from '@heroicons/react/outline';
-import Router from 'next/router';
+import { useRouter } from 'next/router';
 import PR from 'pulltorefreshjs';
 import { useEffect } from 'react';
 import ReactDOMServer from 'react-dom/server';
 
-const PullToRefresh: React.FC = () => {
+const PullToRefresh = () => {
+  const router = useRouter();
+
   useEffect(() => {
     PR.init({
       mainElement: '#pull-to-refresh',
       onRefresh() {
-        Router.reload();
+        router.reload();
       },
       iconArrow: ReactDOMServer.renderToString(
         <div className="p-2">
@@ -28,11 +30,14 @@ const PullToRefresh: React.FC = () => {
       instructionsReleaseToRefresh: ReactDOMServer.renderToString(<div />),
       instructionsRefreshing: ReactDOMServer.renderToString(<div />),
       distReload: 60,
+      distIgnore: 15,
+      shouldPullToRefresh: () =>
+        !window.scrollY && document.body.style.overflow !== 'hidden',
     });
     return () => {
       PR.destroyAll();
     };
-  }, []);
+  }, [router]);
 
   return <div id="pull-to-refresh"></div>;
 };


### PR DESCRIPTION
#### Description

Scrolling performance improved if window is at the top of the page. There was also an issue if a modal was active that would prevent a user from scrolling up. Mostly affected the Slideover modal. 

 - distIgnore option added to ignore PTR until after a certain distance is pulled.
 - Layout will check if body overflow is set to hidden or visible.
 
#### To-Dos

- [x] Successful build `yarn build`
