### PR TITLE
fix(mediaentity): change cascade from `update` to `remove`

### DIFF
--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -91,7 +91,7 @@ class Media {
   public status4k: MediaStatus;
 
   @OneToMany(() => MediaRequest, (request) => request.media, {
-    cascade: ['insert', 'update'],
+    cascade: ['insert', 'remove'],
   })
   public requests: MediaRequest[];
 


### PR DESCRIPTION
#### Description
I mistyped the cascade on condition in #4124. It should not be `update`. That is the whole thing we are trying to avoid to prevent the lifecycle hook triggers.

How it should have been (ref: [original pr in jellyseerr](https://github.com/fallenbagel/jellyseerr/pull/1619/)): 
https://github.com/fallenbagel/jellyseerr/blob/cd8d5744ef1f739697bee06171ec527b9c8cb3ab/server/entity/Media.ts#L112

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
