### PR TITLE
fix: improve count badge styling

### DIFF
--- a/src/components/Layout/MobileMenu/index.tsx
+++ b/src/components/Layout/MobileMenu/index.tsx
@@ -240,7 +240,9 @@ const MobileMenu = ({
                               router.pathname.match(link.activeRegExp)
                                 ? 'border-indigo-600 from-indigo-700 to-purple-700'
                                 : 'border-indigo-500 from-indigo-600 to-purple-600'
-                            } flex h-4 w-4 items-center justify-center !px-[9px] !py-[9px] text-[9px]`}
+                            } flex ${
+                              pendingRequestsCount > 99 ? 'w-6' : 'w-4'
+                            } h-4  items-center justify-center !px-[5px] !py-[7px] text-[8px]`}
                           >
                             {pendingRequestsCount > 99
                               ? '99+'


### PR DESCRIPTION
#### Description

Improved styling of the request count badge that is appended to the request icon button on the mobile menu. Width and height will remain static unless requests are greater than 99.

#### Screenshot (if UI-related)

<img width="365" alt="Screenshot 2025-02-26 at 10 35 42 AM" src="https://github.com/user-attachments/assets/4f003398-2d75-482c-a93f-d1e7324eb144" />

#### To-Dos

- [x] Successful build `yarn build`
