### PR TITLE
fix(request): mark request as approved if media is already available when retrying failed request

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -767,7 +767,7 @@ export class MediaRequest {
         if (
           media[this.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
         ) {
-          logger.warn('Media already available, marking request as APPROVED', {
+          logger.warn('Media already exists, marking request as APPROVED', {
             label: 'Media Request',
             requestId: this.id,
             mediaId: this.media.id,
@@ -917,7 +917,7 @@ export class MediaRequest {
         if (
           media[this.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
         ) {
-          logger.warn('Media already available, marking request as APPROVED', {
+          logger.warn('Media already exists, marking request as APPROVED', {
             label: 'Media Request',
             requestId: this.id,
             mediaId: this.media.id,

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -767,7 +767,16 @@ export class MediaRequest {
         if (
           media[this.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
         ) {
-          throw new Error('Media already available');
+          logger.warn('Media already available, marking request as APPROVED', {
+            label: 'Media Request',
+            requestId: this.id,
+            mediaId: this.media.id,
+          });
+
+          const requestRepository = getRepository(MediaRequest);
+          this.status = MediaRequestStatus.APPROVED;
+          await requestRepository.save(this);
+          return;
         }
 
         const radarrMovieOptions: RadarrMovieOptions = {
@@ -908,7 +917,16 @@ export class MediaRequest {
         if (
           media[this.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
         ) {
-          throw new Error('Media already available');
+          logger.warn('Media already available, marking request as APPROVED', {
+            label: 'Media Request',
+            requestId: this.id,
+            mediaId: this.media.id,
+          });
+
+          const requestRepository = getRepository(MediaRequest);
+          this.status = MediaRequestStatus.APPROVED;
+          await requestRepository.save(this);
+          return;
         }
 
         const tmdb = new TheMovieDb();


### PR DESCRIPTION
#### Description

Failed requests whose media have become available while the request wasn't retried would fail with the error message `Media already available` when retried. This changes that behaviour to mark the request as approved instead.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
