### PR TITLE
feat(telegram): Allow to specify telegram topic ID for notifications if required

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1238,6 +1238,8 @@ components:
               type: string
             chatId:
               type: string
+            messageThreadId:
+              type: string
             sendSilently:
               type: boolean
     PushbulletSettings:
@@ -1719,6 +1721,9 @@ components:
           type: string
           nullable: true
         telegramChatId:
+          type: string
+          nullable: true
+        telegramMessageThreadId:
           type: string
           nullable: true
         telegramSendSilently:

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -18,6 +18,7 @@ interface TelegramMessagePayload {
   text: string;
   parse_mode: string;
   chat_id: string;
+  message_thread_id: string;
   disable_notification: boolean;
 }
 
@@ -26,6 +27,7 @@ interface TelegramPhotoPayload {
   caption: string;
   parse_mode: string;
   chat_id: string;
+  message_thread_id: string;
   disable_notification: boolean;
 }
 
@@ -178,6 +180,7 @@ class TelegramAgent
         await axios.post(endpoint, {
           ...notificationPayload,
           chat_id: settings.options.chatId,
+          message_thread_id: settings.options.messageThreadId,
           disable_notification: !!settings.options.sendSilently,
         } as TelegramMessagePayload | TelegramPhotoPayload);
       } catch (e) {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -177,6 +177,7 @@ export interface NotificationAgentTelegram extends NotificationAgentConfig {
     botUsername?: string;
     botAPI: string;
     chatId: string;
+    messageThreadId: string;
     sendSilently: boolean;
   };
 }
@@ -358,6 +359,7 @@ class Settings {
             options: {
               botAPI: '',
               chatId: '',
+              messageThreadId: '',
               sendSilently: false,
             },
           },

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -23,6 +23,9 @@ const messages = defineMessages({
   chatId: 'Chat ID',
   chatIdTip:
     'Start a chat with your bot, add <GetIdBotLink>@get_id_bot</GetIdBotLink>, and issue the <code>/my_id</code> command',
+  messageThreadId: 'Thread/Topic ID',
+  messageThreadIdTip:
+    "If your group chat has topics enabled, you can specify a thread/topic's ID here",
   validationBotAPIRequired: 'You must provide a bot authorization token',
   validationChatIdRequired: 'You must provide a valid chat ID',
   telegramsettingssaved: 'Telegram notification settings saved successfully!',
@@ -64,6 +67,7 @@ const NotificationsTelegram = () => {
         /^-?\d+$/,
         intl.formatMessage(messages.validationChatIdRequired)
       ),
+      messageThreadId: Yup.string().nullable(),
   });
 
   if (!data && !error) {
@@ -78,6 +82,7 @@ const NotificationsTelegram = () => {
         botUsername: data?.options.botUsername,
         botAPI: data?.options.botAPI,
         chatId: data?.options.chatId,
+        messageThreadId: data?.options.messageThreadId,
         sendSilently: data?.options.sendSilently,
       }}
       validationSchema={NotificationsTelegramSchema}
@@ -89,6 +94,7 @@ const NotificationsTelegram = () => {
             options: {
               botAPI: values.botAPI,
               chatId: values.chatId,
+              messageThreadId: values.messageThreadId,
               sendSilently: values.sendSilently,
               botUsername: values.botUsername,
             },
@@ -137,6 +143,7 @@ const NotificationsTelegram = () => {
               options: {
                 botAPI: values.botAPI,
                 chatId: values.chatId,
+                messageThreadId: values.messageThreadId,
                 sendSilently: values.sendSilently,
                 botUsername: values.botUsername,
               },
@@ -282,6 +289,28 @@ const NotificationsTelegram = () => {
                   touched.chatId &&
                   typeof errors.chatId === 'string' && (
                     <div className="error">{errors.chatId}</div>
+                  )}
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="messageThreadId" className="text-label">
+                {intl.formatMessage(messages.messageThreadId)}
+                <span className="label-tip">
+                  {intl.formatMessage(messages.messageThreadIdTip)}
+                </span>
+              </label>
+              <div className="form-input-area">
+                <div className="form-input-field">
+                  <Field
+                    id="messageThreadId"
+                    name="messageThreadId"
+                    type="text"
+                  />
+                </div>
+                {errors.messageThreadId &&
+                  touched.messageThreadId &&
+                  typeof errors.messageThreadId === 'string' && (
+                    <div className="error">{errors.messageThreadId}</div>
                   )}
               </div>
             </div>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -612,6 +612,8 @@
   "components.Settings.Notifications.botUsernameTip": "Allow users to also start a chat with your bot and configure their own notifications",
   "components.Settings.Notifications.chatId": "Chat ID",
   "components.Settings.Notifications.chatIdTip": "Start a chat with your bot, add <GetIdBotLink>@get_id_bot</GetIdBotLink>, and issue the <code>/my_id</code> command",
+  "components.Settings.Notifications.messageThreadId": "Thread/Topic ID",
+  "components.Settings.Notifications.messageThreadIdTip": "If your group chat has topics enabled, you can specify a thread/topic's ID here",
   "components.Settings.Notifications.discordsettingsfailed": "Discord notification settings failed to save.",
   "components.Settings.Notifications.discordsettingssaved": "Discord notification settings saved successfully!",
   "components.Settings.Notifications.emailsender": "Sender Address",

--- a/src/i18n/locale/ru.json
+++ b/src/i18n/locale/ru.json
@@ -703,6 +703,8 @@
   "components.Settings.Notifications.discordsettingsfailed": "Не удалось сохранить настройки уведомлений Discord.",
   "components.Settings.Notifications.chatIdTip": "Начните чат со своим ботом, добавьте <GetIdBotLink>@get_id_bot</GetIdBotLink> и выполните команду <code>/my_id</code>",
   "components.Settings.Notifications.chatId": "ID чата",
+  "components.Settings.Notifications.messageThreadId": "ID топика",
+  "components.Settings.Notifications.messageThreadIdTip": "Если в вашей группе включены топики, Вы можете указать ID нужного топика тут",
   "components.Settings.Notifications.botUsernameTip": "Разрешить пользователям начинать чат с вашим ботом и настраивать свои собственные уведомления",
   "components.Settings.Notifications.botUsername": "Имя бота",
   "components.Settings.Notifications.botAvatarUrl": "URL аватара бота",


### PR DESCRIPTION
#### Description

These commits allow server admin to specify a telegram chat topic ID, where notifications should be send to.

#### To-Dos

- [x] docker compose up -d

