### PR TITLE
perf(server/index.ts): do not set cookies to image proxy so CDNs can cache images

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import WebhookAgent from '@server/lib/notifications/agents/webhook';
 import WebPushAgent from '@server/lib/notifications/agents/webpush';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import clearCookies from '@server/middleware/clearcookies';
 import routes from '@server/routes';
 import imageproxy from '@server/routes/imageproxy';
 import { getAppVersion } from '@server/utils/appVersion';
@@ -182,7 +183,8 @@ app
     });
     server.use('/api/v1', routes);
 
-    server.use('/imageproxy', imageproxy);
+    // Do not set cookies so CDNs can cache them
+    server.use('/imageproxy', clearCookies, imageproxy);
 
     server.get('*', (req, res) => handle(req, res));
     server.use(

--- a/server/middleware/clearcookies.ts
+++ b/server/middleware/clearcookies.ts
@@ -1,0 +1,6 @@
+const clearCookies: Middleware = (_req, res, next) => {
+  res.removeHeader('Set-Cookie');
+  next();
+};
+
+export default clearCookies;


### PR DESCRIPTION
This is only a problem if CSRF protection is enabled.

#### Description

CDNs like Cloudflare bypass their cache if cookies are set in the response.
clearCookies middleware removes the header before imageproxy serves the image.

I initially considered creating a `middlewares` collection and removing CSRF protection from the list if it is present for the image proxy, but removing the header is a much simpler solution.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

_none_