### PR TITLE
feat: remove NSFW category image

### DIFF
--- a/src/components/Discover/MovieGenreList/index.tsx
+++ b/src/components/Discover/MovieGenreList/index.tsx
@@ -39,7 +39,7 @@ const MovieGenreList = () => {
               name={genre.name}
               image={`https://image.tmdb.org/t/p/w1280_filter(duotone,${
                 genreColorMap[genre.id] ?? genreColorMap[0]
-              })${genre.backdrops[4]}`}
+              })${genre.backdrops[5]}`}
               url={`/discover/movies/genre/${genre.id}`}
               canExpand
             />

--- a/src/components/Discover/MovieGenreSlider/index.tsx
+++ b/src/components/Discover/MovieGenreSlider/index.tsx
@@ -42,7 +42,7 @@ const MovieGenreSlider = () => {
             name={genre.name}
             image={`https://image.tmdb.org/t/p/w1280_filter(duotone,${
               genreColorMap[genre.id] ?? genreColorMap[0]
-            })${genre.backdrops[4]}`}
+            })${genre.backdrops[5]}`}
             url={`/discover/movies?genre=${genre.id}`}
           />
         ))}


### PR DESCRIPTION
#### Description

The category image for romance was VERY NSFW so this changes the index from 4 to 5 for that image which is no longer NSFW. I looked to see if the TMDB API included anything to make it non NSFW but it doesn't seem to. This is the best solution for now I think.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
