### PR TITLE
fix: filter specials from modal all seasons and watchlist

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -247,7 +247,9 @@ export class MediaRequest {
       >;
       const requestedSeasons =
         requestBody.seasons === 'all'
-          ? tmdbMediaShow.seasons.map((season) => season.season_number)
+          ? tmdbMediaShow.seasons
+              .filter((season) => season.season_number !== 0)
+              .map((season) => season.season_number)
           : (requestBody.seasons as number[]);
       let existingSeasons: number[] = [];
 

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -69,11 +69,7 @@ export class MediaRequestSubscriber
       availableSeasons.length > 0 &&
       availableSeasons.length === requestedSeasons.length;
 
-    if (
-      entity.media[entity.is4k ? 'status4k' : 'status'] ===
-        MediaStatus.AVAILABLE ||
-      isMediaAvailable
-    ) {
+    if (isMediaAvailable) {
       const tmdb = new TheMovieDb();
 
       try {

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -96,7 +96,9 @@ const ManageSlideOver = ({
     if (data.mediaInfo) {
       await axios.post(`/api/v1/media/${data.mediaInfo?.id}/available`, {
         is4k,
-        ...(mediaType === 'tv' && { seasons: data.seasons }),
+        ...(mediaType === 'tv' && {
+          seasons: data.seasons.filter((season) => season.seasonNumber !== 0),
+        }),
       });
       revalidate();
     }

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -309,12 +309,16 @@ const TvRequestModal = ({
       return;
     }
 
+    const standardUnrequestedSeasons = unrequestedSeasons.filter(
+      (seasonNumber) => seasonNumber !== 0
+    );
+
     if (
       data &&
       selectedSeasons.length >= 0 &&
-      selectedSeasons.length < unrequestedSeasons.length
+      selectedSeasons.length < standardUnrequestedSeasons.length
     ) {
-      setSelectedSeasons(unrequestedSeasons);
+      setSelectedSeasons(standardUnrequestedSeasons);
     } else {
       setSelectedSeasons([]);
     }
@@ -325,9 +329,9 @@ const TvRequestModal = ({
       return false;
     }
     return (
-      selectedSeasons.length ===
+      selectedSeasons.filter((season) => season !== 0).length ===
       getAllSeasons().filter(
-        (season) => !getAllRequestedSeasons().includes(season)
+        (season) => !getAllRequestedSeasons().includes(season) && season !== 0
       ).length
     );
   };


### PR DESCRIPTION
#### Description

This PR addresses a few things related to handling specials:

TV Request Modal – When using the “Select All Seasons” toggle, specials will now be excluded.

Plex Watchlist Sync – When a show is added to a Plex watchlist, specials will no longer be included when syncing with Overseerr.

Mark Seasons as Available - Specials will be skipped when clicking this button.

#### Screenshot (if UI-related)

<img width="751" alt="Screenshot 2025-04-14 at 10 15 04 PM" src="https://github.com/user-attachments/assets/29720079-f532-4a0a-942b-2bf45506ee9b" />


#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #4101 
