### PR TITLE
build: create a devcontainer configuration 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/devcontainers/images/blob/main/src/typescript-node/.devcontainer/Dockerfile
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+  curl \
+  build-essential \
+  libpq-dev \
+  libwebp-dev \
+  libsasl2-dev libldap2-dev libssl-dev \
+  gnupg gnupg2 gnupg1
+
+EXPOSE 5055

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
   //"onCreateCommand": "sudo chown -R node:node /workspaces/overseerr",
   //"onCreateCommand": "git config --global --add safe.directory /workspaces/overseerr",
   "onCreateCommand": "yarn",
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}", // && yarn dev",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global gpg.program $(which gpg)", // && yarn dev",
   // Remote user of container -- Base image uses 'node' as default
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,10 +40,8 @@
     Use 'onCreateCommand' to run commands at the end of container creation.
     Use 'postCreateCommand' to run commands after the container is created.
   **/
-  //"onCreateCommand": "sudo chown -R node:node /workspaces/overseerr",
-  //"onCreateCommand": "git config --global --add safe.directory /workspaces/overseerr",
   "onCreateCommand": "yarn",
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global gpg.program $(which gpg)", // && yarn dev",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global gpg.program $(which gpg)",
   // Remote user of container -- Base image uses 'node' as default
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,8 +34,10 @@
   // Use 'onCreateCommand' to run commands at the end of container creation.
   // Use 'postCreateCommand' to run commands after the container is created.
   //"onCreateCommand": "sudo chown -R node:node /workspaces/overseerr",
-  "onCreateCommand": "git config --global --add safe.directory /workspaces/overseerr && cd /workspaces/overseerr/app && yarn",
-  "postCreateCommand": "yarn dev",
+  //"onCreateCommand": "git config --global --add safe.directory /workspaces/overseerr",
+  //"postCreateCommand": "yarn dev",
+  "onCreateCommand": "yarn",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}", // && yarn dev",
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
   // "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/devcontainers/images/blob/main/src/typescript-node/.devcontainer/Dockerfile
+{
+  "name": "Node Typescript",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      // Update 'VARIANT' to pick a Node version
+      // Append -bullseye or -buster to pin to an OS version.
+      // Use -bullseye variants on local on arm64/Apple Silicon.
+      "VARIANT": "16"
+    }
+  },
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "EditorConfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "Orta.vscode-jest",
+        "stylelint.vscode-stylelint",
+        "bradlc.vscode-tailwindcss",
+        "eamodio.gitlens",
+        "DavidAnson.vscode-markdownlint",
+        "adam-bender.commit-message-editor",
+        "ms-vscode-remote.remote-containers"
+      ]
+    }
+  },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [5055],
+  // Use 'onCreateCommand' to run commands at the end of container creation.
+  // Use 'postCreateCommand' to run commands after the container is created.
+  //"onCreateCommand": "sudo chown -R node:node /workspaces/overseerr",
+  "onCreateCommand": "git config --global --add safe.directory /workspaces/overseerr && cd /workspaces/overseerr/app && yarn",
+  "postCreateCommand": "yarn dev",
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+  // "features": {
+  //   "git": "latest"
+  // }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,18 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/devcontainers/images/blob/main/src/typescript-node/.devcontainer/Dockerfile
+/**
+  For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+  https://github.com/devcontainers/images/blob/main/src/typescript-node/.devcontainer/Dockerfile
+**/
 {
   "name": "Node Typescript",
   "build": {
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      // Update 'VARIANT' to pick a Node version
-      // Append -bullseye or -buster to pin to an OS version.
-      // Use -bullseye variants on local on arm64/Apple Silicon.
+      /**
+        Update 'VARIANT' to pick a Node version
+        Append -bullseye or -buster to pin to an OS version.
+        Use -bullseye variants on local on arm64/Apple Silicon.
+      **/
       "VARIANT": "16"
     }
   },
@@ -31,16 +35,14 @@
   },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [5055],
-  // Use 'onCreateCommand' to run commands at the end of container creation.
-  // Use 'postCreateCommand' to run commands after the container is created.
+  /**
+    Use 'onCreateCommand' to run commands at the end of container creation.
+    Use 'postCreateCommand' to run commands after the container is created.
+  **/
   //"onCreateCommand": "sudo chown -R node:node /workspaces/overseerr",
   //"onCreateCommand": "git config --global --add safe.directory /workspaces/overseerr",
-  //"postCreateCommand": "yarn dev",
   "onCreateCommand": "yarn",
   "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}", // && yarn dev",
-  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  // Remote user of container -- Base image uses 'node' as default
   "remoteUser": "node"
-  // "features": {
-  //   "git": "latest"
-  // }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
         "eamodio.gitlens",
         "DavidAnson.vscode-markdownlint",
         "adam-bender.commit-message-editor",
-        "ms-vscode-remote.remote-containers"
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "ms-vscode.remote-explorer"
       ]
     }
   },


### PR DESCRIPTION
#### Description

Creates a devcontainer configuration for remote development contained within a docker container. Useful as you don't need to install ANY dependencies on the local machine or WSL environment. Keeps your environment for Overseerr development contained to a container.

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
