### PR TITLE
docs: add API doc about the permissions mask bits

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4030,7 +4030,39 @@ paths:
   /user/{userId}/settings/permissions:
     get:
       summary: Get permission settings for a user
-      description: Returns permission settings for a specific user. Requires `MANAGE_USERS` permission if viewing other users.
+      description: |
+        Returns permission settings for a specific user. Requires `MANAGE_USERS` permission if viewing other users.
+        
+        Permissions in Overseerr use a bit mask system, where each permission is represented by a power of 2.
+        
+        Available permissions:
+        - NONE = 0
+        - ADMIN = 2
+        - MANAGE_USERS = 8
+        - MANAGE_REQUESTS = 16
+        - REQUEST = 32
+        - VOTE = 64
+        - AUTO_APPROVE = 128
+        - AUTO_APPROVE_MOVIE = 256
+        - AUTO_APPROVE_TV = 512
+        - REQUEST_4K = 1024
+        - REQUEST_4K_MOVIE = 2048
+        - REQUEST_4K_TV = 4096
+        - REQUEST_ADVANCED = 8192
+        - REQUEST_VIEW = 16384
+        - AUTO_APPROVE_4K = 32768
+        - AUTO_APPROVE_4K_MOVIE = 65536
+        - AUTO_APPROVE_4K_TV = 131072
+        - REQUEST_MOVIE = 262144
+        - REQUEST_TV = 524288
+        - MANAGE_ISSUES = 1048576
+        - VIEW_ISSUES = 2097152
+        - CREATE_ISSUES = 4194304
+        - AUTO_REQUEST = 8388608
+        - AUTO_REQUEST_MOVIE = 16777216
+        - AUTO_REQUEST_TV = 33554432
+        - RECENT_VIEW = 67108864
+        - WATCHLIST_VIEW = 134217728
       tags:
         - users
       parameters:
@@ -4050,6 +4082,7 @@ paths:
                   permissions:
                     type: number
                     example: 2
+                    description: Numeric value representing the sum of all granted permission bit values.
     post:
       summary: Update permission settings for a user
       description: Updates and returns permission settings for a specific user. Requires `MANAGE_USERS` permission if editing other users.
@@ -4070,6 +4103,7 @@ paths:
               properties:
                 permissions:
                   type: number
+                  description: Numeric value representing the sum of all granted permission bit values.
               required:
                 - permissions
       responses:
@@ -4083,6 +4117,7 @@ paths:
                   permissions:
                     type: number
                     example: 2
+                    description: Numeric value representing the sum of all granted permission bit values.
   /user/{userId}/watch_data:
     get:
       summary: Get watch data


### PR DESCRIPTION
#### Description
No docs exist yet on how the permissions at the following API endpoint works : `/user/{userId}/settings/permissions`.  
This PR add the bits mask of each permission to the API doc. 

#### Issues Fixed or Closed

- Fixes https://github.com/sct/overseerr/issues/4119
