### PR TITLE
Make a (shallow) copy of radarr/sonarr tags into a request before adding user tags

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -247,8 +247,8 @@ export class MediaRequest {
       const requestedSeasons =
         requestBody.seasons === 'all'
           ? tmdbMediaShow.seasons
-            .map((season) => season.season_number)
-            .filter((sn) => sn > 0)
+              .map((season) => season.season_number)
+              .filter((sn) => sn > 0)
           : (requestBody.seasons as number[]);
       let existingSeasons: number[] = [];
 
@@ -575,7 +575,7 @@ export class MediaRequest {
       // Do not update the status if the item is already partially available or available
       media[this.is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE &&
       media[this.is4k ? 'status4k' : 'status'] !==
-      MediaStatus.PARTIALLY_AVAILABLE
+        MediaStatus.PARTIALLY_AVAILABLE
     ) {
       media[this.is4k ? 'status4k' : 'status'] = MediaStatus.PROCESSING;
       mediaRepository.save(media);
@@ -1180,14 +1180,14 @@ export class MediaRequest {
         case Notification.MEDIA_AUTO_REQUESTED:
           event = `${
             this.is4k ? '4K ' : ''
-            }${mediaType} Request Automatically Submitted`;
+          }${mediaType} Request Automatically Submitted`;
           notifyAdmin = false;
           notifySystem = false;
           break;
         case Notification.MEDIA_AUTO_APPROVED:
           event = `${
             this.is4k ? '4K ' : ''
-            }${mediaType} Request Automatically Approved`;
+          }${mediaType} Request Automatically Approved`;
           break;
         case Notification.MEDIA_FAILED:
           event = `${this.is4k ? '4K ' : ''}${mediaType} Request Failed`;
@@ -1205,7 +1205,7 @@ export class MediaRequest {
           event,
           subject: `${movie.title}${
             movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
-            }`,
+          }`,
           message: truncate(movie.overview, {
             length: 500,
             separator: /\s/,
@@ -1224,7 +1224,7 @@ export class MediaRequest {
           event,
           subject: `${tv.name}${
             tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
-            }`,
+          }`,
           message: truncate(tv.overview, {
             length: 500,
             separator: /\s/,

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -999,10 +999,14 @@ export class MediaRequest {
           seriesType === 'anime' && sonarrSettings.activeAnimeLanguageProfileId
             ? sonarrSettings.activeAnimeLanguageProfileId
             : sonarrSettings.activeLanguageProfileId;
-        let tags = seriesType === 'anime'
-            ? (sonarrSettings.animeTags ? [...sonarrSettings.animeTags] : [])
-            : (sonarrSettings.tags ? [...sonarrSettings.tags] : []);
-
+        let tags =
+          seriesType === 'anime'
+            ? sonarrSettings.animeTags
+              ? [...sonarrSettings.animeTags]
+              : []
+            : sonarrSettings.tags
+            ? [...sonarrSettings.tags]
+            : [];
 
         if (
           this.rootFolder &&

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -36,10 +36,10 @@ import Media from './Media';
 import SeasonRequest from './SeasonRequest';
 import { User } from './User';
 
-export class RequestPermissionError extends Error {}
-export class QuotaRestrictedError extends Error {}
-export class DuplicateMediaRequestError extends Error {}
-export class NoSeasonsAvailableError extends Error {}
+export class RequestPermissionError extends Error { }
+export class QuotaRestrictedError extends Error { }
+export class DuplicateMediaRequestError extends Error { }
+export class NoSeasonsAvailableError extends Error { }
 
 type MediaRequestOptions = {
   isAutoRequest?: boolean;
@@ -91,8 +91,7 @@ export class MediaRequest {
       )
     ) {
       throw new RequestPermissionError(
-        `You do not have permission to make ${
-          requestBody.is4k ? '4K ' : ''
+        `You do not have permission to make ${requestBody.is4k ? '4K ' : ''
         }movie requests.`
       );
     } else if (
@@ -107,8 +106,7 @@ export class MediaRequest {
       )
     ) {
       throw new RequestPermissionError(
-        `You do not have permission to make ${
-          requestBody.is4k ? '4K ' : ''
+        `You do not have permission to make ${requestBody.is4k ? '4K ' : ''
         }series requests.`
       );
     }
@@ -247,8 +245,8 @@ export class MediaRequest {
       const requestedSeasons =
         requestBody.seasons === 'all'
           ? tmdbMediaShow.seasons
-              .map((season) => season.season_number)
-              .filter((sn) => sn > 0)
+            .map((season) => season.season_number)
+            .filter((sn) => sn > 0)
           : (requestBody.seasons as number[]);
       let existingSeasons: number[] = [];
 
@@ -575,7 +573,7 @@ export class MediaRequest {
       // Do not update the status if the item is already partially available or available
       media[this.is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE &&
       media[this.is4k ? 'status4k' : 'status'] !==
-        MediaStatus.PARTIALLY_AVAILABLE
+      MediaStatus.PARTIALLY_AVAILABLE
     ) {
       media[this.is4k ? 'status4k' : 'status'] = MediaStatus.PROCESSING;
       mediaRepository.save(media);
@@ -688,10 +686,8 @@ export class MediaRequest {
 
         if (!radarrSettings) {
           logger.warn(
-            `There is no default ${
-              this.is4k ? '4K ' : ''
-            }Radarr server configured. Did you set any of your ${
-              this.is4k ? '4K ' : ''
+            `There is no default ${this.is4k ? '4K ' : ''
+            }Radarr server configured. Did you set any of your ${this.is4k ? '4K ' : ''
             }Radarr servers as default?`,
             {
               label: 'Media Request',
@@ -704,7 +700,7 @@ export class MediaRequest {
 
         let rootFolder = radarrSettings.activeDirectory;
         let qualityProfile = radarrSettings.activeProfileId;
-        let tags = radarrSettings.tags;
+        let tags = [...radarrSettings.tags];
 
         if (
           this.rootFolder &&
@@ -923,10 +919,8 @@ export class MediaRequest {
 
         if (!sonarrSettings) {
           logger.warn(
-            `There is no default ${
-              this.is4k ? '4K ' : ''
-            }Sonarr server configured. Did you set any of your ${
-              this.is4k ? '4K ' : ''
+            `There is no default ${this.is4k ? '4K ' : ''
+            }Sonarr server configured. Did you set any of your ${this.is4k ? '4K ' : ''
             }Sonarr servers as default?`,
             {
               label: 'Media Request',
@@ -1001,8 +995,8 @@ export class MediaRequest {
             : sonarrSettings.activeLanguageProfileId;
         let tags =
           seriesType === 'anime'
-            ? sonarrSettings.animeTags
-            : sonarrSettings.tags;
+            ? [...sonarrSettings.animeTags]
+            : [...sonarrSettings.tags];
 
         if (
           this.rootFolder &&
@@ -1178,16 +1172,14 @@ export class MediaRequest {
           event = `New ${this.is4k ? '4K ' : ''}${mediaType} Request`;
           break;
         case Notification.MEDIA_AUTO_REQUESTED:
-          event = `${
-            this.is4k ? '4K ' : ''
-          }${mediaType} Request Automatically Submitted`;
+          event = `${this.is4k ? '4K ' : ''
+            }${mediaType} Request Automatically Submitted`;
           notifyAdmin = false;
           notifySystem = false;
           break;
         case Notification.MEDIA_AUTO_APPROVED:
-          event = `${
-            this.is4k ? '4K ' : ''
-          }${mediaType} Request Automatically Approved`;
+          event = `${this.is4k ? '4K ' : ''
+            }${mediaType} Request Automatically Approved`;
           break;
         case Notification.MEDIA_FAILED:
           event = `${this.is4k ? '4K ' : ''}${mediaType} Request Failed`;
@@ -1203,9 +1195,8 @@ export class MediaRequest {
           notifySystem,
           notifyUser: notifyAdmin ? undefined : this.requestedBy,
           event,
-          subject: `${movie.title}${
-            movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
-          }`,
+          subject: `${movie.title}${movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
+            }`,
           message: truncate(movie.overview, {
             length: 500,
             separator: /\s/,
@@ -1222,9 +1213,8 @@ export class MediaRequest {
           notifySystem,
           notifyUser: notifyAdmin ? undefined : this.requestedBy,
           event,
-          subject: `${tv.name}${
-            tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
-          }`,
+          subject: `${tv.name}${tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
+            }`,
           message: truncate(tv.overview, {
             length: 500,
             separator: /\s/,

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -36,10 +36,10 @@ import Media from './Media';
 import SeasonRequest from './SeasonRequest';
 import { User } from './User';
 
-export class RequestPermissionError extends Error { }
-export class QuotaRestrictedError extends Error { }
-export class DuplicateMediaRequestError extends Error { }
-export class NoSeasonsAvailableError extends Error { }
+export class RequestPermissionError extends Error {}
+export class QuotaRestrictedError extends Error {}
+export class DuplicateMediaRequestError extends Error {}
+export class NoSeasonsAvailableError extends Error {}
 
 type MediaRequestOptions = {
   isAutoRequest?: boolean;
@@ -91,7 +91,8 @@ export class MediaRequest {
       )
     ) {
       throw new RequestPermissionError(
-        `You do not have permission to make ${requestBody.is4k ? '4K ' : ''
+        `You do not have permission to make ${
+          requestBody.is4k ? '4K ' : ''
         }movie requests.`
       );
     } else if (
@@ -106,7 +107,8 @@ export class MediaRequest {
       )
     ) {
       throw new RequestPermissionError(
-        `You do not have permission to make ${requestBody.is4k ? '4K ' : ''
+        `You do not have permission to make ${
+          requestBody.is4k ? '4K ' : ''
         }series requests.`
       );
     }
@@ -686,8 +688,10 @@ export class MediaRequest {
 
         if (!radarrSettings) {
           logger.warn(
-            `There is no default ${this.is4k ? '4K ' : ''
-            }Radarr server configured. Did you set any of your ${this.is4k ? '4K ' : ''
+            `There is no default ${
+              this.is4k ? '4K ' : ''
+            }Radarr server configured. Did you set any of your ${
+              this.is4k ? '4K ' : ''
             }Radarr servers as default?`,
             {
               label: 'Media Request',
@@ -919,8 +923,10 @@ export class MediaRequest {
 
         if (!sonarrSettings) {
           logger.warn(
-            `There is no default ${this.is4k ? '4K ' : ''
-            }Sonarr server configured. Did you set any of your ${this.is4k ? '4K ' : ''
+            `There is no default ${
+              this.is4k ? '4K ' : ''
+            }Sonarr server configured. Did you set any of your ${
+              this.is4k ? '4K ' : ''
             }Sonarr servers as default?`,
             {
               label: 'Media Request',
@@ -1172,13 +1178,15 @@ export class MediaRequest {
           event = `New ${this.is4k ? '4K ' : ''}${mediaType} Request`;
           break;
         case Notification.MEDIA_AUTO_REQUESTED:
-          event = `${this.is4k ? '4K ' : ''
+          event = `${
+            this.is4k ? '4K ' : ''
             }${mediaType} Request Automatically Submitted`;
           notifyAdmin = false;
           notifySystem = false;
           break;
         case Notification.MEDIA_AUTO_APPROVED:
-          event = `${this.is4k ? '4K ' : ''
+          event = `${
+            this.is4k ? '4K ' : ''
             }${mediaType} Request Automatically Approved`;
           break;
         case Notification.MEDIA_FAILED:
@@ -1195,7 +1203,8 @@ export class MediaRequest {
           notifySystem,
           notifyUser: notifyAdmin ? undefined : this.requestedBy,
           event,
-          subject: `${movie.title}${movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
+          subject: `${movie.title}${
+            movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
             }`,
           message: truncate(movie.overview, {
             length: 500,
@@ -1213,7 +1222,8 @@ export class MediaRequest {
           notifySystem,
           notifyUser: notifyAdmin ? undefined : this.requestedBy,
           event,
-          subject: `${tv.name}${tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
+          subject: `${tv.name}${
+            tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
             }`,
           message: truncate(tv.overview, {
             length: 500,

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -704,7 +704,7 @@ export class MediaRequest {
 
         let rootFolder = radarrSettings.activeDirectory;
         let qualityProfile = radarrSettings.activeProfileId;
-        let tags = [...radarrSettings.tags];
+        let tags = radarrSettings.tags ? [...radarrSettings.tags] : [];
 
         if (
           this.rootFolder &&
@@ -999,10 +999,10 @@ export class MediaRequest {
           seriesType === 'anime' && sonarrSettings.activeAnimeLanguageProfileId
             ? sonarrSettings.activeAnimeLanguageProfileId
             : sonarrSettings.activeLanguageProfileId;
-        let tags =
-          seriesType === 'anime'
-            ? [...sonarrSettings.animeTags]
-            : [...sonarrSettings.tags];
+        let tags = seriesType === 'anime'
+            ? (sonarrSettings.animeTags ? [...sonarrSettings.animeTags] : [])
+            : (sonarrSettings.tags ? [...sonarrSettings.tags] : []);
+
 
         if (
           this.rootFolder &&


### PR DESCRIPTION
#### Description
Stops an issue where we were assigning the radarr/sonarr tags to another tags varable, and then mutating that variable with extra user tags (not realizing that this mutation altered the actual original settings tag array).

I don't have a test setup and made this PR through the web UI, so someone else will have to pull and validate it, but it should do the trick.

- Fixes #3480
