### PR TITLE
fix: corrected initial fallback data load on details page

### DIFF
--- a/src/pages/movie/[movieId]/index.tsx
+++ b/src/pages/movie/[movieId]/index.tsx
@@ -1,7 +1,7 @@
 import MovieDetails from '@app/components/MovieDetails';
 import type { MovieDetails as MovieDetailsType } from '@server/models/Movie';
 import axios from 'axios';
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 
 interface MoviePageProps {
   movie?: MovieDetailsType;
@@ -11,25 +11,25 @@ const MoviePage: NextPage<MoviePageProps> = ({ movie }) => {
   return <MovieDetails movie={movie} />;
 };
 
-MoviePage.getInitialProps = async (ctx) => {
-  if (ctx.req) {
-    const response = await axios.get<MovieDetailsType>(
-      `http://localhost:${process.env.PORT || 5055}/api/v1/movie/${
-        ctx.query.movieId
-      }`,
-      {
-        headers: ctx.req?.headers?.cookie
-          ? { cookie: ctx.req.headers.cookie }
-          : undefined,
-      }
-    );
+export const getServerSideProps: GetServerSideProps<MoviePageProps> = async (
+  ctx
+) => {
+  const response = await axios.get<MovieDetailsType>(
+    `http://localhost:${process.env.PORT || 5055}/api/v1/movie/${
+      ctx.query.movieId
+    }`,
+    {
+      headers: ctx.req?.headers?.cookie
+        ? { cookie: ctx.req.headers.cookie }
+        : undefined,
+    }
+  );
 
-    return {
+  return {
+    props: {
       movie: response.data,
-    };
-  }
-
-  return {};
+    },
+  };
 };
 
 export default MoviePage;

--- a/src/pages/tv/[tvId]/index.tsx
+++ b/src/pages/tv/[tvId]/index.tsx
@@ -1,7 +1,7 @@
 import TvDetails from '@app/components/TvDetails';
 import type { TvDetails as TvDetailsType } from '@server/models/Tv';
 import axios from 'axios';
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 
 interface TvPageProps {
   tv?: TvDetailsType;
@@ -11,25 +11,23 @@ const TvPage: NextPage<TvPageProps> = ({ tv }) => {
   return <TvDetails tv={tv} />;
 };
 
-TvPage.getInitialProps = async (ctx) => {
-  if (ctx.req) {
-    const response = await axios.get<TvDetailsType>(
-      `http://localhost:${process.env.PORT || 5055}/api/v1/tv/${
-        ctx.query.tvId
-      }`,
-      {
-        headers: ctx.req?.headers?.cookie
-          ? { cookie: ctx.req.headers.cookie }
-          : undefined,
-      }
-    );
+export const getServerSideProps: GetServerSideProps<TvPageProps> = async (
+  ctx
+) => {
+  const response = await axios.get<TvDetailsType>(
+    `http://localhost:${process.env.PORT || 5055}/api/v1/tv/${ctx.query.tvId}`,
+    {
+      headers: ctx.req?.headers?.cookie
+        ? { cookie: ctx.req.headers.cookie }
+        : undefined,
+    }
+  );
 
-    return {
+  return {
+    props: {
       tv: response.data,
-    };
-  }
-
-  return {};
+    },
+  };
 };
 
 export default TvPage;


### PR DESCRIPTION
#### Description

The fallback data for our movie/tv details component would not load when using a direct route to the movie/tv details page. This was due to using getInitialProps which will only run on the client when navigating to a different route via the link component or by using the router component. To correctly always load our fallback data, I modified the movie/tv details page to use getServerSideProps which will always pull the correct data.

- Movie and tv details page will now use getServerSideProps

#### To-Dos

- [x] Successful build `yarn build`
