### PR TITLE
fix: screen would zoom on mobile if date picker input was selected

### DIFF
--- a/src/components/Discover/FilterSlideover/index.tsx
+++ b/src/components/Discover/FilterSlideover/index.tsx
@@ -95,7 +95,7 @@ const FilterSlideover = ({
                 useRange={false}
                 asSingle
                 containerClassName="datepicker-wrapper"
-                inputClassName="pr-1 sm:pr-4"
+                inputClassName="pr-1 sm:pr-4 text-base leading-5"
               />
             </div>
             <div className="flex flex-col">
@@ -116,7 +116,7 @@ const FilterSlideover = ({
                 useRange={false}
                 asSingle
                 containerClassName="datepicker-wrapper"
-                inputClassName="pr-1 sm:pr-4"
+                inputClassName="pr-1 sm:pr-4 text-base leading-5"
               />
             </div>
           </div>


### PR DESCRIPTION
#### Description

Prevents zooming on mobile when the date picker input is selected. Adding a slightly larger font fixes this.

#### To-Dos

- [x] Successful build `yarn build`
