### PR TITLE
fix(tautulli): only test connection if hostname is defined

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -254,25 +254,27 @@ settingsRoutes.post('/tautulli', async (req, res, next) => {
 
   Object.assign(settings.tautulli, req.body);
 
-  try {
-    const tautulliClient = new TautulliAPI(settings.tautulli);
+  if (settings.tautulli.hostname) {
+    try {
+      const tautulliClient = new TautulliAPI(settings.tautulli);
 
-    const result = await tautulliClient.getInfo();
+      const result = await tautulliClient.getInfo();
 
-    if (!semver.gte(semver.coerce(result?.tautulli_version) ?? '', '2.9.0')) {
-      throw new Error('Tautulli version not supported');
+      if (!semver.gte(semver.coerce(result?.tautulli_version) ?? '', '2.9.0')) {
+        throw new Error('Tautulli version not supported');
+      }
+
+      settings.save();
+    } catch (e) {
+      logger.error('Something went wrong testing Tautulli connection', {
+        label: 'API',
+        errorMessage: e.message,
+      });
+      return next({
+        status: 500,
+        message: 'Unable to connect to Tautulli.',
+      });
     }
-
-    settings.save();
-  } catch (e) {
-    logger.error('Something went wrong testing Tautulli connection', {
-      label: 'API',
-      errorMessage: e.message,
-    });
-    return next({
-      status: 500,
-      message: 'Unable to connect to Tautulli.',
-    });
   }
 
   return res.status(200).json(settings.tautulli);


### PR DESCRIPTION
#### Description

We should only perform Tautulli connection checks when the settings are defined.

This PR just adds a simple check for the hostname.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes [this issue reported on Discord](https://discord.com/channels/783137440809746482/1136421536300011600)