### PR TITLE
fix: air date will use UTC for timezone

### DIFF
--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -37,6 +37,7 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
           year: 'numeric',
           month: 'long',
           day: 'numeric',
+          timeZone: 'UTC',
         })}
       </Badge>
       {showRelative && (

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -621,6 +621,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                           year: 'numeric',
                           month: 'long',
                           day: 'numeric',
+                          timeZone: 'UTC',
                         })}
                       </span>
                     </span>
@@ -640,6 +641,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric',
+                      timeZone: 'UTC',
                     })}
                   </span>
                 </div>

--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -91,11 +91,13 @@ const PersonDetails = () => {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
+            timeZone: 'UTC',
           }),
           deathdate: intl.formatDate(data.deathday, {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
+            timeZone: 'UTC',
           }),
         })
       );
@@ -106,6 +108,7 @@ const PersonDetails = () => {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
+            timeZone: 'UTC',
           }),
         })
       );

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -844,6 +844,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
+                    timeZone: 'UTC',
                   })}
                 </span>
               </div>
@@ -858,6 +859,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric',
+                      timeZone: 'UTC',
                     })}
                   </span>
                 </div>


### PR DESCRIPTION
#### Description

Will make sure the series air dates are using the correct UTC timezone. Previously, series air dates were one day off. Included an example of The Last of Us now showing the correct First and Next Air Date.

#### Screenshot (if UI-related)

<img width="944" alt="Screenshot 2023-01-29 at 2 14 30 AM" src="https://user-images.githubusercontent.com/8635678/215311240-609d5479-9a6c-4ac8-97ed-b00f2a407185.png">


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3289 
