### PR TITLE
fix: availability sync file detection

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -78,29 +78,6 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
     }
   }
 
-  public async getExistingMovieByTmdbId(id: number): Promise<RadarrMovie> {
-    try {
-      const response = await this.axios.get<RadarrMovie[]>('/movie', {
-        params: {
-          tmdbId: id,
-        },
-      });
-
-      if (!response.data[0]) {
-        throw new Error('Movie not found');
-      }
-
-      return response.data[0];
-    } catch (e) {
-      logger.error('Error retrieving movie by TMDB ID', {
-        label: 'Radarr API',
-        errorMessage: e.message,
-        tmdbId: id,
-      });
-      throw new Error('Movie not found');
-    }
-  }
-
   public addMovie = async (
     options: RadarrMovieOptions
   ): Promise<RadarrMovie> => {

--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -78,6 +78,29 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
     }
   }
 
+  public async getExistingMovieByTmdbId(id: number): Promise<RadarrMovie> {
+    try {
+      const response = await this.axios.get<RadarrMovie[]>('/movie', {
+        params: {
+          tmdbId: id,
+        },
+      });
+
+      if (!response.data[0]) {
+        throw new Error('Movie not found');
+      }
+
+      return response.data[0];
+    } catch (e) {
+      logger.error('Error retrieving movie by TMDB ID', {
+        label: 'Radarr API',
+        errorMessage: e.message,
+        tmdbId: id,
+      });
+      throw new Error('Movie not found');
+    }
+  }
+
   public addMovie = async (
     options: RadarrMovieOptions
   ): Promise<RadarrMovie> => {

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -119,6 +119,25 @@ class SonarrAPI extends ServarrBase<{
     }
   }
 
+  public async getSeriesById(id: number): Promise<SonarrSeries> {
+    try {
+      const response = await this.axios.get<SonarrSeries>(`/series/${id}`);
+
+      if (!response.data) {
+        throw new Error('Series not found');
+      }
+
+      return response.data;
+    } catch (e) {
+      logger.error('Error retrieving series by ID', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        id: id,
+      });
+      throw new Error('Series not found');
+    }
+  }
+
   public async getSeriesByTitle(title: string): Promise<SonarrSeries[]> {
     try {
       const response = await this.axios.get<SonarrSeries[]>('/series/lookup', {
@@ -147,29 +166,6 @@ class SonarrAPI extends ServarrBase<{
       const response = await this.axios.get<SonarrSeries[]>('/series/lookup', {
         params: {
           term: `tvdb:${id}`,
-        },
-      });
-
-      if (!response.data[0]) {
-        throw new Error('Series not found');
-      }
-
-      return response.data[0];
-    } catch (e) {
-      logger.error('Error retrieving series by tvdb ID', {
-        label: 'Sonarr API',
-        errorMessage: e.message,
-        tvdbId: id,
-      });
-      throw new Error('Series not found');
-    }
-  }
-
-  public async getExistingSeriesByTvdbId(id: number): Promise<SonarrSeries> {
-    try {
-      const response = await this.axios.get<SonarrSeries[]>('/series', {
-        params: {
-          tvdbId: id,
         },
       });
 

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -76,6 +76,9 @@ export interface SonarrSeries {
     ignoreEpisodesWithoutFiles?: boolean;
     searchForMissingEpisodes?: boolean;
   };
+  statistics: {
+    episodeFileCount: number;
+  };
 }
 
 export interface AddSeriesOptions {
@@ -144,6 +147,29 @@ class SonarrAPI extends ServarrBase<{
       const response = await this.axios.get<SonarrSeries[]>('/series/lookup', {
         params: {
           term: `tvdb:${id}`,
+        },
+      });
+
+      if (!response.data[0]) {
+        throw new Error('Series not found');
+      }
+
+      return response.data[0];
+    } catch (e) {
+      logger.error('Error retrieving series by tvdb ID', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        tvdbId: id,
+      });
+      throw new Error('Series not found');
+    }
+  }
+
+  public async getExistingSeriesByTvdbId(id: number): Promise<SonarrSeries> {
+    try {
+      const response = await this.axios.get<SonarrSeries[]>('/series', {
+        params: {
+          tvdbId: id,
         },
       });
 

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -77,7 +77,13 @@ export interface SonarrSeries {
     searchForMissingEpisodes?: boolean;
   };
   statistics: {
+    seasonCount: number;
     episodeFileCount: number;
+    episodeCount: number;
+    totalEpisodeCount: number;
+    sizeOnDisk: number;
+    releaseGroups: string[];
+    percentOfEpisodes: number;
   };
 }
 
@@ -123,18 +129,9 @@ class SonarrAPI extends ServarrBase<{
     try {
       const response = await this.axios.get<SonarrSeries>(`/series/${id}`);
 
-      if (!response.data) {
-        throw new Error('Series not found');
-      }
-
       return response.data;
     } catch (e) {
-      logger.error('Error retrieving series by ID', {
-        label: 'Sonarr API',
-        errorMessage: e.message,
-        id: id,
-      });
-      throw new Error('Series not found');
+      throw new Error(`[Sonarr] Failed to retrieve series by ID: ${e.message}`);
     }
   }
 

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -310,11 +310,10 @@ class AvailabilitySync {
 
       //check if both exist or if a single non-4k or 4k exists
       //if both do not exist we will return false
-      if (!server.is4k && !meta.id) {
+      if (!server.is4k && (!meta.id || (!meta.hasFile && !meta.monitored))) {
         existsInRadarr = false;
       }
-
-      if (server.is4k && !meta.id) {
+      if (server.is4k && (!meta.id || (!meta.hasFile && !meta.monitored))) {
         existsInRadarr4k = false;
       }
     }


### PR DESCRIPTION
#### Description

The main objective of this PR was to address an issue wherein the series still existed within the arr service but the media was not being monitored and the corresponding file was missing. In such cases, the affected series should be removed from Overseerr. To resolve this, I added a new route for Sonarr to ensure the correct episodeFileCount was being received (a similar route for Radarr already existed), which I then integrated into the availability sync job.

- Created new Sonarr route that will let you find an existing series by its ID.
- Migrated from searching with the respective tmdbid/tvdbid to using the external service ID.
- Logs will now tell you their media ID instead of their tmdbid/tvdbid.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3363 
