### PR TITLE
Update SameSite policy of session cookie to Lax

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -152,7 +152,7 @@ app
         cookie: {
           maxAge: 1000 * 60 * 60 * 24 * 30,
           httpOnly: true,
-          sameSite: true,
+          sameSite: 'lax',
           secure: 'auto',
         },
         store: new TypeormStore({


### PR DESCRIPTION
#### Description

The session cookie `connect.sid` currently has a `Strict` `SameSite` policy, which prevents users to access pages from an external link. Requests with an external `Referrer` are systematically redirected to the login page because the session cookie is not added to the request. Changing this policy will not add vulnerabilities to the application.

Also, an alternative would be to set this policy to `Lax` only when the the `CSRF Protection` is disabled, let me know if this is preferable.

#### To-Dos

- [X] Successful build `yarn build`
- [X] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes [Overseerr-Assistant #11](https://github.com/RemiRigal/Overseerr-Assistant/issues/11)
