### PR TITLE
feat: add Letterboxd link to ExternalLinkBlock for movies

### DIFF
--- a/src/assets/services/letterboxd.svg
+++ b/src/assets/services/letterboxd.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 500 500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.2 (67145) - http://www.bohemiancoding.com/sketch -->
+    <title>letterboxd-decal-dots-pos-rgb</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="129.847328" height="141.389313"></rect>
+        <rect id="path-3" x="0" y="0" width="129.847328" height="141.389313"></rect>
+    </defs>
+    <g id="letterboxd-decal-dots-pos-rgb" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <circle id="Circle" fill="#202830" cx="250" cy="250" r="250"></circle>
+        <g id="dots-neg" transform="translate(61.000000, 180.000000)">
+            <g id="Dots">
+                <ellipse id="Green" fill="#00E054" cx="189" cy="69.9732824" rx="70.0786517" ry="69.9732824"></ellipse>
+                <g id="Blue" transform="translate(248.152672, 0.000000)">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <g id="Mask"></g>
+                    <ellipse fill="#40BCF4" mask="url(#mask-2)" cx="59.7686766" cy="69.9732824" rx="70.0786517" ry="69.9732824"></ellipse>
+                </g>
+                <g id="Orange">
+                    <mask id="mask-4" fill="white">
+                        <use xlink:href="#path-3"></use>
+                    </mask>
+                    <g id="Mask"></g>
+                    <ellipse fill="#FF8000" mask="url(#mask-4)" cx="70.0786517" cy="69.9732824" rx="70.0786517" ry="69.9732824"></ellipse>
+                </g>
+                <path d="M129.539326,107.022244 C122.810493,96.2781677 118.921348,83.5792213 118.921348,69.9732824 C118.921348,56.3673435 122.810493,43.6683972 129.539326,32.9243209 C136.268159,43.6683972 140.157303,56.3673435 140.157303,69.9732824 C140.157303,83.5792213 136.268159,96.2781677 129.539326,107.022244 Z" id="Overlap" fill="#FFFFFF"></path>
+                <path d="M248.460674,32.9243209 C255.189507,43.6683972 259.078652,56.3673435 259.078652,69.9732824 C259.078652,83.5792213 255.189507,96.2781677 248.460674,107.022244 C241.731841,96.2781677 237.842697,83.5792213 237.842697,69.9732824 C237.842697,56.3673435 241.731841,43.6683972 248.460674,32.9243209 Z" id="Overlap" fill="#FFFFFF"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/ExternalLinkBlock/index.tsx
+++ b/src/components/ExternalLinkBlock/index.tsx
@@ -4,6 +4,7 @@ import RTLogo from '@app/assets/services/rt.svg';
 import TmdbLogo from '@app/assets/services/tmdb.svg';
 import TraktLogo from '@app/assets/services/trakt.svg';
 import TvdbLogo from '@app/assets/services/tvdb.svg';
+import LetterboxdLogo from '@app/assets/services/letterboxd.svg';
 import useLocale from '@app/hooks/useLocale';
 import { MediaType } from '@server/constants/media';
 
@@ -88,6 +89,16 @@ const ExternalLinkBlock = ({
           rel="noreferrer"
         >
           <TraktLogo />
+        </a>
+      )}
+      {tmdbId && mediaType === MediaType.MOVIE && (
+        <a
+          href={`https://letterboxd.com/tmdb/${tmdbId}/`}
+          className="w-8 opacity-50 transition duration-300 hover:opacity-100"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <LetterboxdLogo />
         </a>
       )}
     </div>


### PR DESCRIPTION
#### Description

This PR adds a [Letterboxd](https://letterboxd.com/) link to the `ExternalLinkBlock` for movies. The link uses a TMDb 
 ID, as described in https://letterboxd.com/about/film-data/. Example link: https://letterboxd.com/tmdb/945729.

The logo SVG is from https://letterboxd.com/about/brand/.

#### Screenshot (if UI-related)

![Screenshot 2024-10-12 at 3 04 40 PM](https://github.com/user-attachments/assets/cb7b8f4c-3c70-4b5d-9063-7d8f0580b149)


#### To-Dos

- [x] Successful build `yarn build`
- [-] Translation keys `yarn i18n:extract`
- [-] Database migration (if required)