### PR TITLE
fix: correctly load series fallback modal with sonarr v4

### DIFF
--- a/server/routes/service.ts
+++ b/server/routes/service.ts
@@ -183,9 +183,7 @@ serviceRoutes.get<{ tmdbId: string }>(
 
     const sonarr = new SonarrAPI({
       apiKey: sonarrSettings.apiKey,
-      url: `${sonarrSettings.useSsl ? 'https' : 'http'}://${
-        sonarrSettings.hostname
-      }:${sonarrSettings.port}${sonarrSettings.baseUrl ?? ''}/api`,
+      url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
     });
 
     try {


### PR DESCRIPTION
#### Description

This PR addresses an issue with the series fallback lookup breaking when specifically using Sonarr V4. The problem has been resolved by updating the route with the newer v3 API url.

- Changed url from using /api to /api/v3

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
