### PR TITLE
fix: corrected log levels in availability sync

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -601,7 +601,7 @@ class AvailabilitySync {
 
       //if true, media exists in at least one radarr or plex instance.
       if (existsInRadarr) {
-        logger.info(
+        logger.warn(
           `${media.tmdbId} exists in at least one radarr or plex instance. Media will be updated if set to available.`,
           {
             label: 'AvailabilitySync',
@@ -621,7 +621,7 @@ class AvailabilitySync {
 
       //if true, media exists in at least one sonarr or plex instance.
       if (existsInSonarr) {
-        logger.info(
+        logger.warn(
           `${media.tvdbId} exists in at least one sonarr or plex instance. Media will be updated if set to available.`,
           {
             label: 'AvailabilitySync',
@@ -685,7 +685,7 @@ class AvailabilitySync {
     );
 
     if (existsInSonarr) {
-      logger.info(
+      logger.warn(
         `${media.tvdbId}, season: ${season.seasonNumber} exists in at least one sonarr or plex instance. Media will be updated if set to available.`,
         {
           label: 'AvailabilitySync',


### PR DESCRIPTION
#### Description

A few log levels were mistakenly configured to log at the 'info' level instead of 'warn.' They have been updated to 'warn' as they are non-critical.

#### To-Dos

- [x] Successful build `yarn build`