### PR TITLE
feat(tooltip): add tooltip to display exact time on date hover

### DIFF
--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -210,13 +210,24 @@ const RequestBlock = ({ request, onUpdate }: RequestBlockProps) => {
             <Tooltip content={intl.formatMessage(messages.requestdate)}>
               <CalendarIcon className="mr-1.5 h-5 w-5 flex-shrink-0" />
             </Tooltip>
-            <span>
-              {intl.formatDate(request.createdAt, {
+            <Tooltip
+              content={intl.formatDate(request.createdAt, {
                 year: 'numeric',
                 month: 'long',
                 day: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric',
+                second: 'numeric',
               })}
-            </span>
+            >
+              <span>
+                {intl.formatDate(request.createdAt, {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </span>
+            </Tooltip>
           </div>
         </div>
         {(request.seasons ?? []).length > 0 && (


### PR DESCRIPTION
#### Description
I added this because I would like to see the exact time a request was made so I can check if it was just added a few minutes ago, or if something has gone wrong.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
