### PR TITLE
feat: filter to hide already available media

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4244,6 +4244,11 @@ paths:
           schema:
             type: string
             example: 8|9
+        - in: query
+          name: hideAvailable
+          schema:
+            type: boolean
+            example: true
       responses:
         '200':
           description: Results
@@ -4533,6 +4538,11 @@ paths:
           schema:
             type: string
             example: 8|9
+        - in: query
+          name: hideAvailable
+          schema:
+            type: boolean
+            example: true
       responses:
         '200':
           description: Results

--- a/src/components/Discover/FilterSlideover/index.tsx
+++ b/src/components/Discover/FilterSlideover/index.tsx
@@ -1,5 +1,6 @@
 import Button from '@app/components/Common/Button';
 import MultiRangeSlider from '@app/components/Common/MultiRangeSlider';
+import SlideCheckbox from '@app/components/Common/SlideCheckbox';
 import SlideOver from '@app/components/Common/SlideOver';
 import type { FilterOptions } from '@app/components/Discover/constants';
 import { countActiveFilters } from '@app/components/Discover/constants';
@@ -39,6 +40,7 @@ const messages = defineMessages({
   runtime: 'Runtime',
   streamingservices: 'Streaming Services',
   voteCount: 'Number of votes between {minValue} and {maxValue}',
+  hideAvailable: 'Hide available titles',
 });
 
 type FilterSlideoverProps = {
@@ -285,6 +287,20 @@ const FilterSlideover = ({
               minValue: currentFilters.voteCountGte ?? 0,
               maxValue: currentFilters.voteCountLte ?? 1000,
             })}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-lg font-semibold">
+            {intl.formatMessage(messages.hideAvailable)}
+          </span>
+          <SlideCheckbox
+            checked={currentFilters.hideAvailable === 'true'}
+            onClick={() => {
+              updateQueryParams(
+                'hideAvailable',
+                currentFilters.hideAvailable === 'true' ? undefined : 'true'
+              );
+            }}
           />
         </div>
         <span className="text-lg font-semibold">

--- a/src/components/Discover/constants.ts
+++ b/src/components/Discover/constants.ts
@@ -108,6 +108,7 @@ export const QueryFilterOptions = z.object({
   voteCountGte: z.string().optional(),
   watchRegion: z.string().optional(),
   watchProviders: z.string().optional(),
+  hideAvailable: z.string().optional(),
 });
 
 export type FilterOptions = z.infer<typeof QueryFilterOptions>;
@@ -185,6 +186,10 @@ export const prepareFilterValues = (
 
   if (values.watchRegion) {
     filterValues.watchRegion = values.watchRegion;
+  }
+
+  if (values.hideAvailable) {
+    filterValues.hideAvailable = values.hideAvailable;
   }
 
   return filterValues;


### PR DESCRIPTION
This allows users to hide media that is already available, in the discover pages

#### Description

#### Screenshot (if UI-related)

<img width="429" alt="Screenshot 2024-07-16 at 6 19 58 PM" src="https://github.com/user-attachments/assets/d0575456-1e54-4ed1-8f4f-5c52ef9ccab0">


#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Closes #3779
