### PR TITLE
fix: error deleting users with over 1000 requests

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -381,7 +381,14 @@ router.delete<{ id: string }>(
        * we manually remove all requests from the user here so the parent media's
        * properly reflect the change.
        */
-      await requestRepository.remove(user.requests);
+      await requestRepository.remove(user.requests, {
+        /**
+         * Break-up into groups of 1000 requests to be removed at a time.
+         * Necessary for users with >1000 requests, else an SQLite 'Expression tree is too large' error occurs.
+         * https://typeorm.io/repository-api#additional-options
+         */
+        chunk: user.requests.length / 1000,
+      });
 
       await userRepository.delete(user.id);
       return res.status(200).json(user.filter());


### PR DESCRIPTION
#### Description
Break-up request removal into groups of 1000 requests to be removed at a time.
[Typeorm 'chunk' option documentation]( https://typeorm.io/repository-api#additional-options)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Issues #3322 
