### PR TITLE
fix: importing friends

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -234,6 +234,9 @@ class PlexTvAPI extends ExternalAPI {
     }
   }
 
+  /**
+   * @deprecated Plex has deprecated '/pms/friends/all', use getUsers(); instead.
+   */
   public async getFriends(): Promise<FriendResponse> {
     const response = await this.axios.get('/pms/friends/all', {
       transformResponse: [],
@@ -255,7 +258,7 @@ class PlexTvAPI extends ExternalAPI {
         throw new Error('Plex is not configured!');
       }
 
-      const friends = await this.getFriends();
+      const friends = await this.getUsers();
 
       const users = friends.MediaContainer.User;
 

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -82,21 +82,6 @@ interface ServerResponse {
   };
 }
 
-interface FriendResponse {
-  MediaContainer: {
-    User: {
-      $: {
-        id: string;
-        title: string;
-        username: string;
-        email: string;
-        thumb: string;
-      };
-      Server?: ServerResponse[];
-    }[];
-  };
-}
-
 interface UsersResponse {
   MediaContainer: {
     User: {
@@ -234,22 +219,6 @@ class PlexTvAPI extends ExternalAPI {
     }
   }
 
-  /**
-   * @deprecated Plex has deprecated '/pms/friends/all', use getUsers(); instead.
-   */
-  public async getFriends(): Promise<FriendResponse> {
-    const response = await this.axios.get('/pms/friends/all', {
-      transformResponse: [],
-      responseType: 'text',
-    });
-
-    const parsedXml = (await xml2js.parseStringPromise(
-      response.data
-    )) as FriendResponse;
-
-    return parsedXml;
-  }
-
   public async checkUserAccess(userId: number): Promise<boolean> {
     const settings = getSettings();
 
@@ -258,9 +227,9 @@ class PlexTvAPI extends ExternalAPI {
         throw new Error('Plex is not configured!');
       }
 
-      const friends = await this.getUsers();
+      const usersResponse = await this.getUsers();
 
-      const users = friends.MediaContainer.User;
+      const users = usersResponse.MediaContainer.User;
 
       const user = users.find((u) => parseInt(u.$.id) === userId);
 


### PR DESCRIPTION
update checkUserAccess to use getUsers

#### Description

getFriends() calls `pms/friends/all` which is deprecated.
getUsers() should be used instead.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3550
