### PR TITLE
fix(title-card): prevent card details from flickering when quickly hovered

### DIFF
--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -169,14 +169,12 @@ const TitleCard = ({
           <Transition
             as={Fragment}
             show={!image || showDetail || showRequestModal}
-            enter="transition transform opacity-0"
             enterFrom="opacity-0"
             enterTo="opacity-100"
-            leave="transition transform opacity-100"
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="absolute inset-0 overflow-hidden rounded-xl">
+            <div className="absolute inset-0 overflow-hidden rounded-xl transition transform">
               <Link href={mediaType === 'movie' ? `/movie/${id}` : `/tv/${id}`}>
                 <a
                   className="absolute inset-0 h-full w-full cursor-pointer overflow-hidden text-left"


### PR DESCRIPTION

#### Description

Prevent card details from flickering when quickly hovered. Since the UI is hover-based, not sure how we can properly fix that at 100%, but this improves the rendering.

#### Screenshot (if UI-related)
**without** fix

https://user-images.githubusercontent.com/9489181/216782853-69719281-4c32-45d6-82f2-80bed97a7a33.mov


**with** fix

https://user-images.githubusercontent.com/9489181/216782847-177c8ac7-34cb-4ddb-98c5-193e8ed0e09d.mov


#### To-Dos

- [x] Successful build `yarn build`
_- [ ] Translation keys `yarn i18n:extract`_
_- [ ] Database migration (if required)_

#### Issues Fixed or Closed

- Fixes #3273
