### PR TITLE
fix: lock body scroll when using webkit

### DIFF
--- a/src/hooks/useLockBodyScroll.ts
+++ b/src/hooks/useLockBodyScroll.ts
@@ -15,13 +15,20 @@ export const useLockBodyScroll = (
   disabled?: boolean
 ): void => {
   useEffect(() => {
-    const originalStyle = window.getComputedStyle(document.body).overflow;
+    const originalOverflowStyle = window.getComputedStyle(
+      document.body
+    ).overflow;
+    const originalTouchActionStyle = window.getComputedStyle(
+      document.body
+    ).touchAction;
     if (isLocked && !disabled) {
       document.body.style.overflow = 'hidden';
+      document.body.style.touchAction = 'none';
     }
     return () => {
       if (!disabled) {
-        document.body.style.overflow = originalStyle;
+        document.body.style.overflow = originalOverflowStyle;
+        document.body.style.touchAction = originalTouchActionStyle;
       }
     };
   }, [isLocked, disabled]);


### PR DESCRIPTION
#### Description

Resolved an outstanding issue with Mobile Safari(webkit) that prevented the useLockBodyScroll from working. This was especially noticeable when a modal was open and you could still scroll. Adding touch action "none" to the hook fixes this issue.

- Added touch-action: none to the useLockBodyScroll hook.

#### To-Dos

- [x] Successful build `yarn build`
