### PR TITLE
fix: correct deep links on iPad

### DIFF
--- a/src/hooks/useDeepLinks.ts
+++ b/src/hooks/useDeepLinks.ts
@@ -19,7 +19,7 @@ const useDeepLinks = ({
   useEffect(() => {
     if (
       /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-      (navigator.userAgent === 'MacIntel' && navigator.maxTouchPoints > 1)
+      (navigator.userAgent.includes('Mac') && navigator.maxTouchPoints > 1)
     ) {
       setReturnedPlexUrl(iOSPlexUrl);
       setReturnedPlexUrl4k(iOSPlexUrl4k);


### PR DESCRIPTION
#### Description

Seems like recently the iPad detection broke for the deep link hook. We can do a similar check to what we are currently doing and see if the user agent includes type Mac (we also check if the device is touch enabled). Not the most optimal solution but the only solution as far as I'm aware of for now.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
