### PR TITLE
feat(plex-login): use application name for plex product name on login

### DIFF
--- a/src/components/PlexLoginButton/index.tsx
+++ b/src/components/PlexLoginButton/index.tsx
@@ -1,3 +1,4 @@
+import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
 import PlexOAuth from '@app/utils/plex';
 import { ArrowLeftOnRectangleIcon } from '@heroicons/react/24/outline';
@@ -24,11 +25,14 @@ const PlexLoginButton = ({
 }: PlexLoginButtonProps) => {
   const intl = useIntl();
   const [loading, setLoading] = useState(false);
+  const settings = useSettings();
 
   const getPlexLogin = async () => {
     setLoading(true);
     try {
-      const authToken = await plexOAuth.login();
+      const authToken = await plexOAuth.login(
+        settings.currentSettings.applicationTitle
+      );
       setLoading(false);
       onAuthToken(authToken);
     } catch (e) {

--- a/src/components/PlexLoginButton/index.tsx
+++ b/src/components/PlexLoginButton/index.tsx
@@ -31,7 +31,7 @@ const PlexLoginButton = ({
     setLoading(true);
     try {
       const authToken = await plexOAuth.login(
-        settings.currentSettings.applicationTitle
+        settings.currentSettings.applicationTitle || 'Overseerr'
       );
       setLoading(false);
       onAuthToken(authToken);

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -42,9 +42,7 @@ class PlexOAuth {
   private authToken?: string;
   private DEFAULT_APPLICATION_NAME = 'Overseerr';
 
-  public initializeHeaders(
-    applicationName = this.DEFAULT_APPLICATION_NAME
-  ): void {
+  public initializeHeaders(applicationName): void {
     if (!window) {
       throw new Error(
         'Window is not defined. Are you calling this in the browser?'

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -58,11 +58,6 @@ class PlexOAuth {
       clientId = uuid;
     }
 
-    const plexProductName =
-      applicationName === this.DEFAULT_APPLICATION_NAME
-        ? applicationName
-        : `${applicationName} - ${this.DEFAULT_APPLICATION_NAME}`;
-
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {
       Accept: 'application/json',

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -66,7 +66,7 @@ class PlexOAuth {
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {
       Accept: 'application/json',
-      'X-Plex-Product': plexProductName,
+      'X-Plex-Product': applicationName,
       'X-Plex-Version': 'Plex OAuth',
       'X-Plex-Client-Identifier': clientId,
       'X-Plex-Model': 'Plex OAuth',

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -40,8 +40,11 @@ class PlexOAuth {
   private popup?: Window;
 
   private authToken?: string;
+  private DEFAULT_APPLICATION_NAME = 'Overseerr';
 
-  public initializeHeaders(): void {
+  public initializeHeaders(
+    applicationName = this.DEFAULT_APPLICATION_NAME
+  ): void {
     if (!window) {
       throw new Error(
         'Window is not defined. Are you calling this in the browser?'
@@ -55,10 +58,15 @@ class PlexOAuth {
       clientId = uuid;
     }
 
+    const plexProductName =
+      applicationName === this.DEFAULT_APPLICATION_NAME
+        ? applicationName
+        : `${applicationName} - Overseerr`;
+
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {
       Accept: 'application/json',
-      'X-Plex-Product': 'Overseerr',
+      'X-Plex-Product': plexProductName,
       'X-Plex-Version': 'Plex OAuth',
       'X-Plex-Client-Identifier': clientId,
       'X-Plex-Model': 'Plex OAuth',
@@ -93,8 +101,8 @@ class PlexOAuth {
     this.openPopup({ title: 'Plex Auth', w: 600, h: 700 });
   }
 
-  public async login(): Promise<string> {
-    this.initializeHeaders();
+  public async login(applicationName?: string): Promise<string> {
+    this.initializeHeaders(applicationName);
     await this.getPin();
 
     if (!this.plexHeaders || !this.pin) {

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -40,7 +40,6 @@ class PlexOAuth {
   private popup?: Window;
 
   private authToken?: string;
-  private DEFAULT_APPLICATION_NAME = 'Overseerr';
 
   public initializeHeaders(applicationName): void {
     if (!window) {

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -61,7 +61,7 @@ class PlexOAuth {
     const plexProductName =
       applicationName === this.DEFAULT_APPLICATION_NAME
         ? applicationName
-        : `${applicationName} - Overseerr`;
+        : `${applicationName} - ${this.DEFAULT_APPLICATION_NAME}`;
 
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {


### PR DESCRIPTION
#### Description

Update the Plex OAuth flow to include the application name. This allows for a tad more customization and authenticating users not being concerned about what "Overseerr" is. The plex product name shows on the plex login screen as shown in the screenshots below.

If the application name is the default `Overseerr` the plex product name will be `Overseerr`

If the application name is not the default it will be `${applicationName} - Overseerr`.

#### Screenshot (if UI-related)
Default name of `Overseerr`
![image](https://github.com/sct/overseerr/assets/11284473/67f7d8b8-8db1-4c7a-83fc-e49f893342ab)

Application name of `My Server`
![image](https://github.com/sct/overseerr/assets/11284473/a6b54ed7-7a13-48dd-b7f0-bc530787e2ee)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)