### PR TITLE
fix: correct specials affecting availability status

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -326,17 +326,22 @@ class BaseScanner<T> {
 
       const isAllStandardSeasons =
         seasons.length &&
-        seasons.every(
-          (season) =>
-            season.episodes === season.totalEpisodes && season.episodes > 0
-        );
+        seasons
+          .filter((season) => season.seasonNumber !== 0)
+          .every(
+            (season) =>
+              season.episodes === season.totalEpisodes && season.episodes > 0
+          );
 
       const isAll4kSeasons =
         seasons.length &&
-        seasons.every(
-          (season) =>
-            season.episodes4k === season.totalEpisodes && season.episodes4k > 0
-        );
+        seasons
+          .filter((season) => season.seasonNumber !== 0)
+          .every(
+            (season) =>
+              season.episodes4k === season.totalEpisodes &&
+              season.episodes4k > 0
+          );
 
       if (media) {
         media.seasons = [...media.seasons, ...newSeasons];
@@ -401,12 +406,17 @@ class BaseScanner<T> {
         // the status
         const shouldStayAvailable =
           media.status === MediaStatus.AVAILABLE &&
-          newSeasons.filter((season) => season.status !== MediaStatus.UNKNOWN)
-            .length === 0;
+          newSeasons.filter(
+            (season) =>
+              season.status !== MediaStatus.UNKNOWN && season.seasonNumber !== 0
+          ).length === 0;
         const shouldStayAvailable4k =
           media.status4k === MediaStatus.AVAILABLE &&
-          newSeasons.filter((season) => season.status4k !== MediaStatus.UNKNOWN)
-            .length === 0;
+          newSeasons.filter(
+            (season) =>
+              season.status4k !== MediaStatus.UNKNOWN &&
+              season.seasonNumber !== 0
+          ).length === 0;
 
         media.status =
           isAllStandardSeasons || shouldStayAvailable

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -324,6 +324,7 @@ class BaseScanner<T> {
         }
       }
 
+      // We want to skip specials when checking if a show is available
       const isAllStandardSeasons =
         seasons.length &&
         seasons
@@ -403,7 +404,7 @@ class BaseScanner<T> {
         }
 
         // If the show is already available, and there are no new seasons, dont adjust
-        // the status
+        // the status. Skip specials when performing availability check
         const shouldStayAvailable =
           media.status === MediaStatus.AVAILABLE &&
           newSeasons.filter(


### PR DESCRIPTION
#### Description

Updated the availability logic to exclude specials from affecting a show's status. If all regular seasons are available, the show will be marked as fully available, regardless of specials availability. The same goes for the shouldStayAvailable variables, as we want to keep the show available even if a competing scanner says otherwise.

Note: Specials will still affect partial availability.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #XXXX
