### PR TITLE
feat: select default seriesType for anime

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -984,7 +984,7 @@ export class MediaRequest {
             (keyword) => keyword.id === ANIME_KEYWORD_ID
           )
         ) {
-          seriesType = 'anime';
+          seriesType = sonarrSettings.seriesType;
         }
 
         let rootFolder =

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -69,6 +69,7 @@ export interface RadarrSettings extends DVRSettings {
 }
 
 export interface SonarrSettings extends DVRSettings {
+  seriesType: 'standard' | 'daily' | 'anime';
   activeAnimeProfileId?: number;
   activeAnimeProfileName?: string;
   activeAnimeDirectory?: string;

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -43,6 +43,7 @@ const messages = defineMessages({
   qualityprofile: 'Quality Profile',
   languageprofile: 'Language Profile',
   rootfolder: 'Root Folder',
+  seriesType: 'Anime Series Type',
   animequalityprofile: 'Anime Quality Profile',
   animelanguageprofile: 'Anime Language Profile',
   animerootfolder: 'Anime Root Folder',
@@ -244,6 +245,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
           activeProfileId: sonarr?.activeProfileId,
           activeLanguageProfileId: sonarr?.activeLanguageProfileId,
           rootFolder: sonarr?.activeDirectory,
+          seriesType: sonarr?.seriesType,
           activeAnimeProfileId: sonarr?.activeAnimeProfileId,
           activeAnimeLanguageProfileId: sonarr?.activeAnimeLanguageProfileId,
           activeAnimeRootFolder: sonarr?.activeAnimeDirectory,
@@ -280,6 +282,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                 : undefined,
               activeProfileName: profileName,
               activeDirectory: values.rootFolder,
+              seriesType: values.seriesType,
               activeAnimeProfileId: values.activeAnimeProfileId
                 ? Number(values.activeAnimeProfileId)
                 : undefined,
@@ -722,6 +725,27 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                       }
                     />
                   </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="seriesType" className="text-label">
+                    {intl.formatMessage(messages.seriesType)}
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field">
+                      <Field
+                        as="select"
+                        id="seriesType"
+                        name="seriesType"
+                        disabled={!isValidated || isTesting}
+                      >
+                        <option value="standard">Standard</option>
+                        <option value="anime">Anime</option>
+                      </Field>
+                    </div>
+                  </div>
+                  {errors.seriesType && touched.seriesType && (
+                    <div className="error">{errors.seriesType}</div>
+                  )}
                 </div>
                 <div className="form-row">
                   <label htmlFor="activeAnimeProfileId" className="text-label">

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -860,6 +860,7 @@
   "components.Settings.SonarrModal.selectQualityProfile": "Select quality profile",
   "components.Settings.SonarrModal.selectRootFolder": "Select root folder",
   "components.Settings.SonarrModal.selecttags": "Select tags",
+  "components.Settings.SonarrModal.seriesType": "Anime Series Type",
   "components.Settings.SonarrModal.server4k": "4K Server",
   "components.Settings.SonarrModal.servername": "Server Name",
   "components.Settings.SonarrModal.ssl": "Use SSL",


### PR DESCRIPTION
#### Description
Added flexibility to set default anime series type in service settings. Now you can choose 'standard' for anime if you prefer it, making it easier to use features like searching for season packs on Sonarr.

#### Screenshot (if UI-related)
![image](https://github.com/sct/overseerr/assets/98979876/19e81d6a-4085-467f-ad20-5d96075860d5)


#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3626 
