### PR TITLE
fix: compensate for timezone by using offset

### DIFF
--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -15,7 +15,9 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
   const intl = useIntl();
   const dAirDate = new Date(airDate);
   const nowDate = new Date();
-  const alreadyAired = dAirDate.getTime() < nowDate.getTime();
+  const dAirDateOffset =
+    dAirDate.getTime() - dAirDate.getTimezoneOffset() * -60000;
+  const alreadyAired = dAirDateOffset < nowDate.getTime();
 
   const compareWeek = new Date(
     alreadyAired ? Date.now() - WEEK : Date.now() + WEEK
@@ -24,11 +26,15 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
   let showRelative = false;
 
   if (
-    (alreadyAired && dAirDate.getTime() > compareWeek.getTime()) ||
-    (!alreadyAired && dAirDate.getTime() < compareWeek.getTime())
+    (alreadyAired && dAirDateOffset > compareWeek.getTime()) ||
+    (!alreadyAired && dAirDateOffset < compareWeek.getTime())
   ) {
     showRelative = true;
   }
+
+  const relativeTime = (dAirDateOffset - Date.now()) / 1000;
+
+  const within24Hours = Math.floor(Math.abs(relativeTime / (60 * 60))) <= 24;
 
   return (
     <div className="flex items-center space-x-2">
@@ -45,9 +51,15 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
           {intl.formatMessage(
             alreadyAired ? messages.airedrelative : messages.airsrelative,
             {
-              relativeTime: (
+              relativeTime: within24Hours ? (
+                alreadyAired ? (
+                  'today'
+                ) : (
+                  'tomorrow'
+                )
+              ) : (
                 <FormattedRelativeTime
-                  value={(dAirDate.getTime() - Date.now()) / 1000}
+                  value={relativeTime}
                   numeric="auto"
                   updateIntervalInSeconds={1}
                 />


### PR DESCRIPTION
#### Description

Relative air date badge will now always be correct based on what time zone you are located in. Included is a modification to the wording if the episode is airing tomorrow or today.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3300 
