### PR TITLE
fix(web/discover): filter duplicates in pagination

### DIFF
--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -95,6 +95,11 @@ const useDiscover = <
 
   let titles = (data ?? []).reduce((a, v) => [...a, ...v.results], [] as T[]);
 
+  // Check for duplicates, see https://github.com/sct/overseerr/issues/3499
+  titles = (titles as any[]).filter(
+    (value, index, self) => index === self.findIndex((t) => t.id === value.id)
+  );
+
   if (settings.currentSettings.hideAvailable && hideAvailable) {
     titles = titles.filter(
       (i) =>


### PR DESCRIPTION
#### Description

Duplicates coming directly from the TMDB API, filtered at rendering time (within `useDiscover`) so that a cached state at the backend is not needed.

#### Screenshot (if UI-related)

Before
![immagine](https://github.com/sct/overseerr/assets/19221001/60963a59-1f32-4d81-b5d3-be4dbbfbbe86)

After
![immagine](https://github.com/sct/overseerr/assets/19221001/b6c8d27a-2847-4458-b75b-9fcfa0bc3476)


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #3499
