### PR TITLE
feat(lang): French sidebar translation update

### DIFF
--- a/src/i18n/locale/fr.json
+++ b/src/i18n/locale/fr.json
@@ -1209,7 +1209,7 @@
   "components.Discover.DiscoverSliderEdit.deletesuccess": "Slider supprimé avec succès.",
   "components.Discover.FilterSlideover.activefilters": "{count, plural, one {# Filtre actif} other {# Filtres actifs}}",
   "components.Discover.FilterSlideover.studio": "Studio",
-  "components.Layout.Sidebar.browsetv": "Série",
+  "components.Layout.Sidebar.browsetv": "Séries",
   "components.Selector.showmore": "En voir plus",
   "components.Discover.FilterSlideover.streamingservices": "Services de Streaming",
   "components.Selector.showless": "En voir moins",


### PR DESCRIPTION
#### Description

Should be pluralized to "Séries" instead of "Série" in the sidebar, just like it is for "Films" (Movies), and as the page header title.

#### Screenshot (if UI-related)

![msedge_bVgPRON7PW](https://github.com/sct/overseerr/assets/33204743/39a3ef3b-f044-488c-9509-7e8c18585593)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
