### PR TITLE
fix: handle partial seasons more reliably

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -355,6 +355,7 @@ class AvailabilitySync {
         );
       }
 
+      media.lastSeasonChange = new Date();
       await mediaRepository.save(media);
 
       logger.info(

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -58,19 +58,16 @@ export class MediaRequestSubscriber
     // Find all seasons in the related media entity
     // and see if they are available, then we can check
     // if the request contains the same seasons
+    const requestedSeasons =
+      entity.seasons?.map((entitySeason) => entitySeason.seasonNumber) ?? [];
     const availableSeasons = entity.media.seasons.filter(
       (season) =>
-        season[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+        season[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE &&
+        requestedSeasons.includes(season.seasonNumber)
     );
-
     const isMediaAvailable =
       availableSeasons.length > 0 &&
-      availableSeasons.every((availableSeason) =>
-        entity.seasons?.some(
-          (entitySeason) =>
-            entitySeason.seasonNumber === availableSeason.seasonNumber
-        )
-      );
+      availableSeasons.length === requestedSeasons.length;
 
     if (
       entity.media[entity.is4k ? 'status4k' : 'status'] ===


### PR DESCRIPTION
#### Description

Further work needed to be done to prevent older dbs with partial season requests setting to completed. It's possible to have a partially available show and an old + new request.

- Added a check for specific seasons and refactored the mediaSubscriber.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
