### PR TITLE
fix: increase threshold for amount of data to be fetched when SSR'ing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,5 +19,6 @@ module.exports = {
   },
   experimental: {
     scrollRestoration: true,
+    largePageDataBytes: 256000,
   },
 };


### PR DESCRIPTION
#### Description

This increases the threshold for the warning about the amount of data sent when doing server-side rendering from 128KB (the default) to 256KB since the strings for the locale make up almost all of that data already. This warning also gets noticed by users looking at their container logs when something isn't working as expected and may be something that they mistakenly focus on to try to diagnose their issue.

#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
