### PR TITLE
fix: added a refresh interval if download status is in progress

### DIFF
--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -14,7 +14,7 @@ interface ScheduledJob {
   job: schedule.Job;
   name: string;
   type: 'process' | 'command';
-  interval: 'short' | 'long' | 'fixed';
+  interval: 'seconds' | 'minutes' | 'hours' | 'fixed';
   cronSchedule: string;
   running?: () => boolean;
   cancelFn?: () => void;
@@ -30,7 +30,7 @@ export const startJobs = (): void => {
     id: 'plex-recently-added-scan',
     name: 'Plex Recently Added Scan',
     type: 'process',
-    interval: 'short',
+    interval: 'minutes',
     cronSchedule: jobs['plex-recently-added-scan'].schedule,
     job: schedule.scheduleJob(jobs['plex-recently-added-scan'].schedule, () => {
       logger.info('Starting scheduled job: Plex Recently Added Scan', {
@@ -47,7 +47,7 @@ export const startJobs = (): void => {
     id: 'plex-full-scan',
     name: 'Plex Full Library Scan',
     type: 'process',
-    interval: 'long',
+    interval: 'hours',
     cronSchedule: jobs['plex-full-scan'].schedule,
     job: schedule.scheduleJob(jobs['plex-full-scan'].schedule, () => {
       logger.info('Starting scheduled job: Plex Full Library Scan', {
@@ -64,7 +64,7 @@ export const startJobs = (): void => {
     id: 'plex-watchlist-sync',
     name: 'Plex Watchlist Sync',
     type: 'process',
-    interval: 'short',
+    interval: 'minutes',
     cronSchedule: jobs['plex-watchlist-sync'].schedule,
     job: schedule.scheduleJob(jobs['plex-watchlist-sync'].schedule, () => {
       logger.info('Starting scheduled job: Plex Watchlist Sync', {
@@ -79,7 +79,7 @@ export const startJobs = (): void => {
     id: 'radarr-scan',
     name: 'Radarr Scan',
     type: 'process',
-    interval: 'long',
+    interval: 'hours',
     cronSchedule: jobs['radarr-scan'].schedule,
     job: schedule.scheduleJob(jobs['radarr-scan'].schedule, () => {
       logger.info('Starting scheduled job: Radarr Scan', { label: 'Jobs' });
@@ -94,7 +94,7 @@ export const startJobs = (): void => {
     id: 'sonarr-scan',
     name: 'Sonarr Scan',
     type: 'process',
-    interval: 'long',
+    interval: 'hours',
     cronSchedule: jobs['sonarr-scan'].schedule,
     job: schedule.scheduleJob(jobs['sonarr-scan'].schedule, () => {
       logger.info('Starting scheduled job: Sonarr Scan', { label: 'Jobs' });
@@ -109,7 +109,7 @@ export const startJobs = (): void => {
     id: 'download-sync',
     name: 'Download Sync',
     type: 'command',
-    interval: 'fixed',
+    interval: 'seconds',
     cronSchedule: jobs['download-sync'].schedule,
     job: schedule.scheduleJob(jobs['download-sync'].schedule, () => {
       logger.debug('Starting scheduled job: Download Sync', {
@@ -124,7 +124,7 @@ export const startJobs = (): void => {
     id: 'download-sync-reset',
     name: 'Download Sync Reset',
     type: 'command',
-    interval: 'long',
+    interval: 'hours',
     cronSchedule: jobs['download-sync-reset'].schedule,
     job: schedule.scheduleJob(jobs['download-sync-reset'].schedule, () => {
       logger.info('Starting scheduled job: Download Sync Reset', {
@@ -134,12 +134,12 @@ export const startJobs = (): void => {
     }),
   });
 
-  // Run image cache cleanup every 5 minutes
+  // Run image cache cleanup every 24 hours
   scheduledJobs.push({
     id: 'image-cache-cleanup',
     name: 'Image Cache Cleanup',
     type: 'process',
-    interval: 'long',
+    interval: 'hours',
     cronSchedule: jobs['image-cache-cleanup'].schedule,
     job: schedule.scheduleJob(jobs['image-cache-cleanup'].schedule, () => {
       logger.info('Starting scheduled job: Image Cache Cleanup', {

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -16,7 +16,7 @@ import type { Collection } from '@server/models/Collection';
 import { uniq } from 'lodash';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import useSWR from 'swr';
 
@@ -38,7 +38,26 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
   const { hasPermission } = useUser();
   const [requestModal, setRequestModal] = useState(false);
   const [is4k, setIs4k] = useState(false);
-  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
+
+  const refreshIntervalChecker = (data: Collection | undefined) => {
+    const [tempDownloadStatus, tempDownloadStatus4k] = [
+      data?.parts.flatMap((item) =>
+        item.mediaInfo?.downloadStatus ? item.mediaInfo?.downloadStatus : []
+      ),
+      data?.parts.flatMap((item) =>
+        item.mediaInfo?.downloadStatus4k ? item.mediaInfo?.downloadStatus4k : []
+      ),
+    ];
+
+    if (
+      (tempDownloadStatus ?? []).length > 0 ||
+      (tempDownloadStatus4k ?? []).length > 0
+    ) {
+      return 5000;
+    } else {
+      return 0;
+    }
+  };
 
   const {
     data,
@@ -47,7 +66,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
   } = useSWR<Collection>(`/api/v1/collection/${router.query.collectionId}`, {
     fallbackData: collection,
     revalidateOnMount: true,
-    refreshInterval: refreshIntervalTimer,
+    refreshInterval: refreshIntervalChecker(collection),
   });
 
   const { data: genres } =
@@ -74,17 +93,6 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
         .map((title) => title.title),
     ];
   }, [data?.parts]);
-
-  useEffect(() => {
-    if (
-      (downloadStatus ?? []).length > 0 ||
-      (downloadStatus4k ?? []).length > 0
-    ) {
-      setRefreshIntervalTimer(5000);
-    } else {
-      setRefreshIntervalTimer(0);
-    }
-  }, [downloadStatus, downloadStatus4k]);
 
   if (!data && !error) {
     return <LoadingSpinner />;

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -16,7 +16,7 @@ import type { Collection } from '@server/models/Collection';
 import { uniq } from 'lodash';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import useSWR from 'swr';
 
@@ -38,6 +38,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
   const { hasPermission } = useUser();
   const [requestModal, setRequestModal] = useState(false);
   const [is4k, setIs4k] = useState(false);
+  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
 
   const {
     data,
@@ -46,6 +47,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
   } = useSWR<Collection>(`/api/v1/collection/${router.query.collectionId}`, {
     fallbackData: collection,
     revalidateOnMount: true,
+    refreshInterval: refreshIntervalTimer,
   });
 
   const { data: genres } =
@@ -72,6 +74,17 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
         .map((title) => title.title),
     ];
   }, [data?.parts]);
+
+  useEffect(() => {
+    if (
+      (downloadStatus ?? []).length > 0 ||
+      (downloadStatus4k ?? []).length > 0
+    ) {
+      setRefreshIntervalTimer(5000);
+    } else {
+      setRefreshIntervalTimer(0);
+    }
+  }, [downloadStatus, downloadStatus4k]);
 
   if (!data && !error) {
     return <LoadingSpinner />;

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -103,7 +103,17 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   const minStudios = 3;
   const [showMoreStudios, setShowMoreStudios] = useState(false);
   const [showIssueModal, setShowIssueModal] = useState(false);
-  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
+
+  const refreshIntervalChecker = (data: MovieDetailsType | undefined) => {
+    if (
+      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
+      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
+    ) {
+      return 5000;
+    } else {
+      return 0;
+    }
+  };
 
   const {
     data,
@@ -111,7 +121,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     mutate: revalidate,
   } = useSWR<MovieDetailsType>(`/api/v1/movie/${router.query.movieId}`, {
     fallbackData: movie,
-    refreshInterval: refreshIntervalTimer,
+    refreshInterval: refreshIntervalChecker(movie),
   });
 
   const { data: ratingData } = useSWR<RTRating>(
@@ -122,17 +132,6 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     () => sortCrewPriority(data?.credits.crew ?? []),
     [data]
   );
-
-  useEffect(() => {
-    if (
-      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
-      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
-    ) {
-      setRefreshIntervalTimer(5000);
-    } else {
-      setRefreshIntervalTimer(0);
-    }
-  }, [data?.mediaInfo?.downloadStatus, data?.mediaInfo?.downloadStatus4k]);
 
   useEffect(() => {
     setShowManager(router.query.manage == '1' ? true : false);

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -103,6 +103,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   const minStudios = 3;
   const [showMoreStudios, setShowMoreStudios] = useState(false);
   const [showIssueModal, setShowIssueModal] = useState(false);
+  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
 
   const {
     data,
@@ -110,6 +111,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     mutate: revalidate,
   } = useSWR<MovieDetailsType>(`/api/v1/movie/${router.query.movieId}`, {
     fallbackData: movie,
+    refreshInterval: refreshIntervalTimer,
   });
 
   const { data: ratingData } = useSWR<RTRating>(
@@ -120,6 +122,17 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     () => sortCrewPriority(data?.credits.crew ?? []),
     [data]
   );
+
+  useEffect(() => {
+    if (
+      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
+      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
+    ) {
+      setRefreshIntervalTimer(5000);
+    } else {
+      setRefreshIntervalTimer(0);
+    }
+  }, [data?.mediaInfo?.downloadStatus, data?.mediaInfo?.downloadStatus4k]);
 
   useEffect(() => {
     setShowManager(router.query.manage == '1' ? true : false);

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -26,6 +26,7 @@ import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import Error from '@app/pages/_error';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
+import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import {
   ArrowRightCircleIcon,
   CloudIcon,
@@ -104,24 +105,19 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   const [showMoreStudios, setShowMoreStudios] = useState(false);
   const [showIssueModal, setShowIssueModal] = useState(false);
 
-  const refreshIntervalChecker = (data: MovieDetailsType | undefined) => {
-    if (
-      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
-      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
-    ) {
-      return 5000;
-    } else {
-      return 0;
-    }
-  };
-
   const {
     data,
     error,
     mutate: revalidate,
   } = useSWR<MovieDetailsType>(`/api/v1/movie/${router.query.movieId}`, {
     fallbackData: movie,
-    refreshInterval: refreshIntervalChecker(movie),
+    refreshInterval: refreshIntervalHelper(
+      {
+        downloadStatus: movie?.mediaInfo?.downloadStatus,
+        downloadStatus4k: movie?.mediaInfo?.downloadStatus4k,
+      },
+      15000
+    ),
   });
 
   const { data: ratingData } = useSWR<RTRating>(

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -216,6 +216,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
   const { addToast } = useToasts();
   const [isRetrying, setRetrying] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
   const url =
     request.type === 'movie'
       ? `/api/v1/movie/${request.media.tmdbId}`
@@ -229,7 +230,19 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
     mutate: revalidate,
   } = useSWR<MediaRequest>(`/api/v1/request/${request.id}`, {
     fallbackData: request,
+    refreshInterval: refreshIntervalTimer,
   });
+
+  useEffect(() => {
+    if (
+      (requestData?.media.downloadStatus ?? []).length > 0 ||
+      (requestData?.media.downloadStatus4k ?? []).length > 0
+    ) {
+      setRefreshIntervalTimer(5000);
+    } else {
+      setRefreshIntervalTimer(0);
+    }
+  }, [requestData?.media.downloadStatus, requestData?.media.downloadStatus4k]);
 
   const { plexUrl, plexUrl4k } = useDeepLinks({
     plexUrl: requestData?.media?.plexUrl,

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -216,11 +216,22 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
   const { addToast } = useToasts();
   const [isRetrying, setRetrying] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
-  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
   const url =
     request.type === 'movie'
       ? `/api/v1/movie/${request.media.tmdbId}`
       : `/api/v1/tv/${request.media.tmdbId}`;
+
+  const refreshIntervalChecker = (data: MediaRequest) => {
+    if (
+      (data.media.downloadStatus ?? []).length > 0 ||
+      (data.media.downloadStatus4k ?? []).length > 0
+    ) {
+      return 5000;
+    } else {
+      return 0;
+    }
+  };
+
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? `${url}` : null
   );
@@ -230,19 +241,8 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
     mutate: revalidate,
   } = useSWR<MediaRequest>(`/api/v1/request/${request.id}`, {
     fallbackData: request,
-    refreshInterval: refreshIntervalTimer,
+    refreshInterval: refreshIntervalChecker(request),
   });
-
-  useEffect(() => {
-    if (
-      (requestData?.media.downloadStatus ?? []).length > 0 ||
-      (requestData?.media.downloadStatus4k ?? []).length > 0
-    ) {
-      setRefreshIntervalTimer(5000);
-    } else {
-      setRefreshIntervalTimer(0);
-    }
-  }, [requestData?.media.downloadStatus, requestData?.media.downloadStatus4k]);
 
   const { plexUrl, plexUrl4k } = useDeepLinks({
     plexUrl: requestData?.media?.plexUrl,

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -20,7 +20,7 @@ import type { MovieDetails } from '@server/models/Movie';
 import type { TvDetails } from '@server/models/Tv';
 import axios from 'axios';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { defineMessages, FormattedRelativeTime, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
@@ -282,6 +282,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
   const intl = useIntl();
   const { user, hasPermission } = useUser();
   const [showEditModal, setShowEditModal] = useState(false);
+  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
   const url =
     request.type === 'movie'
       ? `/api/v1/movie/${request.media.tmdbId}`
@@ -293,8 +294,20 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
     `/api/v1/request/${request.id}`,
     {
       fallbackData: request,
+      refreshInterval: refreshIntervalTimer,
     }
   );
+
+  useEffect(() => {
+    if (
+      (requestData?.media.downloadStatus ?? []).length > 0 ||
+      (requestData?.media.downloadStatus4k ?? []).length > 0
+    ) {
+      setRefreshIntervalTimer(5000);
+    } else {
+      setRefreshIntervalTimer(0);
+    }
+  }, [requestData?.media.downloadStatus, requestData?.media.downloadStatus4k]);
 
   const [isRetrying, setRetrying] = useState(false);
 

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -7,6 +7,7 @@ import StatusBadge from '@app/components/StatusBadge';
 import useDeepLinks from '@app/hooks/useDeepLinks';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import {
   ArrowPathIcon,
   CheckIcon,
@@ -286,18 +287,6 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
     request.type === 'movie'
       ? `/api/v1/movie/${request.media.tmdbId}`
       : `/api/v1/tv/${request.media.tmdbId}`;
-
-  const refreshIntervalChecker = (data: MediaRequest) => {
-    if (
-      (data.media.downloadStatus ?? []).length > 0 ||
-      (data.media.downloadStatus4k ?? []).length > 0
-    ) {
-      return 5000;
-    } else {
-      return 0;
-    }
-  };
-
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? url : null
   );
@@ -305,7 +294,13 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
     `/api/v1/request/${request.id}`,
     {
       fallbackData: request,
-      refreshInterval: refreshIntervalChecker(request),
+      refreshInterval: refreshIntervalHelper(
+        {
+          downloadStatus: request.media.downloadStatus,
+          downloadStatus4k: request.media.downloadStatus4k,
+        },
+        15000
+      ),
     }
   );
 

--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -67,6 +67,8 @@ const messages: { [messageName: string]: MessageDescriptor } = defineMessages({
     'Every {jobScheduleHours, plural, one {hour} other {{jobScheduleHours} hours}}',
   editJobScheduleSelectorMinutes:
     'Every {jobScheduleMinutes, plural, one {minute} other {{jobScheduleMinutes} minutes}}',
+  editJobScheduleSelectorSeconds:
+    'Every {jobScheduleSeconds, plural, one {second} other {{jobScheduleSeconds} seconds}}',
   imagecache: 'Image Cache',
   imagecacheDescription:
     'When enabled in settings, Overseerr will proxy and cache images from pre-configured external sources. Cached images are saved into your config folder. You can find the files in <code>{appDataPath}/cache/images</code>.',
@@ -78,7 +80,7 @@ interface Job {
   id: JobId;
   name: string;
   type: 'process' | 'command';
-  interval: 'short' | 'long' | 'fixed';
+  interval: 'seconds' | 'minutes' | 'hours' | 'fixed';
   cronSchedule: string;
   nextExecutionTime: string;
   running: boolean;
@@ -89,10 +91,11 @@ type JobModalState = {
   job?: Job;
   scheduleHours: number;
   scheduleMinutes: number;
+  scheduleSeconds: number;
 };
 
 type JobModalAction =
-  | { type: 'set'; hours?: number; minutes?: number }
+  | { type: 'set'; hours?: number; minutes?: number; seconds?: number }
   | {
       type: 'close';
     }
@@ -115,6 +118,7 @@ const jobModalReducer = (
         job: action.job,
         scheduleHours: 1,
         scheduleMinutes: 5,
+        scheduleSeconds: 30,
       };
 
     case 'set':
@@ -122,6 +126,7 @@ const jobModalReducer = (
         ...state,
         scheduleHours: action.hours ?? state.scheduleHours,
         scheduleMinutes: action.minutes ?? state.scheduleMinutes,
+        scheduleSeconds: action.seconds ?? state.scheduleSeconds,
       };
   }
 };
@@ -149,6 +154,7 @@ const SettingsJobs = () => {
     isOpen: false,
     scheduleHours: 1,
     scheduleMinutes: 5,
+    scheduleSeconds: 30,
   });
   const [isSaving, setIsSaving] = useState(false);
 
@@ -200,9 +206,11 @@ const SettingsJobs = () => {
     const jobScheduleCron = ['0', '0', '*', '*', '*', '*'];
 
     try {
-      if (jobModalState.job?.interval === 'short') {
+      if (jobModalState.job?.interval === 'seconds') {
+        jobScheduleCron.splice(0, 2, `*/${jobModalState.scheduleSeconds}`, '*');
+      } else if (jobModalState.job?.interval === 'minutes') {
         jobScheduleCron[1] = `*/${jobModalState.scheduleMinutes}`;
-      } else if (jobModalState.job?.interval === 'long') {
+      } else if (jobModalState.job?.interval === 'hours') {
         jobScheduleCron[2] = `*/${jobModalState.scheduleHours}`;
       } else {
         // jobs with interval: fixed should not be editable
@@ -286,7 +294,30 @@ const SettingsJobs = () => {
                   {intl.formatMessage(messages.editJobSchedulePrompt)}
                 </label>
                 <div className="form-input-area">
-                  {jobModalState.job?.interval === 'short' ? (
+                  {jobModalState.job?.interval === 'seconds' ? (
+                    <select
+                      name="jobScheduleSeconds"
+                      className="inline"
+                      value={jobModalState.scheduleSeconds}
+                      onChange={(e) =>
+                        dispatch({
+                          type: 'set',
+                          seconds: Number(e.target.value),
+                        })
+                      }
+                    >
+                      {[30, 45, 60].map((v) => (
+                        <option value={v} key={`jobScheduleSeconds-${v}`}>
+                          {intl.formatMessage(
+                            messages.editJobScheduleSelectorSeconds,
+                            {
+                              jobScheduleSeconds: v,
+                            }
+                          )}
+                        </option>
+                      ))}
+                    </select>
+                  ) : jobModalState.job?.interval === 'minutes' ? (
                     <select
                       name="jobScheduleMinutes"
                       className="inline"

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -102,6 +102,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     router.query.manage == '1' ? true : false
   );
   const [showIssueModal, setShowIssueModal] = useState(false);
+  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
 
   const {
     data,
@@ -109,6 +110,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     mutate: revalidate,
   } = useSWR<TvDetailsType>(`/api/v1/tv/${router.query.tvId}`, {
     fallbackData: tv,
+    refreshInterval: refreshIntervalTimer,
   });
 
   const { data: ratingData } = useSWR<RTRating>(
@@ -119,6 +121,17 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     () => sortCrewPriority(data?.credits.crew ?? []),
     [data]
   );
+
+  useEffect(() => {
+    if (
+      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
+      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
+    ) {
+      setRefreshIntervalTimer(5000);
+    } else {
+      setRefreshIntervalTimer(0);
+    }
+  }, [data?.mediaInfo?.downloadStatus, data?.mediaInfo?.downloadStatus4k]);
 
   useEffect(() => {
     setShowManager(router.query.manage == '1' ? true : false);

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -30,6 +30,7 @@ import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import Error from '@app/pages/_error';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
+import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import { Disclosure, Transition } from '@headlessui/react';
 import {
   ArrowRightCircleIcon,
@@ -103,24 +104,19 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   );
   const [showIssueModal, setShowIssueModal] = useState(false);
 
-  const refreshIntervalChecker = (data: TvDetailsType | undefined) => {
-    if (
-      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
-      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
-    ) {
-      return 5000;
-    } else {
-      return 0;
-    }
-  };
-
   const {
     data,
     error,
     mutate: revalidate,
   } = useSWR<TvDetailsType>(`/api/v1/tv/${router.query.tvId}`, {
     fallbackData: tv,
-    refreshInterval: refreshIntervalChecker(tv),
+    refreshInterval: refreshIntervalHelper(
+      {
+        downloadStatus: tv?.mediaInfo?.downloadStatus,
+        downloadStatus4k: tv?.mediaInfo?.downloadStatus4k,
+      },
+      15000
+    ),
   });
 
   const { data: ratingData } = useSWR<RTRating>(

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -102,7 +102,17 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     router.query.manage == '1' ? true : false
   );
   const [showIssueModal, setShowIssueModal] = useState(false);
-  const [refreshIntervalTimer, setRefreshIntervalTimer] = useState(0);
+
+  const refreshIntervalChecker = (data: TvDetailsType | undefined) => {
+    if (
+      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
+      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
+    ) {
+      return 5000;
+    } else {
+      return 0;
+    }
+  };
 
   const {
     data,
@@ -110,7 +120,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     mutate: revalidate,
   } = useSWR<TvDetailsType>(`/api/v1/tv/${router.query.tvId}`, {
     fallbackData: tv,
-    refreshInterval: refreshIntervalTimer,
+    refreshInterval: refreshIntervalChecker(tv),
   });
 
   const { data: ratingData } = useSWR<RTRating>(
@@ -121,17 +131,6 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     () => sortCrewPriority(data?.credits.crew ?? []),
     [data]
   );
-
-  useEffect(() => {
-    if (
-      (data?.mediaInfo?.downloadStatus ?? []).length > 0 ||
-      (data?.mediaInfo?.downloadStatus4k ?? []).length > 0
-    ) {
-      setRefreshIntervalTimer(5000);
-    } else {
-      setRefreshIntervalTimer(0);
-    }
-  }, [data?.mediaInfo?.downloadStatus, data?.mediaInfo?.downloadStatus4k]);
 
   useEffect(() => {
     setShowManager(router.query.manage == '1' ? true : false);

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -739,6 +739,7 @@
   "components.Settings.SettingsJobsCache.editJobSchedulePrompt": "New Frequency",
   "components.Settings.SettingsJobsCache.editJobScheduleSelectorHours": "Every {jobScheduleHours, plural, one {hour} other {{jobScheduleHours} hours}}",
   "components.Settings.SettingsJobsCache.editJobScheduleSelectorMinutes": "Every {jobScheduleMinutes, plural, one {minute} other {{jobScheduleMinutes} minutes}}",
+  "components.Settings.SettingsJobsCache.editJobScheduleSelectorSeconds": "Every {jobScheduleSeconds, plural, one {second} other {{jobScheduleSeconds} seconds}}",
   "components.Settings.SettingsJobsCache.flushcache": "Flush Cache",
   "components.Settings.SettingsJobsCache.image-cache-cleanup": "Image Cache Cleanup",
   "components.Settings.SettingsJobsCache.imagecache": "Image Cache",

--- a/src/utils/refreshIntervalHelper.ts
+++ b/src/utils/refreshIntervalHelper.ts
@@ -1,0 +1,18 @@
+import type { DownloadingItem } from '@server/lib/downloadtracker';
+
+export const refreshIntervalHelper = (
+  downloadItem: {
+    downloadStatus: DownloadingItem[] | undefined;
+    downloadStatus4k: DownloadingItem[] | undefined;
+  },
+  timer: number
+) => {
+  if (
+    (downloadItem.downloadStatus ?? []).length > 0 ||
+    (downloadItem.downloadStatus4k ?? []).length > 0
+  ) {
+    return timer;
+  } else {
+    return 0;
+  }
+};


### PR DESCRIPTION
#### Description

Progress bar would not fetch new download status progress if page was not refocused or reloaded. To solve this, I added a refreshInterval if there is a download to watch. I also added in a change to make the download sync editable, in case you want to grab the download status at a faster rate.

- Each component we will call refreshIntervalHelper to see if downloadStatus contains items and then update the timer accordingly.
- Timer set to 5000ms if items are present but this can be altered if needed.
- Download sync schedule is now editable. Editable times are 30, 45, and 60 seconds. 

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #3270 