### PR TITLE
feat: pwa badge notifications

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 // previously cached resources to be updated from the network.
 // This variable is intentionally declared and unused.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const OFFLINE_VERSION = 3;
+const OFFLINE_VERSION = 4;
 const CACHE_NAME = 'offline';
 // Customize this with a different URL if needed.
 const OFFLINE_URL = '/offline.html';
@@ -105,6 +105,25 @@ self.addEventListener('push', (event) => {
         title: 'Decline',
       }
     );
+  }
+
+  // Set the badge with the amount of pending requests
+  // Only update the badge if the payload confirms they are the admin
+  if (
+    (payload.notificationType === 'MEDIA_APPROVED' ||
+      payload.notificationType === 'MEDIA_DECLINED') &&
+    payload.isAdmin
+  ) {
+    if ('setAppBadge' in navigator) {
+      navigator.setAppBadge(payload.pendingRequestsCount);
+    }
+    return;
+  }
+
+  if (payload.notificationType === 'MEDIA_PENDING') {
+    if ('setAppBadge' in navigator) {
+      navigator.setAppBadge(payload.pendingRequestsCount);
+    }
   }
 
   event.waitUntil(self.registration.showNotification(payload.subject, options));

--- a/server/lib/notifications/agents/agent.ts
+++ b/server/lib/notifications/agents/agent.ts
@@ -19,6 +19,8 @@ export interface NotificationPayload {
   request?: MediaRequest;
   issue?: Issue;
   comment?: IssueComment;
+  pendingRequestsCount?: number;
+  isAdmin?: boolean;
 }
 
 export abstract class BaseAgent<T extends NotificationAgentConfig> {

--- a/src/components/Layout/MobileMenu/index.tsx
+++ b/src/components/Layout/MobileMenu/index.tsx
@@ -240,9 +240,11 @@ const MobileMenu = ({
                               router.pathname.match(link.activeRegExp)
                                 ? 'border-indigo-600 from-indigo-700 to-purple-700'
                                 : 'border-indigo-500 from-indigo-600 to-purple-600'
-                            } !px-1 !py-[1px] leading-none`}
+                            } flex h-4 w-4 items-center justify-center !px-[9px] !py-[9px] text-[9px]`}
                           >
-                            {pendingRequestsCount}
+                            {pendingRequestsCount > 99
+                              ? '99+'
+                              : pendingRequestsCount}
                           </Badge>
                         </div>
                       )}


### PR DESCRIPTION
#### Description

This pull request implements the app badging API, enabling the addition of a badge to the app while using the PWA. The badge will display the number of pending requests and will only be visible to admin users.

- Utilizes the navigator object to set the app badge.
- Created a specific notification payload only for admins that will tell the service worker to update the badge.

#### Screenshot (if UI-related)

Ignore the icon logo as it was for testing purposes.

![IMG_5220](https://user-images.githubusercontent.com/8635678/230260106-3465ce1f-56a3-4e3a-ac78-ba2191d646e2.PNG)

#### To-Dos

- [x] Successful build `yarn build`