### PR TITLE
fix(ui): style range thumbs correctly for firefox

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -452,8 +452,9 @@
     @apply hidden;
   }
 
-  input[type='range']::-webkit-slider-thumb {
-    @apply rounded-full bg-indigo-500;
+  input[type='range']::-webkit-slider-thumb,
+  input[type='range']::-moz-range-thumb {
+    @apply rounded-full border-0 bg-indigo-500;
     pointer-events: all;
     width: 16px;
     height: 16px;


### PR DESCRIPTION
#### Description

Fix styling for range sliders in Firefox.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3288 
