### PR TITLE
fix: center count badge on sidebar and mobile menu

### DIFF
--- a/src/components/Layout/MobileMenu/index.tsx
+++ b/src/components/Layout/MobileMenu/index.tsx
@@ -191,7 +191,7 @@ const MobileMenu = ({
                 {link.href === '/requests' &&
                   pendingRequestsCount > 0 &&
                   hasPermission(Permission.MANAGE_REQUESTS) && (
-                    <div className="ml-auto">
+                    <div className="ml-auto flex">
                       <Badge className="rounded-md border-indigo-500 bg-gradient-to-br from-indigo-600 to-purple-600">
                         {pendingRequestsCount}
                       </Badge>
@@ -200,7 +200,7 @@ const MobileMenu = ({
                 {link.href === '/issues' &&
                   openIssuesCount > 0 &&
                   hasPermission(Permission.MANAGE_ISSUES) && (
-                    <div className="ml-auto">
+                    <div className="ml-auto flex">
                       <Badge className="rounded-md border-indigo-500 bg-gradient-to-br from-indigo-600 to-purple-600">
                         {openIssuesCount}
                       </Badge>

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -284,7 +284,7 @@ const Sidebar = ({
                         {sidebarLink.messagesKey === 'requests' &&
                           pendingRequestsCount > 0 &&
                           hasPermission(Permission.MANAGE_REQUESTS) && (
-                            <div className="ml-auto">
+                            <div className="ml-auto flex">
                               <Badge
                                 className={`rounded-md bg-gradient-to-br ${
                                   router.pathname.match(
@@ -301,7 +301,7 @@ const Sidebar = ({
                         {sidebarLink.messagesKey === 'issues' &&
                           openIssuesCount > 0 &&
                           hasPermission(Permission.MANAGE_ISSUES) && (
-                            <div className="ml-auto">
+                            <div className="ml-auto flex">
                               <Badge
                                 className={`rounded-md bg-gradient-to-br ${
                                   router.pathname.match(


### PR DESCRIPTION
#### Description

Minor change that centers the count badge on the sidebar and on the mobile menu when expanded.

#### Screenshot (if UI-related)

<img width="583" alt="Screenshot 2025-02-25 at 8 28 27 PM" src="https://github.com/user-attachments/assets/464715bb-d5ba-4436-808d-3ceb364a6865" />


#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

