### PR TITLE
Removed 'available' from /request/{requestId}/{status} endpoint

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1051,7 +1051,7 @@ components:
         status:
           type: number
           example: 0
-          description: Availability of the media. 1 = UNKNOWN, 2 = PENDING, 3 = PROCESSING, 4 = PARTIAL, 5 = AVAILABLE
+          description: Availability of the media. 1 = `UNKNOWN`, 2 = `PENDING`, 3 = `PROCESSING`, 4 = `PARTIALLY_AVAILABLE`, 5 = `AVAILABLE`
         requests:
           type: array
           readOnly: true

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -5023,7 +5023,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [pending, approve, decline]
+            enum: [approve, decline]
       responses:
         '200':
           description: Request status changed

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1050,6 +1050,8 @@ components:
           nullable: true
         status:
           type: number
+          example: 0
+          description: Availability of the media. 1 = UNKNOWN, 2 = PENDING, 3 = PROCESSING, 4 = PARTIAL, 5 = AVAILABLE
         requests:
           type: array
           readOnly: true
@@ -5021,7 +5023,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [pending, approve, decline, available]
+            enum: [pending, approve, decline]
       responses:
         '200':
           description: Request status changed


### PR DESCRIPTION
'available' is not a possible request status. It already falls under the '/media/{mediaId}/available' endpoint.
Also added the meaning of each 'media' status numbers.

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3097
