### PR TITLE
fix: corrected default badge hover opacity

### DIFF
--- a/src/components/Common/Badge/index.tsx
+++ b/src/components/Common/Badge/index.tsx
@@ -71,7 +71,7 @@ const Badge = (
         'bg-indigo-500 bg-opacity-80 border border-indigo-500 !text-indigo-100'
       );
       if (href) {
-        badgeStyle.push('hover:bg-indigo-500 bg-opacity-100');
+        badgeStyle.push('hover:bg-indigo-500 hover:bg-opacity-100');
       }
   }
 


### PR DESCRIPTION
#### Description

Extremely minor fix for the badge component. The default badge opacity was adjusted slightly to include the missing hover attribute.

#### Screenshot (if UI-related)

<img width="152" alt="Screenshot 2023-03-02 at 12 12 03 AM" src="https://user-images.githubusercontent.com/8635678/222337006-4fe5a566-d8a9-413b-90f0-5408fb8ee684.png"> <img width="149" alt="Screenshot 2023-03-02 at 12 12 37 AM" src="https://user-images.githubusercontent.com/8635678/222337078-71f62d02-364a-4368-911b-9d7695aa239b.png">

#### To-Dos

- [x] Successful build `yarn build`