### PR TITLE
fix: pwa app badge

### DIFF
--- a/server/lib/notifications/agents/webpush.ts
+++ b/server/lib/notifications/agents/webpush.ts
@@ -241,7 +241,7 @@ class WebPushAgent
       const allSubs = await userPushSubRepository
         .createQueryBuilder('pushSub')
         .leftJoinAndSelect('pushSub.user', 'user')
-        .where('pushSub.userId IN (:users)', {
+        .where('pushSub.userId IN (:...users)', {
           users: manageUsers.map((user) => user.id),
         })
         .getMany();


### PR DESCRIPTION
#### Description

Fixes some weird scenarios where you may not have received a notification and the PWA badge didn't clear or update. The main issue was the coercion on the users array when sending a web push.

- Added an event listener to check badge count on focus.
- Add spread to user push subs check. This could sometimes fail (usually if more than one admin).

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
