### PR TITLE
fix(ui): hide search bar behind slideover when opened

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
     }
   ],
   "editor.formatOnSave": true,
-  "typescript.preferences.importModuleSpecifier": "non-relative"
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "files.associations": {
+    "globals.css": "tailwindcss"
+  }
 }

--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -67,7 +67,7 @@ const SlideOver = ({
             >
               {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
               <div
-                className="slideover relative h-full w-screen max-w-md p-2 sm:p-4"
+                className="slideover relative h-full w-screen max-w-md p-2 sm:p-3"
                 ref={slideoverRef}
                 onClick={(e) => e.stopPropagation()}
               >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -43,8 +43,8 @@
   }
 
   .slideover {
-    padding-top: calc(1rem + env(safe-area-inset-top)) !important;
-    padding-bottom: calc(1rem + env(safe-area-inset-top)) !important;
+    padding-top: calc(0.75rem + env(safe-area-inset-top)) !important;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-top)) !important;
   }
 
   .sidebar-close-button {


### PR DESCRIPTION
#### Description

Also adds a change to the workspace settings to associate the `globals.css` file to the tailwindcss language so that VS Code doesn't show 100+ warnings when opening that file 👀 

#### Screenshot (if UI-related)
Before: 
![Screenshot_162](https://user-images.githubusercontent.com/20923978/220535698-3c174fed-0ada-4841-ad67-024a7cf7d62c.png)
![Screenshot_163](https://user-images.githubusercontent.com/20923978/220535688-dbb5194b-5c6c-430e-a800-40bd17415967.png)

After:
![Screenshot_160](https://user-images.githubusercontent.com/20923978/220535758-62608cb6-1202-4a03-ba16-cf5791a13c71.png)
![Screenshot_161](https://user-images.githubusercontent.com/20923978/220535766-cc23ff3b-1825-49d0-83fa-d210cd320fe2.png)


#### To-Dos


- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes none
