### PR TITLE
docs on the docker CLI do not have correct name

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ For details on the Docker CLI, please [review the official `docker run` document
 
 ```bash
 docker run -d \
-  --name overseerr \
+  --name sctx/overseerr \
   -e LOG_LEVEL=debug \
   -e TZ=Asia/Tokyo \
   -e PORT=5055 `#optional` \


### PR DESCRIPTION
Added sctx/ to the overseerr as its the wrong image and can't pull just overseerr as image

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
