### PR TITLE
fix: recently added items scan

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -226,12 +226,13 @@ class PlexAPI {
     id: string,
     options: { addedAt: number } = {
       addedAt: Date.now() - 1000 * 60 * 60,
-    }
+    },
+    mediaType: 'movie' | 'show'
   ): Promise<PlexLibraryItem[]> {
     const response = await this.plexClient.query<PlexLibraryResponse>({
-      uri: `/library/sections/${id}/all?sort=addedAt%3Adesc&addedAt>>=${Math.floor(
-        options.addedAt / 1000
-      )}`,
+      uri: `/library/sections/${id}/all?type=${
+        mediaType === 'show' ? '4' : '1'
+      }&sort=addedAt%3Adesc&addedAt>>=${Math.floor(options.addedAt / 1000)}`,
       extraHeaders: {
         'X-Plex-Container-Start': `0`,
         'X-Plex-Container-Size': `500`,

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -96,7 +96,8 @@ class PlexScanner
                   // We remove 10 minutes from the last scan as a buffer
                   addedAt: library.lastScan - 1000 * 60 * 10,
                 }
-              : undefined
+              : undefined,
+            library.type
           );
 
           // Bundle items up by rating keys


### PR DESCRIPTION
#### Description

Plex recently added would not add any new seasons if the show was already added at least once. We will now pass in and check the Plex library based on the media type. This will make sure we will check for new seasons/episodes that are added to an existing show.

- Passed in a new prop to getRecentlyAdded for mediaType
- Type 4 will be used for shows. Type 1 used for movies.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3276 
