### PR TITLE
feat: persistent filters

### DIFF
--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@app/components/Discover/constants';
 import FilterSlideover from '@app/components/Discover/FilterSlideover';
 import useDiscover from '@app/hooks/useDiscover';
+import usePersistentFilters from '@app/hooks/usePersistentFilteres';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import Error from '@app/pages/_error';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
@@ -49,6 +50,8 @@ const DiscoverMovies = () => {
   const updateQueryParams = useUpdateQueryParams({});
 
   const preparedFilters = prepareFilterValues(router.query);
+
+  usePersistentFilters('dm-filter-settings');
 
   const {
     isLoadingInitialData,

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@app/components/Discover/constants';
 import FilterSlideover from '@app/components/Discover/FilterSlideover';
 import useDiscover from '@app/hooks/useDiscover';
+import usePersistentFilters from '@app/hooks/usePersistentFilteres';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import Error from '@app/pages/_error';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
@@ -49,6 +50,7 @@ const DiscoverTv = () => {
   const [showFilters, setShowFilters] = useState(false);
   const preparedFilters = prepareFilterValues(router.query);
   const updateQueryParams = useUpdateQueryParams({});
+  usePersistentFilters('dtv-filter-settings');
 
   const {
     isLoadingInitialData,

--- a/src/hooks/usePersistentFilteres.ts
+++ b/src/hooks/usePersistentFilteres.ts
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef } from 'react';
+
+const usePersistentFilters = (localStorageKey: string) => {
+  const router = useRouter();
+  const initialLoadCompleteRef = useRef(false);
+
+  const handleRouterReplace = useCallback(() => {
+    const savedFilters = localStorage.getItem(localStorageKey);
+    const parsedFilters = savedFilters ? JSON.parse(savedFilters) : null;
+    router.replace(
+      { pathname: router.pathname, query: parsedFilters },
+      undefined,
+      { shallow: true }
+    );
+    initialLoadCompleteRef.current = true;
+  }, [router, localStorageKey]);
+
+  useEffect(() => {
+    if (!initialLoadCompleteRef.current && router.isReady) {
+      handleRouterReplace();
+    } else if (initialLoadCompleteRef.current && router.isReady) {
+      localStorage.setItem(localStorageKey, JSON.stringify(router.query));
+    }
+  }, [router.isReady, router.query, handleRouterReplace, localStorageKey]);
+};
+
+export default usePersistentFilters;


### PR DESCRIPTION
#### Description
Use localstorage to save filters and orderBy settings in discover tv/movie pages.

#### Screenshot (if UI-related)
![output](https://github.com/user-attachments/assets/e1c1bbb7-f417-4c32-abff-780a95106302)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Closes #3889
