### PR TITLE
fix: show username for token that failed

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -365,7 +365,7 @@ class PlexTvAPI extends ExternalAPI {
     }
   }
 
-  public async pingToken() {
+  public async pingToken(displayName: string) {
     try {
       const response = await this.axios.get('/api/v2/ping', {
         headers: {
@@ -376,7 +376,7 @@ class PlexTvAPI extends ExternalAPI {
         throw new Error('No pong response');
       }
     } catch (e) {
-      logger.error('Failed to ping token', {
+      logger.error(`Failed to ping token for ${displayName}`, {
         label: 'Plex Refresh Token',
         errorMessage: e.message,
       });

--- a/server/lib/refreshToken.ts
+++ b/server/lib/refreshToken.ts
@@ -28,7 +28,7 @@ class RefreshToken {
     }
 
     const plexTvApi = new PlexTvAPI(user.plexToken);
-    plexTvApi.pingToken();
+    plexTvApi.pingToken(user.displayName);
   }
 }
 


### PR DESCRIPTION
#### Description

Small change that will show which user the plex refresh token API failed for. Will make debugging easier.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #XXXX
