### PR TITLE
chore: remove unnecessary parenthesis

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -546,7 +546,7 @@ class Settings {
   }
 
   private generateApiKey(): string {
-    return Buffer.from(`${Date.now()}${randomUUID()})`).toString('base64');
+    return Buffer.from(`${Date.now()}${randomUUID()}`).toString('base64');
   }
 
   private generateVapidKeys(force = false): void {


### PR DESCRIPTION
#### Description

This doesn't really change anything, I just noticed that there is an additional parenthesis that was added into the API key data before being encoded. 🤷🏻

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
