### PR TITLE
[Documentation] Updated docker volumes from /app/config to /config

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -29,7 +29,7 @@ docker run -d \
   -e LOG_LEVEL=debug \
   -e TZ=Asia/Tokyo \
   -p 5055:5055 \
-  -v /path/to/appdata/config:/app/config \
+  -v /path/to/appdata/config:/config \
   --restart unless-stopped \
   sctx/overseerr
 ```
@@ -84,7 +84,7 @@ services:
     ports:
       - 5055:5055
     volumes:
-      - /path/to/appdata/config:/app/config
+      - /path/to/appdata/config:/config
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
#### Description
Hello,

I just discovered overseerr recently and when I was trying to install it using docker and the snippets provided by the documentation the app was complaining that the /config mount wasn't working. I realized that the app is expecting the mount to be at /config but the documentation has it at /app/config. So, I simply want to update the doc to make it easier for everyone. 

Thanks. 

#### Screenshot (if UI-related)

#### To-Dos

- [x] docker compose up works as expected


#### Issues Fixed or Closed

No open issues
