### PR TITLE
fix: prevent request badge showing when no related media

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -197,7 +197,7 @@ requestRoutes.get('/count', async (_req, res, next) => {
   try {
     const query = requestRepository
       .createQueryBuilder('request')
-      .leftJoinAndSelect('request.media', 'media');
+      .innerJoinAndSelect('request.media', 'media');
 
     const totalCount = await query.getCount();
 


### PR DESCRIPTION
#### Description

There is an underlying issue where some requests can lose their associated media relation. When this happens, the request would no longer appear in the requests list, but the badge count would still reflect it—leading to a mismatch between the count and the requests list.

This PR updates the logic so that only requests with a valid media relation (i.e., those that would actually appear in the requests list) are included in the badge count.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
