### PR TITLE
fix(request): approve request when retrying request

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -492,8 +492,10 @@ requestRoutes.post<{
         relations: { requestedBy: true, modifiedBy: true },
       });
 
-      await request.updateParentStatus();
-      await request.sendMedia();
+      // this also triggers updating the parent media's status & sending to *arr
+      request.status = MediaRequestStatus.APPROVED;
+      await requestRepository.save(request);
+
       return res.status(200).json(request);
     } catch (e) {
       logger.error('Error processing request retry', {


### PR DESCRIPTION
#### Description

The retry logic was not updated when the criteria used to determine what a failed request is was updated in #2944. With the way failed requests are identified now, the only thing required when retrying a request is to accept it since TypeORM will update the parent media's status (for TV shows, when applicable) as well as send the request to the *arr when a request is accepted.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3090 
