### PR TITLE
fix(ui): hide mini status badge if non-4K media status is unknown

### DIFF
--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -141,7 +141,7 @@ const TitleCard = ({
                   : intl.formatMessage(globalMessages.tvshow)}
               </div>
             </div>
-            {currentStatus && (
+            {currentStatus && currentStatus !== MediaStatus.UNKNOWN && (
               <div className="pointer-events-none z-40 flex items-center">
                 <StatusBadgeMini
                   status={currentStatus}


### PR DESCRIPTION
#### Description

The mini status badge doesn't show status of 4K media, hence it shouldn't be displayed when media has been requested/is processing/is available in 4K only.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3345
