### PR TITLE
fix: series first air date filtering

### DIFF
--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -91,10 +91,10 @@ const DiscoverTv = () => {
               <option value={SortOptions.PopularityAsc}>
                 {intl.formatMessage(messages.sortPopularityAsc)}
               </option>
-              <option value={SortOptions.ReleaseDateDesc}>
+              <option value={SortOptions.FirstAirDateDesc}>
                 {intl.formatMessage(messages.sortFirstAirDateDesc)}
               </option>
-              <option value={SortOptions.ReleaseDateAsc}>
+              <option value={SortOptions.FirstAirDateAsc}>
                 {intl.formatMessage(messages.sortFirstAirDateAsc)}
               </option>
               <option value={SortOptions.TmdbRatingDesc}>


### PR DESCRIPTION
#### Description

Series sorting was not filtering correctly when use the first date ascending or descending. Incorrect sort option was being passed in as a value. Works well now!

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3280 
