### PR TITLE
feat(watchlistsync): add 4K support for auto request from plex watchlist

### DIFF
--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -117,7 +117,39 @@ class WatchlistSync {
               mediaItem.type === 'show' ? MediaType.TV : MediaType.MOVIE,
             seasons: mediaItem.type === 'show' ? 'all' : undefined,
             tvdbId: mediaItem.tvdbId,
-            is4k: false,
+            is4k: 
+              (mediaItem.type === 'movie' &&
+                user.hasPermission(
+                  [
+                    Permission.REQUEST_4K,
+                    Permission.REQUEST_4K_MOVIE,
+                  ],
+                  { type: 'or' }
+                ) &&
+                user.hasPermission(
+                  [
+                    Permission.AUTO_APPROVE_4K,
+                    Permission.AUTO_APPROVE_4K_MOVIE,
+                  ],
+                  { type: 'or' }
+                )
+              ) ||
+              (mediaItem.type === 'show' &&
+                user.hasPermission(
+                  [
+                    Permission.REQUEST_4K,
+                    Permission.REQUEST_4K_TV,
+                  ],
+                  { type: 'or' }
+                ) &&
+                user.hasPermission(
+                  [
+                    Permission.AUTO_APPROVE_4K,
+                    Permission.AUTO_APPROVE_4K_TV,
+                  ],
+                  { type: 'or' }
+                )
+              ),
           },
           user,
           { isAutoRequest: true }


### PR DESCRIPTION
modified the auto request logic to allow users with auto_request, request_4k and auto_approve_4k permissions to request content with 4k profile

#### Description
I wanted the users to be able to auto request content with the existing plex watchlist sync feature with the 4k profile. I was actually going to add extra settings to user permissions but then it made more sense to auto request in 4k if the user already had auto_request, request_4k and auto_approve_4k permissions. If a user can auto request, request in 4k and auto approve in 4k, I don't see why we would need any extra settings or permissions and why the users couldn't auto request in 4k. If they can already do this by logging into overseer and request and auto approve in 4k, I think we should also request their plex watchlist in 4k.
#### Screenshot (if UI-related)

#### To-Dos

- [+] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #3849
