### PR TITLE
fix(ui): corrected mobile menu spacing in collection details

### DIFF
--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -348,7 +348,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
           />
         ))}
       />
-      <div className="pb-8" />
+      <div className="extra-bottom-space relative" />
     </div>
   );
 };


### PR DESCRIPTION
#### Description

The collections details page was missing the extra padding for the new mobile menu.

- Added the extra-bottom-space class to the collection details page.

#### Screenshot (if UI-related)

<img width="310" alt="Screenshot 2023-04-30 at 7 13 27 PM" src="https://user-images.githubusercontent.com/8635678/235380395-695d0f37-e575-4669-bc53-88b6070acb74.png">

#### To-Dos

- [x] Successful build `yarn build`
