### PR TITLE
Change localhost to process.env.HOST for client requests

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -233,7 +233,7 @@ CoreApp.getInitialProps = async (initialProps) => {
   if (ctx.res) {
     // Check if app is initialized and redirect if necessary
     const response = await axios.get<PublicSettingsResponse>(
-      `http://localhost:${process.env.PORT || 5055}/api/v1/settings/public`
+      `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/settings/public`
     );
 
     currentSettings = response.data;
@@ -251,7 +251,7 @@ CoreApp.getInitialProps = async (initialProps) => {
       try {
         // Attempt to get the user by running a request to the local api
         const response = await axios.get<User>(
-          `http://localhost:${process.env.PORT || 5055}/api/v1/auth/me`,
+          `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/auth/me`,
           {
             headers:
               ctx.req && ctx.req.headers.cookie

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -233,7 +233,9 @@ CoreApp.getInitialProps = async (initialProps) => {
   if (ctx.res) {
     // Check if app is initialized and redirect if necessary
     const response = await axios.get<PublicSettingsResponse>(
-      `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/settings/public`
+      `http://${process.env.HOST || 'localhost'}:${
+        process.env.PORT || 5055
+      }/api/v1/settings/public`
     );
 
     currentSettings = response.data;
@@ -251,7 +253,9 @@ CoreApp.getInitialProps = async (initialProps) => {
       try {
         // Attempt to get the user by running a request to the local api
         const response = await axios.get<User>(
-          `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/auth/me`,
+          `http://${process.env.HOST || 'localhost'}:${
+            process.env.PORT || 5055
+          }/api/v1/auth/me`,
           {
             headers:
               ctx.req && ctx.req.headers.cookie

--- a/src/pages/collection/[collectionId]/index.tsx
+++ b/src/pages/collection/[collectionId]/index.tsx
@@ -15,7 +15,7 @@ export const getServerSideProps: GetServerSideProps<
   CollectionPageProps
 > = async (ctx) => {
   const response = await axios.get<Collection>(
-    `http://localhost:${process.env.PORT || 5055}/api/v1/collection/${
+    `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/collection/${
       ctx.query.collectionId
     }`,
     {

--- a/src/pages/collection/[collectionId]/index.tsx
+++ b/src/pages/collection/[collectionId]/index.tsx
@@ -15,9 +15,9 @@ export const getServerSideProps: GetServerSideProps<
   CollectionPageProps
 > = async (ctx) => {
   const response = await axios.get<Collection>(
-    `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/collection/${
-      ctx.query.collectionId
-    }`,
+    `http://${process.env.HOST || 'localhost'}:${
+      process.env.PORT || 5055
+    }/api/v1/collection/${ctx.query.collectionId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/movie/[movieId]/index.tsx
+++ b/src/pages/movie/[movieId]/index.tsx
@@ -15,7 +15,7 @@ export const getServerSideProps: GetServerSideProps<MoviePageProps> = async (
   ctx
 ) => {
   const response = await axios.get<MovieDetailsType>(
-    `http://localhost:${process.env.PORT || 5055}/api/v1/movie/${
+    `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/movie/${
       ctx.query.movieId
     }`,
     {

--- a/src/pages/movie/[movieId]/index.tsx
+++ b/src/pages/movie/[movieId]/index.tsx
@@ -15,9 +15,9 @@ export const getServerSideProps: GetServerSideProps<MoviePageProps> = async (
   ctx
 ) => {
   const response = await axios.get<MovieDetailsType>(
-    `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/movie/${
-      ctx.query.movieId
-    }`,
+    `http://${process.env.HOST || 'localhost'}:${
+      process.env.PORT || 5055
+    }/api/v1/movie/${ctx.query.movieId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/tv/[tvId]/index.tsx
+++ b/src/pages/tv/[tvId]/index.tsx
@@ -15,7 +15,9 @@ export const getServerSideProps: GetServerSideProps<TvPageProps> = async (
   ctx
 ) => {
   const response = await axios.get<TvDetailsType>(
-    `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/tv/${ctx.query.tvId}`,
+    `http://${process.env.HOST || 'localhost'}:${
+      process.env.PORT || 5055
+    }/api/v1/tv/${ctx.query.tvId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/tv/[tvId]/index.tsx
+++ b/src/pages/tv/[tvId]/index.tsx
@@ -15,7 +15,7 @@ export const getServerSideProps: GetServerSideProps<TvPageProps> = async (
   ctx
 ) => {
   const response = await axios.get<TvDetailsType>(
-    `http://localhost:${process.env.PORT || 5055}/api/v1/tv/${ctx.query.tvId}`,
+    `http://${process.env.HOST || 'localhost'}:${process.env.PORT || 5055}/api/v1/tv/${ctx.query.tvId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }


### PR DESCRIPTION
#### Description
Server side loads the IP address to bind the socket to from environment variable `HOST`, but client side expects the API to always be on localhost. This generally works, but when you have IPv6 capable server and trying to bind to IPv4 port (e.g. HOST=127.0.0.1), this does not work as client side has hardcoded `localhost` instead of using `process.env.HOST`. As IPv6 takes priority over v4, localhost resolves to ::1 resulting in internal server error.

This fix replaces all occurrences of api calls from localhost:PORT to HOST:PORT.

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`

#### Issues Fixed or Closed

- Fixes #3838 
