### PR TITLE
fix: series displayed an empty season with series list/request modal

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -232,7 +232,7 @@ const TvRequestModal = ({
 
   const getAllSeasons = (): number[] => {
     return (data?.seasons ?? [])
-      .filter((season) => season.seasonNumber !== 0)
+      .filter((season) => (season.seasonNumber && season.episodeCount) !== 0)
       .map((season) => season.seasonNumber);
   };
 
@@ -555,7 +555,10 @@ const TvRequestModal = ({
                 </thead>
                 <tbody className="divide-y divide-gray-700">
                   {data?.seasons
-                    .filter((season) => season.seasonNumber !== 0)
+                    .filter(
+                      (season) =>
+                        (season.seasonNumber && season.episodeCount) !== 0
+                    )
                     .map((season) => {
                       const seasonRequest = getSeasonRequest(
                         season.seasonNumber

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -232,7 +232,9 @@ const TvRequestModal = ({
 
   const getAllSeasons = (): number[] => {
     return (data?.seasons ?? [])
-      .filter((season) => (season.seasonNumber && season.episodeCount) !== 0)
+      .filter(
+        (season) => season.seasonNumber !== 0 && season.episodeCount !== 0
+      )
       .map((season) => season.seasonNumber);
   };
 
@@ -557,7 +559,7 @@ const TvRequestModal = ({
                   {data?.seasons
                     .filter(
                       (season) =>
-                        (season.seasonNumber && season.episodeCount) !== 0
+                        season.seasonNumber !== 0 && season.episodeCount !== 0
                     )
                     .map((season) => {
                       const seasonRequest = getSeasonRequest(

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -224,20 +224,16 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   const isComplete =
     seasonCount <=
     (
-      data.mediaInfo?.seasons.filter(
-        (season) =>
-          season.status === MediaStatus.AVAILABLE ||
-          season.status === MediaStatus.PARTIALLY_AVAILABLE
+      data.mediaInfo?.requests.filter(
+        (requests) => !requests.is4k && requests.seasons
       ) ?? []
     ).length;
 
   const is4kComplete =
     seasonCount <=
     (
-      data.mediaInfo?.seasons.filter(
-        (season) =>
-          season.status4k === MediaStatus.AVAILABLE ||
-          season.status4k === MediaStatus.PARTIALLY_AVAILABLE
+      data.mediaInfo?.requests.filter(
+        (requests) => requests.is4k && requests.seasons
       ) ?? []
     ).length;
 
@@ -811,12 +807,13 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                 )}
               </div>
             )}
-            {data.originalName && data.originalLanguage !== locale.slice(0, 2) && (
-              <div className="media-fact">
-                <span>{intl.formatMessage(messages.originaltitle)}</span>
-                <span className="media-fact-value">{data.originalName}</span>
-              </div>
-            )}
+            {data.originalName &&
+              data.originalLanguage !== locale.slice(0, 2) && (
+                <div className="media-fact">
+                  <span>{intl.formatMessage(messages.originaltitle)}</span>
+                  <span className="media-fact-value">{data.originalName}</span>
+                </div>
+              )}
             {data.keywords.some(
               (keyword) => keyword.id === ANIME_KEYWORD_ID
             ) && (

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -38,7 +38,7 @@ import {
   FilmIcon,
   PlayIcon,
 } from '@heroicons/react/24/outline';
-import { ChevronUpIcon } from '@heroicons/react/24/solid';
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import type { RTRating } from '@server/api/rottentomatoes';
 import { ANIME_KEYWORD_ID } from '@server/api/themoviedb/constants';
 import { IssueStatus } from '@server/constants/issue';
@@ -193,7 +193,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   }
 
   const seasonCount = data.seasons.filter(
-    (season) => season.seasonNumber !== 0
+    (season) => (season.seasonNumber && season.episodeCount) !== 0
   ).length;
 
   if (seasonCount) {
@@ -539,204 +539,216 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                     ) && r.is4k
                 );
 
-                return (
-                  <Disclosure key={`season-discoslure-${season.seasonNumber}`}>
-                    {({ open }) => (
-                      <>
-                        <Disclosure.Button
-                          className={`mt-2 flex w-full items-center justify-between space-x-2 border-gray-700 bg-gray-800 px-4 py-2 text-gray-200 ${
-                            open
-                              ? 'rounded-t-md border-t border-l border-r'
-                              : 'rounded-md border'
-                          }`}
-                        >
-                          <div className="flex flex-1 items-center space-x-2 text-lg">
-                            <span>
-                              {intl.formatMessage(messages.seasonnumber, {
-                                seasonNumber: season.seasonNumber,
-                              })}
-                            </span>
-                            <Badge badgeType="dark">
-                              {intl.formatMessage(messages.episodeCount, {
-                                episodeCount: season.episodeCount,
-                              })}
-                            </Badge>
-                          </div>
-                          {((!mSeason &&
-                            request?.status === MediaRequestStatus.APPROVED) ||
-                            mSeason?.status === MediaStatus.PROCESSING) && (
-                            <>
-                              <div className="hidden md:flex">
-                                <Badge badgeType="primary">
-                                  {intl.formatMessage(globalMessages.requested)}
-                                </Badge>
-                              </div>
-                              <div className="flex md:hidden">
-                                <StatusBadgeMini
-                                  status={MediaStatus.PROCESSING}
-                                />
-                              </div>
-                            </>
-                          )}
-                          {((!mSeason &&
-                            request?.status === MediaRequestStatus.PENDING) ||
-                            mSeason?.status === MediaStatus.PENDING) && (
-                            <>
-                              <div className="hidden md:flex">
-                                <Badge badgeType="warning">
-                                  {intl.formatMessage(globalMessages.pending)}
-                                </Badge>
-                              </div>
-                              <div className="flex md:hidden">
-                                <StatusBadgeMini status={MediaStatus.PENDING} />
-                              </div>
-                            </>
-                          )}
-                          {mSeason?.status ===
-                            MediaStatus.PARTIALLY_AVAILABLE && (
-                            <>
-                              <div className="hidden md:flex">
-                                <Badge badgeType="success">
-                                  {intl.formatMessage(
-                                    globalMessages.partiallyavailable
-                                  )}
-                                </Badge>
-                              </div>
-                              <div className="flex md:hidden">
-                                <StatusBadgeMini
-                                  status={MediaStatus.PARTIALLY_AVAILABLE}
-                                />
-                              </div>
-                            </>
-                          )}
-                          {mSeason?.status === MediaStatus.AVAILABLE && (
-                            <>
-                              <div className="hidden md:flex">
-                                <Badge badgeType="success">
-                                  {intl.formatMessage(globalMessages.available)}
-                                </Badge>
-                              </div>
-                              <div className="flex md:hidden">
-                                <StatusBadgeMini
-                                  status={MediaStatus.AVAILABLE}
-                                />
-                              </div>
-                            </>
-                          )}
-                          {((!mSeason4k &&
-                            request4k?.status ===
-                              MediaRequestStatus.APPROVED) ||
-                            mSeason4k?.status4k === MediaStatus.PROCESSING) &&
-                            show4k && (
+                if (season.episodeCount !== 0) {
+                  return (
+                    <Disclosure
+                      key={`season-discoslure-${season.seasonNumber}`}
+                    >
+                      {({ open }) => (
+                        <>
+                          <Disclosure.Button
+                            className={`mt-2 flex w-full items-center justify-between space-x-2 border-gray-700 bg-gray-800 px-4 py-2 text-gray-200 ${
+                              open
+                                ? 'rounded-t-md border-t border-l border-r'
+                                : 'rounded-md border'
+                            }`}
+                          >
+                            <div className="flex flex-1 items-center space-x-2 text-lg">
+                              <span>
+                                {intl.formatMessage(messages.seasonnumber, {
+                                  seasonNumber: season.seasonNumber,
+                                })}
+                              </span>
+                              <Badge badgeType="dark">
+                                {intl.formatMessage(messages.episodeCount, {
+                                  episodeCount: season.episodeCount,
+                                })}
+                              </Badge>
+                            </div>
+                            {((!mSeason &&
+                              request?.status ===
+                                MediaRequestStatus.APPROVED) ||
+                              mSeason?.status === MediaStatus.PROCESSING) && (
                               <>
                                 <div className="hidden md:flex">
                                   <Badge badgeType="primary">
-                                    {intl.formatMessage(messages.status4k, {
-                                      status: intl.formatMessage(
-                                        globalMessages.requested
-                                      ),
-                                    })}
+                                    {intl.formatMessage(
+                                      globalMessages.requested
+                                    )}
                                   </Badge>
                                 </div>
                                 <div className="flex md:hidden">
                                   <StatusBadgeMini
                                     status={MediaStatus.PROCESSING}
-                                    is4k={true}
                                   />
                                 </div>
                               </>
                             )}
-                          {((!mSeason4k &&
-                            request4k?.status === MediaRequestStatus.PENDING) ||
-                            mSeason?.status4k === MediaStatus.PENDING) &&
-                            show4k && (
+                            {((!mSeason &&
+                              request?.status === MediaRequestStatus.PENDING) ||
+                              mSeason?.status === MediaStatus.PENDING) && (
                               <>
                                 <div className="hidden md:flex">
                                   <Badge badgeType="warning">
-                                    {intl.formatMessage(messages.status4k, {
-                                      status: intl.formatMessage(
-                                        globalMessages.pending
-                                      ),
-                                    })}
+                                    {intl.formatMessage(globalMessages.pending)}
                                   </Badge>
                                 </div>
                                 <div className="flex md:hidden">
                                   <StatusBadgeMini
                                     status={MediaStatus.PENDING}
-                                    is4k={true}
                                   />
                                 </div>
                               </>
                             )}
-                          {mSeason4k?.status4k ===
-                            MediaStatus.PARTIALLY_AVAILABLE &&
-                            show4k && (
+                            {mSeason?.status ===
+                              MediaStatus.PARTIALLY_AVAILABLE && (
                               <>
                                 <div className="hidden md:flex">
                                   <Badge badgeType="success">
-                                    {intl.formatMessage(messages.status4k, {
-                                      status: intl.formatMessage(
-                                        globalMessages.partiallyavailable
-                                      ),
-                                    })}
+                                    {intl.formatMessage(
+                                      globalMessages.partiallyavailable
+                                    )}
                                   </Badge>
                                 </div>
                                 <div className="flex md:hidden">
                                   <StatusBadgeMini
                                     status={MediaStatus.PARTIALLY_AVAILABLE}
-                                    is4k={true}
                                   />
                                 </div>
                               </>
                             )}
-                          {mSeason4k?.status4k === MediaStatus.AVAILABLE &&
-                            show4k && (
+                            {mSeason?.status === MediaStatus.AVAILABLE && (
                               <>
                                 <div className="hidden md:flex">
                                   <Badge badgeType="success">
-                                    {intl.formatMessage(messages.status4k, {
-                                      status: intl.formatMessage(
-                                        globalMessages.available
-                                      ),
-                                    })}
+                                    {intl.formatMessage(
+                                      globalMessages.available
+                                    )}
                                   </Badge>
                                 </div>
                                 <div className="flex md:hidden">
                                   <StatusBadgeMini
                                     status={MediaStatus.AVAILABLE}
-                                    is4k={true}
                                   />
                                 </div>
                               </>
                             )}
-                          <ChevronUpIcon
-                            className={`${
-                              open ? 'rotate-180 transform' : ''
-                            } h-6 w-6 text-gray-500`}
-                          />
-                        </Disclosure.Button>
-                        <Transition
-                          show={open}
-                          enter="transition duration-100 ease-out"
-                          enterFrom="transform opacity-0"
-                          enterTo="transform opacity-100"
-                          leave="transition duration-75 ease-out"
-                          leaveFrom="transform opacity-100"
-                          leaveTo="transform opacity-0"
-                          // Not sure why this transition is adding a margin without this here
-                          style={{ margin: '0px' }}
-                        >
-                          <Disclosure.Panel className="w-full rounded-b-md border-b border-l border-r border-gray-700 px-4 pb-2">
-                            <Season
-                              tvId={data.id}
-                              seasonNumber={season.seasonNumber}
+                            {((!mSeason4k &&
+                              request4k?.status ===
+                                MediaRequestStatus.APPROVED) ||
+                              mSeason4k?.status4k === MediaStatus.PROCESSING) &&
+                              show4k && (
+                                <>
+                                  <div className="hidden md:flex">
+                                    <Badge badgeType="primary">
+                                      {intl.formatMessage(messages.status4k, {
+                                        status: intl.formatMessage(
+                                          globalMessages.requested
+                                        ),
+                                      })}
+                                    </Badge>
+                                  </div>
+                                  <div className="flex md:hidden">
+                                    <StatusBadgeMini
+                                      status={MediaStatus.PROCESSING}
+                                      is4k={true}
+                                    />
+                                  </div>
+                                </>
+                              )}
+                            {((!mSeason4k &&
+                              request4k?.status ===
+                                MediaRequestStatus.PENDING) ||
+                              mSeason?.status4k === MediaStatus.PENDING) &&
+                              show4k && (
+                                <>
+                                  <div className="hidden md:flex">
+                                    <Badge badgeType="warning">
+                                      {intl.formatMessage(messages.status4k, {
+                                        status: intl.formatMessage(
+                                          globalMessages.pending
+                                        ),
+                                      })}
+                                    </Badge>
+                                  </div>
+                                  <div className="flex md:hidden">
+                                    <StatusBadgeMini
+                                      status={MediaStatus.PENDING}
+                                      is4k={true}
+                                    />
+                                  </div>
+                                </>
+                              )}
+                            {mSeason4k?.status4k ===
+                              MediaStatus.PARTIALLY_AVAILABLE &&
+                              show4k && (
+                                <>
+                                  <div className="hidden md:flex">
+                                    <Badge badgeType="success">
+                                      {intl.formatMessage(messages.status4k, {
+                                        status: intl.formatMessage(
+                                          globalMessages.partiallyavailable
+                                        ),
+                                      })}
+                                    </Badge>
+                                  </div>
+                                  <div className="flex md:hidden">
+                                    <StatusBadgeMini
+                                      status={MediaStatus.PARTIALLY_AVAILABLE}
+                                      is4k={true}
+                                    />
+                                  </div>
+                                </>
+                              )}
+                            {mSeason4k?.status4k === MediaStatus.AVAILABLE &&
+                              show4k && (
+                                <>
+                                  <div className="hidden md:flex">
+                                    <Badge badgeType="success">
+                                      {intl.formatMessage(messages.status4k, {
+                                        status: intl.formatMessage(
+                                          globalMessages.available
+                                        ),
+                                      })}
+                                    </Badge>
+                                  </div>
+                                  <div className="flex md:hidden">
+                                    <StatusBadgeMini
+                                      status={MediaStatus.AVAILABLE}
+                                      is4k={true}
+                                    />
+                                  </div>
+                                </>
+                              )}
+                            <ChevronDownIcon
+                              className={`${
+                                open ? 'rotate-180 transform' : ''
+                              } h-6 w-6 text-gray-500`}
                             />
-                          </Disclosure.Panel>
-                        </Transition>
-                      </>
-                    )}
-                  </Disclosure>
-                );
+                          </Disclosure.Button>
+                          <Transition
+                            show={open}
+                            enter="transition duration-100 ease-out"
+                            enterFrom="transform opacity-0"
+                            enterTo="transform opacity-100"
+                            leave="transition duration-75 ease-out"
+                            leaveFrom="transform opacity-100"
+                            leaveTo="transform opacity-0"
+                            // Not sure why this transition is adding a margin without this here
+                            style={{ margin: '0px' }}
+                          >
+                            <Disclosure.Panel className="w-full rounded-b-md border-b border-l border-r border-gray-700 px-4 pb-2">
+                              <Season
+                                tvId={data.id}
+                                seasonNumber={season.seasonNumber}
+                              />
+                            </Disclosure.Panel>
+                          </Transition>
+                        </>
+                      )}
+                    </Disclosure>
+                  );
+                }
               })}
           </div>
         </div>
@@ -799,13 +811,12 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                 )}
               </div>
             )}
-            {data.originalName &&
-              data.originalLanguage !== locale.slice(0, 2) && (
-                <div className="media-fact">
-                  <span>{intl.formatMessage(messages.originaltitle)}</span>
-                  <span className="media-fact-value">{data.originalName}</span>
-                </div>
-              )}
+            {data.originalName && data.originalLanguage !== locale.slice(0, 2) && (
+              <div className="media-fact">
+                <span>{intl.formatMessage(messages.originaltitle)}</span>
+                <span className="media-fact-value">{data.originalName}</span>
+              </div>
+            )}
             {data.keywords.some(
               (keyword) => keyword.id === ANIME_KEYWORD_ID
             ) && (


### PR DESCRIPTION
#### Description

**Empty Episode Count**

Season list and request modal on the tv details page would show empty seasons. Specifically for the request modal, it would allow you to request a season with 0 episodes. Another addition in this PR is a change to the ChevronIcon for consistency across the app.

- Episode count is now added as a conditional to check for seasons.
- ChevronUpIcon changed to ChevronDownIcon

#### To-Dos

- [x] Successful build `yarn build`
