### PR TITLE
fix(statusbadge): handle missing season/episode number

### DIFF
--- a/src/components/StatusBadge/index.tsx
+++ b/src/components/StatusBadge/index.tsx
@@ -166,11 +166,11 @@ const StatusBadge = ({
               </span>
               {inProgress && (
                 <>
-                  {mediaType === 'tv' && (
+                  {mediaType === 'tv' && downloadItem[0].episode && (
                     <span className="ml-1">
                       {intl.formatMessage(messages.seasonepisodenumber, {
-                        seasonNumber: downloadItem[0].episode?.seasonNumber,
-                        episodeNumber: downloadItem[0].episode?.episodeNumber,
+                        seasonNumber: downloadItem[0].episode.seasonNumber,
+                        episodeNumber: downloadItem[0].episode.episodeNumber,
                       })}
                     </span>
                   )}
@@ -219,11 +219,11 @@ const StatusBadge = ({
               </span>
               {inProgress && (
                 <>
-                  {mediaType === 'tv' && (
+                  {mediaType === 'tv' && downloadItem[0].episode && (
                     <span className="ml-1">
                       {intl.formatMessage(messages.seasonepisodenumber, {
-                        seasonNumber: downloadItem[0].episode?.seasonNumber,
-                        episodeNumber: downloadItem[0].episode?.episodeNumber,
+                        seasonNumber: downloadItem[0].episode.seasonNumber,
+                        episodeNumber: downloadItem[0].episode.episodeNumber,
                       })}
                     </span>
                   )}
@@ -272,11 +272,11 @@ const StatusBadge = ({
               </span>
               {inProgress && (
                 <>
-                  {mediaType === 'tv' && (
+                  {mediaType === 'tv' && downloadItem[0].episode && (
                     <span className="ml-1">
                       {intl.formatMessage(messages.seasonepisodenumber, {
-                        seasonNumber: downloadItem[0].episode?.seasonNumber,
-                        episodeNumber: downloadItem[0].episode?.episodeNumber,
+                        seasonNumber: downloadItem[0].episode.seasonNumber,
+                        episodeNumber: downloadItem[0].episode.episodeNumber,
                       })}
                     </span>
                   )}


### PR DESCRIPTION
#### Description

Minor bug fix to handle cases where the download item does not have a season/episode number.

#### Screenshot (if UI-related)

Current behavior:
<img width="132" alt="image" src="https://github.com/sct/overseerr/assets/52870424/ef3c5114-d10c-410f-b7c5-cc2bbc82dce7">

#### To-Dos

- [x] Successful build `yarn build`
