### PR TITLE
fix: display request button if show is available and has specials

### DIFF
--- a/src/components/RequestButton/index.tsx
+++ b/src/components/RequestButton/index.tsx
@@ -294,7 +294,6 @@ const RequestButton = ({
       type: 'or',
     }) &&
     media &&
-    media.status !== MediaStatus.AVAILABLE &&
     !isShowComplete
   ) {
     buttons.push({
@@ -339,7 +338,6 @@ const RequestButton = ({
       type: 'or',
     }) &&
     media &&
-    media.status4k !== MediaStatus.AVAILABLE &&
     !is4kShowComplete &&
     settings.currentSettings.series4kEnabled
   ) {


### PR DESCRIPTION
#### Description

This PR makes sure the request button appears even if a show is available but specials have not yet been requested. The show’s status won’t change based on specials, but if there are specials to request, the button will still be visible.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #4080 
