### PR TITLE
fix: multiple genre filtering now works

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4418,7 +4418,7 @@ paths:
         - in: query
           name: genre
           schema:
-            type: number
+            type: string
             example: 18
         - in: query
           name: network

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -85,7 +85,7 @@ interface DiscoverTvOptions {
   voteAverageLte?: string;
   includeEmptyReleaseDate?: boolean;
   originalLanguage?: string;
-  genre?: number;
+  genre?: string;
   network?: number;
   keywords?: string;
   sortBy?: SortOptions;

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -356,7 +356,7 @@ discoverRoutes.get('/tv', async (req, res, next) => {
       page: Number(query.page),
       sortBy: query.sortBy as SortOptions,
       language: req.locale ?? query.language,
-      genre: query.genre ? Number(query.genre) : undefined,
+      genre: query.genre,
       network: query.network ? Number(query.network) : undefined,
       firstAirDateLte: query.firstAirDateLte
         ? new Date(query.firstAirDateLte).toISOString().split('T')[0]
@@ -491,7 +491,7 @@ discoverRoutes.get<{ genreId: string }>(
       const data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
         language: req.locale ?? (req.query.language as string),
-        genre: Number(req.params.genreId),
+        genre: req.params.genreId,
       });
 
       const media = await Media.getRelatedMedia(
@@ -770,7 +770,9 @@ discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
 
       await Promise.all(
         genres.map(async (genre) => {
-          const genreData = await tmdb.getDiscoverTv({ genre: genre.id });
+          const genreData = await tmdb.getDiscoverTv({
+            genre: genre.id.toString(),
+          });
 
           mappedGenres.push({
             id: genre.id,


### PR DESCRIPTION
#### Description

Adding multiple genres to the filter caused a 500 error. Query was being passed in as a number but is now passed in as a string. This is the same as we do for movie genre filtering.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3279 
