### PR TITLE
feat(server): fix queue processing

### DIFF
--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -48,6 +48,17 @@ export interface QualityProfile {
   name: string;
 }
 
+interface QueueStatus {
+  id: number;
+  totalCount: number;
+  count: number;
+  unknownCount: number;
+  errors: boolean;
+  warnings: boolean;
+  unknownErrors: boolean;
+  unknownWarnings: boolean;
+}
+
 interface QueueItem {
   size: number;
   title: string;
@@ -155,13 +166,28 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
     }
   };
 
+  public getQueueStatus = async (): Promise<QueueStatus> => {
+    try {
+      const response = await this.axios.get<QueueStatus>(`/queue/status`);
+
+      return response.data;
+    } catch (e) {
+      throw new Error(
+        `[${this.apiName}] Failed to retrieve queue status: ${e.message}`
+      );
+    }
+  };
+
   public getQueue = async (): Promise<(QueueItem & QueueItemAppendT)[]> => {
     try {
+      const { totalCount } = await this.getQueueStatus();
+
       const response = await this.axios.get<QueueResponse<QueueItemAppendT>>(
         `/queue`,
         {
           params: {
             includeEpisode: true,
+            pageSize: totalCount,
           },
         }
       );


### PR DESCRIPTION
#### Description

This PR fixes an issue that does not move all downloads up the queue. The server is currently requesting a page of 10 items.

The fix requests the size of the queue before request for the content of the queue to allow more than 10 elements to be seen.
