### PR TITLE
Add displayname to plex tv api and use in watchlist log

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -135,8 +135,10 @@ export interface PlexWatchlistCache {
 
 class PlexTvAPI extends ExternalAPI {
   private authToken: string;
+  // Additional info for enchanced error messages
+  private userDisplayName?: string;
 
-  constructor(authToken: string) {
+  constructor(authToken: string, userDisplayName?: string) {
     super(
       'https://plex.tv',
       {},
@@ -151,6 +153,7 @@ class PlexTvAPI extends ExternalAPI {
     );
 
     this.authToken = authToken;
+    this.userDisplayName = userDisplayName;
   }
 
   public async getDevices(): Promise<PlexDevice[]> {
@@ -352,10 +355,13 @@ class PlexTvAPI extends ExternalAPI {
         items: filteredList,
       };
     } catch (e) {
-      logger.error('Failed to retrieve watchlist items', {
-        label: 'Plex.TV Metadata API',
-        errorMessage: e.message,
-      });
+      logger.error(
+        `Failed to retrieve watchlist items for user "${this.userDisplayName}"`,
+        {
+          label: 'Plex.TV Metadata API',
+          errorMessage: e.message,
+        }
+      );
       return {
         offset,
         size,

--- a/server/lib/refreshToken.ts
+++ b/server/lib/refreshToken.ts
@@ -27,7 +27,7 @@ class RefreshToken {
       return;
     }
 
-    const plexTvApi = new PlexTvAPI(user.plexToken);
+    const plexTvApi = new PlexTvAPI(user.plexToken, user.displayName);
     plexTvApi.pingToken();
   }
 }

--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -60,7 +60,7 @@ class WatchlistSync {
       return;
     }
 
-    const plexTvApi = new PlexTvAPI(user.plexToken);
+    const plexTvApi = new PlexTvAPI(user.plexToken, user.displayName);
 
     const response = await plexTvApi.getWatchlist({ size: 20 });
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -67,7 +67,10 @@ authRoutes.post('/plex', async (req, res, next) => {
         select: { id: true, plexToken: true, plexId: true, email: true },
         where: { id: 1 },
       });
-      const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
+      const mainPlexTv = new PlexTvAPI(
+        mainUser.plexToken ?? '',
+        mainUser.displayName
+      );
 
       if (!account.id) {
         logger.error('Plex ID was missing from Plex.tv response', {
@@ -222,7 +225,10 @@ authRoutes.post('/local', async (req, res, next) => {
       select: { id: true, plexToken: true, plexId: true },
       where: { id: 1 },
     });
-    const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
+    const mainPlexTv = new PlexTvAPI(
+      mainUser.plexToken ?? '',
+      mainUser.displayName
+    );
 
     if (!user.plexId) {
       try {

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -832,7 +832,7 @@ discoverRoutes.get<Record<string, unknown>, WatchlistResponse>(
       });
     }
 
-    const plexTV = new PlexTvAPI(activeUser.plexToken);
+    const plexTV = new PlexTvAPI(activeUser.plexToken, activeUser.displayName);
 
     const watchlist = await plexTV.getWatchlist({ offset });
 

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -136,7 +136,7 @@ settingsRoutes.get('/plex/devices/servers', async (req, res, next) => {
       where: { id: 1 },
     });
     const plexTvClient = admin.plexToken
-      ? new PlexTvAPI(admin.plexToken)
+      ? new PlexTvAPI(admin.plexToken, admin.displayName)
       : null;
     const devices = (await plexTvClient?.getDevices())?.filter((device) => {
       return device.provides.includes('server') && device.owned;
@@ -292,7 +292,7 @@ settingsRoutes.get(
         select: { id: true, plexToken: true },
         where: { id: 1 },
       });
-      const plexApi = new PlexTvAPI(admin.plexToken ?? '');
+      const plexApi = new PlexTvAPI(admin.plexToken ?? '', admin.displayName);
       const plexUsers = (await plexApi.getUsers()).MediaContainer.User.map(
         (user) => user.$
       ).filter((user) => user.email);

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -420,7 +420,10 @@ router.post(
         select: { id: true, plexToken: true },
         where: { id: 1 },
       });
-      const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
+      const mainPlexTv = new PlexTvAPI(
+        mainUser.plexToken ?? '',
+        mainUser.displayName
+      );
 
       const plexUsersResponse = await mainPlexTv.getUsers();
       const createdUsers: User[] = [];
@@ -652,7 +655,7 @@ router.get<{ id: string }, WatchlistResponse>(
       });
     }
 
-    const plexTV = new PlexTvAPI(user.plexToken);
+    const plexTV = new PlexTvAPI(user.plexToken, user.displayName);
 
     const watchlist = await plexTV.getWatchlist({ offset });
 


### PR DESCRIPTION
#### Description

Adds a displayname to the `getWatchlist` endpoint so in the error logs we can see which users need to reauthenticate

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

