### PR TITLE
fix(notifications): sending test-notifications for email now respects…

### DIFF
--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -204,6 +204,7 @@ const NotificationsEmail = () => {
                 requireTls: values.encryption === 'opportunistic',
                 authUser: values.authUser,
                 authPass: values.authPass,
+                allowSelfSigned: values.allowSelfSigned,
                 senderName: values.senderName,
                 pgpPrivateKey: values.pgpPrivateKey,
                 pgpPassword: values.pgpPassword,


### PR DESCRIPTION
#### Description

Sending a test-notification from the email-notification now respects the optional allowSelfSigned value.

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #4102
