### PR TITLE
fix(ui): ensure title fits into the `view collection` box

### DIFF
--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -500,7 +500,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                         }}
                       />
                     </div>
-                    <div className="relative z-10 flex h-14 items-center justify-between p-4 text-gray-200 transition duration-300 group-hover:text-white">
+                    <div className="relative z-10 flex h-full items-center justify-between p-4 text-gray-200 transition duration-300 group-hover:text-white">
                       <div>{data.collection.name}</div>
                       <Button buttonSize="sm">
                         {intl.formatMessage(globalMessages.view)}


### PR DESCRIPTION
#### Description
Changed the height of the container to `h-full` to ensure that media with long titles such as `Fate/Grand Order the Movie: Divine Realm of the Round Table Collection` fits into the box. This does not affect smaller titles (see attached screenshots for examples)

#### Screenshot (if UI-related)
**Before:**
![Notfixed](https://github.com/sct/overseerr/assets/98979876/a723cc33-ff77-44bb-abc4-2ce81b2fb3fd)

**After:**
![fixed](https://github.com/sct/overseerr/assets/98979876/2554f0f9-be68-4c77-9b93-b4ab5d13b32a)

**Other smaller titles:**
![small](https://github.com/sct/overseerr/assets/98979876/ba2bcc06-9c3a-424f-b205-03abfcf80fd3)


#### To-Dos

- [x] Successful build `yarn build`


