### PR TITLE
fix: correct notification sending for wrong status

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -58,14 +58,17 @@ export class MediaRequestSubscriber
     // Find all seasons in the related media entity
     // and see if they are available, then we can check
     // if the request contains the same seasons
-    const isMediaAvailable = entity.media.seasons
-      .filter(
-        (season) =>
-          season[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-      )
-      .every((seasonRequest) =>
-        entity.seasons.find(
-          (season) => season.seasonNumber === seasonRequest.seasonNumber
+    const availableSeasons = entity.media.seasons.filter(
+      (season) =>
+        season[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+    );
+
+    const isMediaAvailable =
+      availableSeasons.length > 0 &&
+      availableSeasons.every((availableSeason) =>
+        entity.seasons?.some(
+          (entitySeason) =>
+            entitySeason.seasonNumber === availableSeason.seasonNumber
         )
       );
 


### PR DESCRIPTION
#### Description

Previously, shows that were completely deleted could still send available notifications due to how we checked each season for availability. We've updated the logic to ensure a show can only send a notification if it has at least one available season.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
