### PR TITLE
fix: fixes RT ratings for Tvshows

### DIFF
--- a/server/api/rottentomatoes.ts
+++ b/server/api/rottentomatoes.ts
@@ -17,7 +17,7 @@ interface RTAlgoliaHit {
   title: string;
   titles: string[];
   description: string;
-  releaseYear: string;
+  releaseYear: number;
   rating: string;
   genres: string[];
   updateDate: string;
@@ -111,22 +111,19 @@ class RottenTomatoes extends ExternalAPI {
 
       // First, attempt to match exact name and year
       let movie = contentResults.hits.find(
-        (movie) => movie.releaseYear === year.toString() && movie.title === name
+        (movie) => movie.releaseYear === year && movie.title === name
       );
 
       // If we don't find a movie, try to match partial name and year
       if (!movie) {
         movie = contentResults.hits.find(
-          (movie) =>
-            movie.releaseYear === year.toString() && movie.title.includes(name)
+          (movie) => movie.releaseYear === year && movie.title.includes(name)
         );
       }
 
       // If we still dont find a movie, try to match just on year
       if (!movie) {
-        movie = contentResults.hits.find(
-          (movie) => movie.releaseYear === year.toString()
-        );
+        movie = contentResults.hits.find((movie) => movie.releaseYear === year);
       }
 
       // One last try, try exact name match only
@@ -181,7 +178,7 @@ class RottenTomatoes extends ExternalAPI {
 
       if (year) {
         tvshow = contentResults.hits.find(
-          (series) => series.releaseYear === year.toString()
+          (series) => series.releaseYear === year
         );
       }
 


### PR DESCRIPTION
#### Description
As described in #3491, in the existing code, there was a mismatch in data types when comparing the `releaseYear` property (number) of the `contentResults` object with the `year` parameter (string). This caused the comparison to fail and led to incorrect retrieval of TV show ratings, resulting in a "404 RT ratings not found" error.

To address this issue, this pull request removes the conversion of the `year` parameter to a string and instead keeps it as a number type. This change aligns the data types correctly for the comparison and resolves the issue of retrieving TV show ratings.

#### Screenshot (if UI-related)
Before
![image](https://github.com/sct/overseerr/assets/98979876/957d646b-c2a0-499a-a190-d18759f1a423)

After
![image](https://github.com/sct/overseerr/assets/98979876/14c124f3-93f9-4cba-b867-dff4b906fe1f)


#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3491 
