### PR TITLE
fix(docs): correct openapi docs minor issues

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -3473,7 +3473,7 @@ paths:
                   results:
                     type: array
                     items:
-                    $ref: '#/components/schemas/User'
+                      $ref: '#/components/schemas/User'
     post:
       summary: Create new user
       description: |

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -3170,6 +3170,12 @@ paths:
         Updates a single slider and return the newly updated slider. Requires the `ADMIN` permission.
       tags:
         - settings
+      parameters:
+        - in: path
+          name: sliderId
+          required: true
+          schema:
+            type: number
       requestBody:
         required: true
         content:


### PR DESCRIPTION
#### Description
This is to correct what I think are a couple of small issue with the api doc:
- correct indentation of get user response
- add missing parameter in slider update (as per https://swagger.io/docs/specification/describing-parameters/)