### PR TITLE
fix: correct edge case with deletion not updating requests

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -301,7 +301,7 @@ class AvailabilitySync {
         { label: 'Availability Sync' }
       );
 
-      await mediaRepository.save({ media, ...media });
+      await mediaRepository.save(media);
     } catch (ex) {
       logger.debug(
         `Failure updating the ${is4k ? '4K' : 'non-4K'} ${
@@ -355,7 +355,7 @@ class AvailabilitySync {
         );
       }
 
-      await mediaRepository.save({ media, ...media });
+      await mediaRepository.save(media);
 
       logger.info(
         `The ${is4k ? '4K' : 'non-4K'} season(s) [${seasonKeys}] [TMDB ID ${


### PR DESCRIPTION
#### Description

Fix an edge case where a media request was not marked as complete when the associated media was marked as deleted.

This resolves a rare issue where the media becomes available before the request is fully processed. In these cases, the request was not being set to complete when the media status is set to deleted from the availability sync, leaving the request in an incorrect state.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
