### PR TITLE
fix(mediasubscriber): remove async from afterInsert and afterUpdate

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -753,35 +753,35 @@ export class MediaRequestSubscriber
     await manager.save(fullMedia);
   }
 
-  public async afterUpdate(event: UpdateEvent<MediaRequest>): Promise<void> {
+  public afterUpdate(event: UpdateEvent<MediaRequest>): void {
     if (!event.entity) {
       return;
     }
 
-    await this.sendToRadarr(event.entity as MediaRequest);
-    await this.sendToSonarr(event.entity as MediaRequest);
+    this.sendToRadarr(event.entity as MediaRequest);
+    this.sendToSonarr(event.entity as MediaRequest);
 
-    await this.updateParentStatus(event.entity as MediaRequest);
+    this.updateParentStatus(event.entity as MediaRequest);
 
     if (event.entity.status === MediaRequestStatus.COMPLETED) {
       if (event.entity.media.mediaType === MediaType.MOVIE) {
-        await this.notifyAvailableMovie(event.entity as MediaRequest);
+        this.notifyAvailableMovie(event.entity as MediaRequest);
       }
       if (event.entity.media.mediaType === MediaType.TV) {
-        await this.notifyAvailableSeries(event.entity as MediaRequest);
+        this.notifyAvailableSeries(event.entity as MediaRequest);
       }
     }
   }
 
-  public async afterInsert(event: InsertEvent<MediaRequest>): Promise<void> {
+  public afterInsert(event: InsertEvent<MediaRequest>): void {
     if (!event.entity) {
       return;
     }
 
-    await this.sendToRadarr(event.entity as MediaRequest);
-    await this.sendToSonarr(event.entity as MediaRequest);
+    this.sendToRadarr(event.entity as MediaRequest);
+    this.sendToSonarr(event.entity as MediaRequest);
 
-    await this.updateParentStatus(event.entity as MediaRequest);
+    this.updateParentStatus(event.entity as MediaRequest);
   }
 
   public async afterRemove(event: RemoveEvent<MediaRequest>): Promise<void> {


### PR DESCRIPTION
#### Description

Asynchronous operations introduced in commit 3b9e195496c3db1f794549786b123a3ff55b08a0 caused issues during media requests: the mediaId was not properly assigned and remained null.

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Related to #4124
