### PR TITLE
feat: add hideTags option in user settings

### DIFF
--- a/server/entity/UserSettings.ts
+++ b/server/entity/UserSettings.ts
@@ -63,6 +63,9 @@ export class UserSettings {
   @Column({ nullable: true })
   public watchlistSyncTv?: boolean;
 
+  @Column({ nullable: true })
+  public hideTags?: boolean;
+
   @Column({
     type: 'text',
     nullable: true,

--- a/server/interfaces/api/userSettingsInterfaces.ts
+++ b/server/interfaces/api/userSettingsInterfaces.ts
@@ -16,6 +16,7 @@ export interface UserSettingsGeneralResponse {
   globalTvQuotaDays?: number;
   watchlistSyncMovies?: boolean;
   watchlistSyncTv?: boolean;
+  hideTags?: boolean;
 }
 
 export type NotificationAgentTypes = Record<NotificationAgentKey, number>;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -97,6 +97,7 @@ export interface MainSettings {
     tv: Quota;
   };
   hideAvailable: boolean;
+  hideTags: boolean;
   localLogin: boolean;
   newPlexLogin: boolean;
   region: string;
@@ -292,6 +293,7 @@ class Settings {
           tv: {},
         },
         hideAvailable: false,
+        hideTags: false,
         localLogin: true,
         newPlexLogin: true,
         region: '',

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -65,6 +65,7 @@ userSettingsRoutes.get<{ id: string }, UserSettingsGeneralResponse>(
         globalTvQuotaLimit: defaultQuotas.tv.quotaLimit,
         watchlistSyncMovies: user.settings?.watchlistSyncMovies,
         watchlistSyncTv: user.settings?.watchlistSyncTv,
+        hideTags: user.settings?.hideTags,
       });
     } catch (e) {
       next({ status: 500, message: e.message });
@@ -118,6 +119,7 @@ userSettingsRoutes.post<
         originalLanguage: req.body.originalLanguage,
         watchlistSyncMovies: req.body.watchlistSyncMovies,
         watchlistSyncTv: req.body.watchlistSyncTv,
+        hideTags: req.body.hideTags,
       });
     } else {
       user.settings.discordId = req.body.discordId;
@@ -126,6 +128,7 @@ userSettingsRoutes.post<
       user.settings.originalLanguage = req.body.originalLanguage;
       user.settings.watchlistSyncMovies = req.body.watchlistSyncMovies;
       user.settings.watchlistSyncTv = req.body.watchlistSyncTv;
+      user.settings.hideTags = req.body.hideTags;
     }
 
     await userRepository.save(user);
@@ -138,6 +141,7 @@ userSettingsRoutes.post<
       originalLanguage: user.settings.originalLanguage,
       watchlistSyncMovies: user.settings.watchlistSyncMovies,
       watchlistSyncTv: user.settings.watchlistSyncTv,
+      hideTags: user.settings.hideTags,
     });
   } catch (e) {
     next({ status: 500, message: e.message });

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -464,7 +464,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
               </div>
             </>
           )}
-          {data.keywords.length > 0 && (
+          {!user?.settings?.hideTags && data.keywords.length > 0 && (
             <div className="mt-6">
               {data.keywords.map((keyword) => (
                 <Link

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -503,7 +503,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
               </div>
             </>
           )}
-          {data.keywords.length > 0 && (
+          {!user?.settings?.hideTags && data.keywords.length > 0 && (
             <div className="mt-6">
               {data.keywords.map((keyword) => (
                 <Link

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -55,6 +55,8 @@ const messages = defineMessages({
   plexwatchlistsyncseries: 'Auto-Request Series',
   plexwatchlistsyncseriestip:
     'Automatically request series on your <PlexWatchlistSupportLink>Plex Watchlist</PlexWatchlistSupportLink>',
+  hideTags: 'Hide Tags',
+  hideTagsTip: 'Hide the tags in a listing detail page',
 });
 
 const UserGeneralSettings = () => {
@@ -130,6 +132,7 @@ const UserGeneralSettings = () => {
           tvQuotaDays: data?.tvQuotaDays,
           watchlistSyncMovies: data?.watchlistSyncMovies,
           watchlistSyncTv: data?.watchlistSyncTv,
+          hideTags: data?.hideTags,
         }}
         validationSchema={UserGeneralSettingsSchema}
         enableReinitialize
@@ -149,6 +152,7 @@ const UserGeneralSettings = () => {
               tvQuotaDays: tvQuotaEnabled ? values.tvQuotaDays : null,
               watchlistSyncMovies: values.watchlistSyncMovies,
               watchlistSyncTv: values.watchlistSyncTv,
+              hideTags: values.hideTags,
             });
 
             if (currentUser?.id === user?.id && setLocale) {
@@ -332,6 +336,24 @@ const UserGeneralSettings = () => {
                       isUserSettings
                     />
                   </div>
+                </div>
+              </div>
+              <div className="form-row">
+                <label htmlFor="hideTags" className="checkbox-label">
+                  <span>{intl.formatMessage(messages.hideTags)}</span>
+                  <span className="label-tip">
+                    {intl.formatMessage(messages.hideTagsTip)}
+                  </span>
+                </label>
+                <div className="form-input-area">
+                  <Field
+                    type="checkbox"
+                    id="hideTags"
+                    name="hideTags"
+                    onChange={() => {
+                      setFieldValue('hideTags', !values.hideTags);
+                    }}
+                  />
                 </div>
               </div>
               {currentHasPermission(Permission.MANAGE_USERS) &&

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,5 +1,4 @@
 import { UserType } from '@server/constants/user';
-import type { UserSettingsGeneralResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import type { PermissionCheckOptions } from '@server/lib/permissions';
 import { hasPermission, Permission } from '@server/lib/permissions';
 import type { NotificationAgentKey } from '@server/lib/settings';
@@ -26,14 +25,15 @@ export interface User {
 
 type NotificationAgentTypes = Record<NotificationAgentKey, number>;
 
-type UserSettings = Pick<
-  UserSettingsGeneralResponse,
-  'discordId' | 'region' | 'originalLanguage' | 'locale' | 'hideTags'
-> & {
+export interface UserSettings {
+  discordId?: string;
+  region?: string;
+  originalLanguage?: string;
+  locale?: string;
   notificationTypes: Partial<NotificationAgentTypes>;
   watchlistSyncMovies?: boolean;
   watchlistSyncTv?: boolean;
-};
+}
 
 interface UserHookResponse {
   user?: User;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,4 +1,5 @@
 import { UserType } from '@server/constants/user';
+import type { UserSettingsGeneralResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import type { PermissionCheckOptions } from '@server/lib/permissions';
 import { hasPermission, Permission } from '@server/lib/permissions';
 import type { NotificationAgentKey } from '@server/lib/settings';
@@ -25,15 +26,14 @@ export interface User {
 
 type NotificationAgentTypes = Record<NotificationAgentKey, number>;
 
-export interface UserSettings {
-  discordId?: string;
-  region?: string;
-  originalLanguage?: string;
-  locale?: string;
+type UserSettings = Pick<
+  UserSettingsGeneralResponse,
+  'discordId' | 'region' | 'originalLanguage' | 'locale' | 'hideTags'
+> & {
   notificationTypes: Partial<NotificationAgentTypes>;
   watchlistSyncMovies?: boolean;
   watchlistSyncTv?: boolean;
-}
+};
 
 interface UserHookResponse {
   user?: User;

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1085,6 +1085,8 @@
   "components.UserProfile.UserSettings.UserGeneralSettings.enableOverride": "Override Global Limit",
   "components.UserProfile.UserSettings.UserGeneralSettings.general": "General",
   "components.UserProfile.UserSettings.UserGeneralSettings.generalsettings": "General Settings",
+  "components.UserProfile.UserSettings.UserGeneralSettings.hideTags": "Hide Tags",
+  "components.UserProfile.UserSettings.UserGeneralSettings.hideTagsTip": "Hide the tags in a listing detail page",
   "components.UserProfile.UserSettings.UserGeneralSettings.languageDefault": "Default ({language})",
   "components.UserProfile.UserSettings.UserGeneralSettings.localuser": "Local User",
   "components.UserProfile.UserSettings.UserGeneralSettings.movierequestlimit": "Movie Request Limit",


### PR DESCRIPTION
#### Description
This new option will allow for a user to hide the tags that show in a Movie or TV Show details page. If the setting `Hide Tags` is checked, the tags will not show. If it is unchecked, the tags will show.

#### Screenshot (if UI-related)
Setting:
<img width="1311" alt="image" src="https://github.com/sct/overseerr/assets/66661368/790bf837-8a41-406d-a3a9-49fa6919281b">

Before:
<img width="451" alt="image" src="https://github.com/sct/overseerr/assets/66661368/2c79cc75-7081-4dd4-b51a-44881576db48">

After:
<img width="449" alt="image" src="https://github.com/sct/overseerr/assets/66661368/7bfe7f75-ef1b-4d3b-adcc-ae33337a3bd2">

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3350 
