### PR TITLE
fix: bypass specials when partial requests is disabled

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -200,7 +200,8 @@ const TvRequestModal = ({
         seasons: settings.currentSettings.partialRequestsEnabled
           ? selectedSeasons
           : getAllSeasons().filter(
-              (season) => !getAllRequestedSeasons().includes(season)
+              (season) =>
+                !getAllRequestedSeasons().includes(season) && season !== 0
             ),
         ...overrideParams,
       });
@@ -296,8 +297,10 @@ const TvRequestModal = ({
     }
   };
 
-  const unrequestedSeasons = getAllSeasons().filter(
-    (season) => !getAllRequestedSeasons().includes(season)
+  const unrequestedSeasons = getAllSeasons().filter((season) =>
+    !settings.currentSettings.partialRequestsEnabled
+      ? !getAllRequestedSeasons().includes(season) && season !== 0
+      : !getAllRequestedSeasons().includes(season)
   );
 
   const toggleAllSeasons = (): void => {
@@ -565,7 +568,11 @@ const TvRequestModal = ({
                 </thead>
                 <tbody className="divide-y divide-gray-700">
                   {data?.seasons
-                    .filter((season) => season.episodeCount !== 0)
+                    .filter((season) =>
+                      !settings.currentSettings.partialRequestsEnabled
+                        ? season.episodeCount !== 0 && season.seasonNumber !== 0
+                        : season.episodeCount !== 0
+                    )
                     .map((season) => {
                       const seasonRequest = getSeasonRequest(
                         season.seasonNumber


### PR DESCRIPTION
#### Description

Simple fix that will bypass specials when partial requests is disabled.

#### Screenshot (if UI-related)
<img width="756" alt="Screenshot 2025-05-02 at 12 32 16 PM" src="https://github.com/user-attachments/assets/e61cdd61-3815-4600-bc2b-cb98137ae893" />

#### To-Dos

- [x] Successful build `yarn build`
