### PR TITLE
fix(snapcraft): use the correct config folder for image cache

### DIFF
--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -18,14 +18,14 @@ type ImageResponse = {
   imageBuffer: Buffer;
 };
 
+const baseCacheDirectory = process.env.CONFIG_DIRECTORY
+  ? `${process.env.CONFIG_DIRECTORY}/cache/images`
+  : path.join(__dirname, '../../config/cache/images');
+
 class ImageProxy {
   public static async clearCache(key: string) {
     let deletedImages = 0;
-    const cacheDirectory = path.join(
-      __dirname,
-      '../../config/cache/images/',
-      key
-    );
+    const cacheDirectory = path.join(baseCacheDirectory, key);
 
     const files = await promises.readdir(cacheDirectory);
 
@@ -57,11 +57,7 @@ class ImageProxy {
   public static async getImageStats(
     key: string
   ): Promise<{ size: number; imageCount: number }> {
-    const cacheDirectory = path.join(
-      __dirname,
-      '../../config/cache/images/',
-      key
-    );
+    const cacheDirectory = path.join(baseCacheDirectory, key);
 
     const imageTotalSize = await ImageProxy.getDirectorySize(cacheDirectory);
     const imageCount = await ImageProxy.getImageCount(cacheDirectory);
@@ -263,7 +259,7 @@ class ImageProxy {
   }
 
   private getCacheDirectory() {
-    return path.join(__dirname, '../../config/cache/images/', this.key);
+    return path.join(baseCacheDirectory, this.key);
   }
 }
 


### PR DESCRIPTION
#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3170 
