### PR TITLE
feat: add Peacock to Network Slider

### DIFF
--- a/src/components/Discover/NetworkSlider/index.tsx
+++ b/src/components/Discover/NetworkSlider/index.tsx
@@ -139,6 +139,12 @@ const networks: Network[] = [
       'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/ikZXxg6GnwpzqiZbRPhJGaZapqB.png',
     url: '/discover/tv/network/13',
   },
+  {
+    name: 'Peacock',
+    image:
+      'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/gIAcGTjKKr0KOHL5s4O36roJ8p7.png',
+    url: '/discover/tv/network/3353',
+  },
 ];
 
 const NetworkSlider = () => {


### PR DESCRIPTION
#### Description

Added Peacock to Network Slider

#### Screenshot (if UI-related)

<img width="1880" alt="Screenshot 2023-07-09 at 10 58 59" src="https://github.com/sct/overseerr/assets/1459386/f84c2334-7435-40a2-896f-a0765c89fe57">

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys yarn i18n:extract
