### PR TITLE
fix: corrected issues icon color

### DIFF
--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -71,9 +71,7 @@ const SidebarLinks: SidebarLinkProps[] = [
   {
     href: '/issues',
     messagesKey: 'issues',
-    svgIcon: (
-      <ExclamationTriangleIcon className="mr-3 h-6 w-6 text-gray-300 transition duration-150 ease-in-out group-hover:text-gray-100 group-focus:text-gray-300" />
-    ),
+    svgIcon: <ExclamationTriangleIcon className="mr-3 h-6 w-6" />,
     activeRegExp: /^\/issues/,
     requiredPermission: [
       Permission.MANAGE_ISSUES,


### PR DESCRIPTION
#### Description

The issues icon color was gray instead of white like the rest of the icons in the sidebar. This PR fixes that!

#### Screenshot (if UI-related)

Before

<img width="393" alt="Screenshot 2023-06-12 at 1 16 43 AM" src="https://github.com/sct/overseerr/assets/8635678/b70ddabc-c917-49aa-a8d3-cc7ab3c58b2e">

After

<img width="377" alt="Screenshot 2023-06-12 at 1 16 31 AM" src="https://github.com/sct/overseerr/assets/8635678/5ab7631d-0dc2-43ef-8741-b968ed5f2940">


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3495 
