### PR TITLE
feat(requests): add filter `requested` status in dropdown

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4903,6 +4903,7 @@ paths:
                 processing,
                 unavailable,
                 failed,
+                requested,
               ]
         - in: query
           name: sort

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -43,6 +43,13 @@ requestRoutes.get<Record<string, unknown>, RequestResultsResponse>(
         case 'available':
           statusFilter = [MediaRequestStatus.APPROVED];
           break;
+        case 'requested':
+          statusFilter = [
+            MediaRequestStatus.PENDING,
+            MediaRequestStatus.APPROVED,
+            MediaRequestStatus.DECLINED,
+          ];
+          break;
         case 'pending':
           statusFilter = [MediaRequestStatus.PENDING];
           break;
@@ -77,6 +84,12 @@ requestRoutes.get<Record<string, unknown>, RequestResultsResponse>(
             MediaStatus.PENDING,
             MediaStatus.PROCESSING,
             MediaStatus.PARTIALLY_AVAILABLE,
+          ];
+          break;
+        case 'requested':
+          mediaStatusFilter = [
+            MediaStatus.UNKNOWN,
+            MediaStatus.PENDING
           ];
           break;
         default:

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -33,6 +33,7 @@ enum Filter {
   PROCESSING = 'processing',
   AVAILABLE = 'available',
   UNAVAILABLE = 'unavailable',
+  REQUESTED = 'requested',
   FAILED = 'failed',
 }
 
@@ -176,6 +177,9 @@ const RequestList = () => {
               </option>
               <option value="unavailable">
                 {intl.formatMessage(globalMessages.unavailable)}
+              </option>
+              <option value="requested">
+                {intl.formatMessage(globalMessages.requested)}
               </option>
             </select>
           </div>


### PR DESCRIPTION
#### Description

Adds a `requested` status on the Requests page.

It shows PENDING, APPROVED, DECLINED requests, and UNKNOWN & PENDING media statuses.
That way, a lambda user is able to follow the status of requests and see their status.

I think this will not create a duplicate with the`pending` filter since it offers more information, especially this helps user to know if a request was declined.

#### Screenshot (if UI-related)
<img width="1678" alt="Screenshot 2023-02-04 at 5 55 45 PM" src="https://user-images.githubusercontent.com/9489181/216779750-d5b1c86f-8559-4f47-9e11-56bf4f377185.png">

<img width="331" alt="Screenshot 2023-02-04 at 5 56 00 PM" src="https://user-images.githubusercontent.com/9489181/216780026-d63a64cd-d890-40a4-8c78-9e852d37f092.png">



#### To-Dos

- [x] Successful build `yarn build`
_- [ ] Translation keys `yarn i18n:extract`_
_- [ ] Database migration (if required)_

#### Issues Fixed or Closed

- Fixes #3265
