### PR TITLE
fix: api language query parameter ignored

### DIFF
--- a/server/routes/collection.ts
+++ b/server/routes/collection.ts
@@ -12,7 +12,7 @@ collectionRoutes.get<{ id: string }>('/:id', async (req, res, next) => {
   try {
     const collection = await tmdb.getCollection({
       collectionId: Number(req.params.id),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getRelatedMedia(

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -164,7 +164,7 @@ discoverRoutes.get<{ language: string }>(
 
       const data = await tmdb.getDiscoverMovies({
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         originalLanguage: req.params.language,
       });
 
@@ -208,7 +208,7 @@ discoverRoutes.get<{ genreId: string }>(
 
     try {
       const genres = await tmdb.getMovieGenres({
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
       });
 
       const genre = genres.find(
@@ -221,7 +221,7 @@ discoverRoutes.get<{ genreId: string }>(
 
       const data = await tmdb.getDiscoverMovies({
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         genre: req.params.genreId as string,
       });
 
@@ -268,7 +268,7 @@ discoverRoutes.get<{ studioId: string }>(
 
       const data = await tmdb.getDiscoverMovies({
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         studio: req.params.studioId as string,
       });
 
@@ -317,7 +317,7 @@ discoverRoutes.get('/movies/upcoming', async (req, res, next) => {
   try {
     const data = await tmdb.getDiscoverMovies({
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
       primaryReleaseDateGte: date,
     });
 
@@ -440,7 +440,7 @@ discoverRoutes.get<{ language: string }>(
 
       const data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         originalLanguage: req.params.language,
       });
 
@@ -484,7 +484,7 @@ discoverRoutes.get<{ genreId: string }>(
 
     try {
       const genres = await tmdb.getTvGenres({
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
       });
 
       const genre = genres.find(
@@ -497,7 +497,7 @@ discoverRoutes.get<{ genreId: string }>(
 
       const data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         genre: req.params.genreId,
       });
 
@@ -544,7 +544,7 @@ discoverRoutes.get<{ networkId: string }>(
 
       const data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         network: Number(req.params.networkId),
       });
 
@@ -593,7 +593,7 @@ discoverRoutes.get('/tv/upcoming', async (req, res, next) => {
   try {
     const data = await tmdb.getDiscoverTv({
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
       firstAirDateGte: date,
     });
 
@@ -632,7 +632,7 @@ discoverRoutes.get('/trending', async (req, res, next) => {
   try {
     const data = await tmdb.getAllTrending({
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getRelatedMedia(
@@ -686,7 +686,7 @@ discoverRoutes.get<{ keywordId: string }>(
       const data = await tmdb.getMoviesByKeyword({
         keywordId: Number(req.params.keywordId),
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
       });
 
       const media = await Media.getRelatedMedia(
@@ -730,7 +730,7 @@ discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
       const mappedGenres: GenreSliderItem[] = [];
 
       const genres = await tmdb.getMovieGenres({
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
       });
 
       await Promise.all(
@@ -774,7 +774,7 @@ discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
       const mappedGenres: GenreSliderItem[] = [];
 
       const genres = await tmdb.getTvGenres({
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
       });
 
       await Promise.all(

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -235,7 +235,7 @@ router.get('/genres/movie', isAuthenticated(), async (req, res, next) => {
 
   try {
     const genres = await tmdb.getMovieGenres({
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     return res.status(200).json(genres);
@@ -256,7 +256,7 @@ router.get('/genres/tv', isAuthenticated(), async (req, res, next) => {
 
   try {
     const genres = await tmdb.getTvGenres({
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     return res.status(200).json(genres);

--- a/server/routes/movie.ts
+++ b/server/routes/movie.ts
@@ -17,7 +17,7 @@ movieRoutes.get('/:id', async (req, res, next) => {
   try {
     const tmdbMovie = await tmdb.getMovie({
       movieId: Number(req.params.id),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getMedia(tmdbMovie.id, MediaType.MOVIE);
@@ -43,7 +43,7 @@ movieRoutes.get('/:id/recommendations', async (req, res, next) => {
     const results = await tmdb.getMovieRecommendations({
       movieId: Number(req.params.id),
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getRelatedMedia(
@@ -84,7 +84,7 @@ movieRoutes.get('/:id/similar', async (req, res, next) => {
     const results = await tmdb.getMovieSimilar({
       movieId: Number(req.params.id),
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getRelatedMedia(

--- a/server/routes/person.ts
+++ b/server/routes/person.ts
@@ -16,7 +16,7 @@ personRoutes.get('/:id', async (req, res, next) => {
   try {
     const person = await tmdb.getPerson({
       personId: Number(req.params.id),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
     return res.status(200).json(mapPersonDetails(person));
   } catch (e) {
@@ -38,7 +38,7 @@ personRoutes.get('/:id/combined_credits', async (req, res, next) => {
   try {
     const combinedCredits = await tmdb.getPersonCombinedCredits({
       personId: Number(req.params.id),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const castMedia = await Media.getRelatedMedia(

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -20,7 +20,7 @@ searchRoutes.get('/', async (req, res, next) => {
         .match(searchProvider.pattern) as RegExpMatchArray;
       results = await searchProvider.search({
         id,
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
         query: queryString,
       });
     } else {
@@ -29,7 +29,7 @@ searchRoutes.get('/', async (req, res, next) => {
       results = await tmdb.searchMulti({
         query: queryString,
         page: Number(req.query.page),
-        language: req.locale ?? (req.query.language as string),
+        language: (req.query.language as string) ?? req.locale,
       });
     }
 

--- a/server/routes/tv.ts
+++ b/server/routes/tv.ts
@@ -14,7 +14,7 @@ tvRoutes.get('/:id', async (req, res, next) => {
   try {
     const tv = await tmdb.getTvShow({
       tvId: Number(req.params.id),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getMedia(tv.id, MediaType.TV);
@@ -40,7 +40,7 @@ tvRoutes.get('/:id/season/:seasonNumber', async (req, res, next) => {
     const season = await tmdb.getTvSeason({
       tvId: Number(req.params.id),
       seasonNumber: Number(req.params.seasonNumber),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     return res.status(200).json(mapSeasonWithEpisodes(season));
@@ -65,7 +65,7 @@ tvRoutes.get('/:id/recommendations', async (req, res, next) => {
     const results = await tmdb.getTvRecommendations({
       tvId: Number(req.params.id),
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getRelatedMedia(
@@ -105,7 +105,7 @@ tvRoutes.get('/:id/similar', async (req, res, next) => {
     const results = await tmdb.getTvSimilar({
       tvId: Number(req.params.id),
       page: Number(req.query.page),
-      language: req.locale ?? (req.query.language as string),
+      language: (req.query.language as string) ?? req.locale,
     });
 
     const media = await Media.getRelatedMedia(


### PR DESCRIPTION
#### Description

Fixes bug where language query parameter is ignored in API requests. Currently user's locale or main settings locale value is used over language specified in query for API requests to TMDB. User's may want to query the API in other languages to grab textless posters with 'xx' language query for example. 

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- None
