### PR TITLE
feat: filter out genres in discovery, default user settings

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4264,6 +4264,11 @@ paths:
             type: string
             example: 18
         - in: query
+          name: withoutGenre
+          schema:
+            type: string
+            example: 28
+        - in: query
           name: studio
           schema:
             type: number
@@ -4552,6 +4557,11 @@ paths:
           schema:
             type: string
             example: 18
+        - in: query
+          name: withoutGenre
+          schema:
+            type: string
+            example: 28
         - in: query
           name: network
           schema:

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4264,7 +4264,7 @@ paths:
             type: string
             example: 18
         - in: query
-          name: withoutGenre
+          name: filterGenre
           schema:
             type: string
             example: 28
@@ -4558,7 +4558,7 @@ paths:
             type: string
             example: 18
         - in: query
-          name: withoutGenre
+          name: filterGenre
           schema:
             type: string
             example: 28

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -69,6 +69,7 @@ interface DiscoverMovieOptions {
   voteCountLte?: string;
   originalLanguage?: string;
   genre?: string;
+  withoutGenre?: string;
   studio?: string;
   keywords?: string;
   sortBy?: SortOptions;
@@ -90,6 +91,7 @@ interface DiscoverTvOptions {
   includeEmptyReleaseDate?: boolean;
   originalLanguage?: string;
   genre?: string;
+  withoutGenre?: string;
   network?: number;
   keywords?: string;
   sortBy?: SortOptions;
@@ -460,6 +462,7 @@ class TheMovieDb extends ExternalAPI {
     primaryReleaseDateLte,
     originalLanguage,
     genre,
+    withoutGenre,
     studio,
     keywords,
     withRuntimeGte,
@@ -506,6 +509,7 @@ class TheMovieDb extends ExternalAPI {
               ? defaultFutureDate
               : primaryReleaseDateLte,
           with_genres: genre,
+          without_genres: withoutGenre,
           with_companies: studio,
           with_keywords: keywords,
           'with_runtime.gte': withRuntimeGte,
@@ -534,6 +538,7 @@ class TheMovieDb extends ExternalAPI {
     includeEmptyReleaseDate = false,
     originalLanguage,
     genre,
+    withoutGenre,
     network,
     keywords,
     withRuntimeGte,
@@ -580,6 +585,7 @@ class TheMovieDb extends ExternalAPI {
               : this.originalLanguage,
           include_null_first_air_dates: includeEmptyReleaseDate,
           with_genres: genre,
+          without_genres: withoutGenre,
           with_networks: network,
           with_keywords: keywords,
           'with_runtime.gte': withRuntimeGte,

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -69,7 +69,7 @@ interface DiscoverMovieOptions {
   voteCountLte?: string;
   originalLanguage?: string;
   genre?: string;
-  withoutGenre?: string;
+  filterGenre?: string;
   studio?: string;
   keywords?: string;
   sortBy?: SortOptions;
@@ -91,7 +91,7 @@ interface DiscoverTvOptions {
   includeEmptyReleaseDate?: boolean;
   originalLanguage?: string;
   genre?: string;
-  withoutGenre?: string;
+  filterGenre?: string;
   network?: number;
   keywords?: string;
   sortBy?: SortOptions;
@@ -462,7 +462,7 @@ class TheMovieDb extends ExternalAPI {
     primaryReleaseDateLte,
     originalLanguage,
     genre,
-    withoutGenre,
+    filterGenre,
     studio,
     keywords,
     withRuntimeGte,
@@ -509,7 +509,7 @@ class TheMovieDb extends ExternalAPI {
               ? defaultFutureDate
               : primaryReleaseDateLte,
           with_genres: genre,
-          without_genres: withoutGenre,
+          without_genres: filterGenre,
           with_companies: studio,
           with_keywords: keywords,
           'with_runtime.gte': withRuntimeGte,
@@ -538,7 +538,7 @@ class TheMovieDb extends ExternalAPI {
     includeEmptyReleaseDate = false,
     originalLanguage,
     genre,
-    withoutGenre,
+    filterGenre,
     network,
     keywords,
     withRuntimeGte,
@@ -585,7 +585,7 @@ class TheMovieDb extends ExternalAPI {
               : this.originalLanguage,
           include_null_first_air_dates: includeEmptyReleaseDate,
           with_genres: genre,
-          without_genres: withoutGenre,
+          without_genres: filterGenre,
           with_networks: network,
           with_keywords: keywords,
           'with_runtime.gte': withRuntimeGte,

--- a/server/entity/UserSettings.ts
+++ b/server/entity/UserSettings.ts
@@ -37,6 +37,12 @@ export class UserSettings {
   public originalLanguage?: string;
 
   @Column({ nullable: true })
+  public filterTvGenresDefault?: string;
+
+  @Column({ nullable: true })
+  public filterMovieGenresDefault?: string;
+
+  @Column({ nullable: true })
   public pgpKey?: string;
 
   @Column({ nullable: true })

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -30,6 +30,8 @@ export interface PublicSettingsResponse {
   series4kEnabled: boolean;
   region: string;
   originalLanguage: string;
+  filterMovieGenresDefault: string;
+  filterTvGenresDefault: string;
   partialRequestsEnabled: boolean;
   cacheImages: boolean;
   vapidPublic: string;

--- a/server/interfaces/api/userSettingsInterfaces.ts
+++ b/server/interfaces/api/userSettingsInterfaces.ts
@@ -6,6 +6,8 @@ export interface UserSettingsGeneralResponse {
   locale?: string;
   region?: string;
   originalLanguage?: string;
+  filterMovieGenresDefault?: string;
+  filterTvGenresDefault?: string;
   movieQuotaLimit?: number;
   movieQuotaDays?: number;
   tvQuotaLimit?: number;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -101,6 +101,8 @@ export interface MainSettings {
   newPlexLogin: boolean;
   region: string;
   originalLanguage: string;
+  filterTvGenresDefault: string;
+  filterMovieGenresDefault: string;
   trustProxy: boolean;
   partialRequestsEnabled: boolean;
   locale: string;
@@ -298,6 +300,8 @@ class Settings {
         newPlexLogin: true,
         region: '',
         originalLanguage: '',
+        filterTvGenresDefault: '',
+        filterMovieGenresDefault: '',
         trustProxy: false,
         partialRequestsEnabled: true,
         locale: 'en',

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -59,6 +59,7 @@ const QueryFilterOptions = z.object({
   firstAirDateLte: z.coerce.string().optional(),
   studio: z.coerce.string().optional(),
   genre: z.coerce.string().optional(),
+  withoutGenre: z.coerce.string().optional(),
   keywords: z.coerce.string().optional(),
   language: z.coerce.string().optional(),
   withRuntimeGte: z.coerce.string().optional(),
@@ -86,6 +87,7 @@ discoverRoutes.get('/movies', async (req, res, next) => {
       language: req.locale ?? query.language,
       originalLanguage: query.language,
       genre: query.genre,
+      withoutGenre: query.withoutGenre,
       studio: query.studio,
       primaryReleaseDateLte: query.primaryReleaseDateLte
         ? new Date(query.primaryReleaseDateLte).toISOString().split('T')[0]
@@ -362,6 +364,7 @@ discoverRoutes.get('/tv', async (req, res, next) => {
       sortBy: query.sortBy as SortOptions,
       language: req.locale ?? query.language,
       genre: query.genre,
+      withoutGenre: query.withoutGenre,
       network: query.network ? Number(query.network) : undefined,
       firstAirDateLte: query.firstAirDateLte
         ? new Date(query.firstAirDateLte).toISOString().split('T')[0]

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -59,7 +59,7 @@ const QueryFilterOptions = z.object({
   firstAirDateLte: z.coerce.string().optional(),
   studio: z.coerce.string().optional(),
   genre: z.coerce.string().optional(),
-  withoutGenre: z.coerce.string().optional(),
+  filterGenre: z.coerce.string().optional(),
   keywords: z.coerce.string().optional(),
   language: z.coerce.string().optional(),
   withRuntimeGte: z.coerce.string().optional(),
@@ -81,13 +81,38 @@ discoverRoutes.get('/movies', async (req, res, next) => {
   try {
     const query = QueryFilterOptions.parse(req.query);
     const keywords = query.keywords;
+
+    // Handle user default excluded genres
+    let filterGenre = query.filterGenre;
+    if (filterGenre === 'none') {
+      filterGenre = undefined;
+    } else if (
+      filterGenre === undefined &&
+      req.user?.settings?.filterMovieGenresDefault
+    ) {
+      filterGenre = req.user.settings.filterMovieGenresDefault;
+    }
+
+    // Resolve conflicts: when explicit genres are present, remove them from exclusions
+    if (query.genre && filterGenre) {
+      const explicitGenres = query.genre.split(',');
+      const excludedGenres = filterGenre.split(',');
+      const resolvedExclusions = excludedGenres.filter(
+        (id) => !explicitGenres.includes(id)
+      );
+      filterGenre =
+        resolvedExclusions.length > 0
+          ? resolvedExclusions.join(',')
+          : undefined;
+    }
+
     const data = await tmdb.getDiscoverMovies({
       page: Number(query.page),
       sortBy: query.sortBy as SortOptions,
       language: req.locale ?? query.language,
       originalLanguage: query.language,
       genre: query.genre,
-      withoutGenre: query.withoutGenre,
+      filterGenre,
       studio: query.studio,
       primaryReleaseDateLte: query.primaryReleaseDateLte
         ? new Date(query.primaryReleaseDateLte).toISOString().split('T')[0]
@@ -359,12 +384,38 @@ discoverRoutes.get('/tv', async (req, res, next) => {
   try {
     const query = QueryFilterOptions.parse(req.query);
     const keywords = query.keywords;
+
+    // Handle user default excluded genres
+    let filterGenre = query.filterGenre;
+    if (filterGenre === 'none') {
+      filterGenre = undefined;
+    } else if (
+      filterGenre === undefined &&
+      req.user?.settings?.filterTvGenresDefault
+    ) {
+      filterGenre = req.user.settings.filterTvGenresDefault;
+    }
+
+    // Always resolve conflicts between explicit genres and exclusions
+    if (query.genre && filterGenre) {
+      const explicitGenres = query.genre.split(',');
+      const excludedGenres = filterGenre.split(',');
+      const resolvedExclusions = excludedGenres.filter(
+        (id) => !explicitGenres.includes(id)
+      );
+
+      filterGenre =
+        resolvedExclusions.length > 0
+          ? resolvedExclusions.join(',')
+          : undefined;
+    }
+
     const data = await tmdb.getDiscoverTv({
       page: Number(query.page),
       sortBy: query.sortBy as SortOptions,
       language: req.locale ?? query.language,
       genre: query.genre,
-      withoutGenre: query.withoutGenre,
+      filterGenre,
       network: query.network ? Number(query.network) : undefined,
       firstAirDateLte: query.firstAirDateLte
         ? new Date(query.firstAirDateLte).toISOString().split('T')[0]

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -55,6 +55,8 @@ userSettingsRoutes.get<{ id: string }, UserSettingsGeneralResponse>(
         locale: user.settings?.locale,
         region: user.settings?.region,
         originalLanguage: user.settings?.originalLanguage,
+        filterTvGenresDefault: user.settings?.filterTvGenresDefault,
+        filterMovieGenresDefault: user.settings?.filterMovieGenresDefault,
         movieQuotaLimit: user.movieQuotaLimit,
         movieQuotaDays: user.movieQuotaDays,
         tvQuotaLimit: user.tvQuotaLimit,
@@ -116,6 +118,8 @@ userSettingsRoutes.post<
         locale: req.body.locale,
         region: req.body.region,
         originalLanguage: req.body.originalLanguage,
+        filterMovieGenresDefault: req.body.filterMovieGenresDefault,
+        filterTvGenresDefault: req.body.filterTvGenresDefault,
         watchlistSyncMovies: req.body.watchlistSyncMovies,
         watchlistSyncTv: req.body.watchlistSyncTv,
       });
@@ -124,6 +128,9 @@ userSettingsRoutes.post<
       user.settings.locale = req.body.locale;
       user.settings.region = req.body.region;
       user.settings.originalLanguage = req.body.originalLanguage;
+      user.settings.filterMovieGenresDefault =
+        req.body.filterMovieGenresDefault;
+      user.settings.filterTvGenresDefault = req.body.filterTvGenresDefault;
       user.settings.watchlistSyncMovies = req.body.watchlistSyncMovies;
       user.settings.watchlistSyncTv = req.body.watchlistSyncTv;
     }
@@ -136,6 +143,8 @@ userSettingsRoutes.post<
       locale: user.settings.locale,
       region: user.settings.region,
       originalLanguage: user.settings.originalLanguage,
+      filterMovieGenresDefault: user.settings.filterMovieGenresDefault,
+      filterTvGenresDefault: user.settings.filterTvGenresDefault,
       watchlistSyncMovies: user.settings.watchlistSyncMovies,
       watchlistSyncTv: user.settings.watchlistSyncTv,
     });

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -10,6 +10,7 @@ import {
 import FilterSlideover from '@app/components/Discover/FilterSlideover';
 import useDiscover from '@app/hooks/useDiscover';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
+import { useUser } from '@app/hooks/useUser';
 import Error from '@app/pages/_error';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
@@ -47,9 +48,9 @@ const DiscoverMovies = () => {
   const intl = useIntl();
   const router = useRouter();
   const updateQueryParams = useUpdateQueryParams({});
+  const { user } = useUser();
 
   const preparedFilters = prepareFilterValues(router.query);
-
   const {
     isLoadingInitialData,
     isEmpty,
@@ -124,7 +125,10 @@ const DiscoverMovies = () => {
               <FunnelIcon />
               <span>
                 {intl.formatMessage(messages.activefilters, {
-                  count: countActiveFilters(preparedFilters),
+                  count: countActiveFilters(
+                    preparedFilters,
+                    !!user?.settings?.filterMovieGenresDefault
+                  ),
                 })}
               </span>
             </Button>

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -10,6 +10,7 @@ import {
 import FilterSlideover from '@app/components/Discover/FilterSlideover';
 import useDiscover from '@app/hooks/useDiscover';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
+import { useUser } from '@app/hooks/useUser';
 import Error from '@app/pages/_error';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
@@ -46,6 +47,7 @@ const SortOptions: Record<string, TMDBSortOptions> = {
 const DiscoverTv = () => {
   const intl = useIntl();
   const router = useRouter();
+  const { user } = useUser();
   const [showFilters, setShowFilters] = useState(false);
   const preparedFilters = prepareFilterValues(router.query);
   const updateQueryParams = useUpdateQueryParams({});
@@ -122,7 +124,10 @@ const DiscoverTv = () => {
               <FunnelIcon />
               <span>
                 {intl.formatMessage(messages.activefilters, {
-                  count: countActiveFilters(preparedFilters),
+                  count: countActiveFilters(
+                    preparedFilters,
+                    !!user?.settings?.filterTvGenresDefault
+                  ),
                 })}
               </span>
             </Button>

--- a/src/components/Discover/FilterSlideover/index.tsx
+++ b/src/components/Discover/FilterSlideover/index.tsx
@@ -15,6 +15,7 @@ import {
   useBatchUpdateQueryParams,
   useUpdateQueryParams,
 } from '@app/hooks/useUpdateQueryParams';
+import { useUser } from '@app/hooks/useUser';
 import { XCircleIcon } from '@heroicons/react/24/outline';
 import { defineMessages, useIntl } from 'react-intl';
 import Datepicker from 'react-tailwindcss-datepicker-sct';
@@ -29,7 +30,7 @@ const messages = defineMessages({
   to: 'To',
   studio: 'Studio',
   genres: 'Genres',
-  withoutGenres: 'Exclude genres',
+  filterGenres: 'Exclude genres',
   keywords: 'Keywords',
   originalLanguage: 'Original Language',
   runtimeText: '{minValue}-{maxValue} minute runtime',
@@ -57,6 +58,7 @@ const FilterSlideover = ({
 }: FilterSlideoverProps) => {
   const intl = useIntl();
   const { currentSettings } = useSettings();
+  const { user } = useUser();
   const updateQueryParams = useUpdateQueryParams({});
   const batchUpdateQueryParams = useBatchUpdateQueryParams({});
 
@@ -65,12 +67,24 @@ const FilterSlideover = ({
   const dateLte =
     type === 'movie' ? 'primaryReleaseDateLte' : 'firstAirDateLte';
 
+  const userDefaultfilterGenres =
+    type === 'movie'
+      ? user?.settings?.filterMovieGenresDefault
+      : user?.settings?.filterTvGenresDefault;
+
+  const filterGenresValue =
+    currentFilters.filterGenre !== undefined
+      ? currentFilters.filterGenre === 'none'
+        ? ''
+        : currentFilters.filterGenre
+      : userDefaultfilterGenres;
+
   return (
     <SlideOver
       show={show}
       title={intl.formatMessage(messages.filters)}
       subText={intl.formatMessage(messages.activefilters, {
-        count: countActiveFilters(currentFilters),
+        count: countActiveFilters(currentFilters, !!userDefaultfilterGenres),
       })}
       onClose={() => onClose()}
     >
@@ -147,21 +161,71 @@ const FilterSlideover = ({
           defaultValue={currentFilters.genre}
           isMulti
           onChange={(value) => {
-            updateQueryParams('genre', value?.map((v) => v.value).join(','));
+            const selectedGenres = value?.map((v) => v.value.toString()) || [];
+
+            // Remove conflicting genres from exclusions
+            if (selectedGenres.length > 0 && filterGenresValue) {
+              const hasConflicts = selectedGenres.some((genre) =>
+                filterGenresValue.includes(genre)
+              );
+              if (hasConflicts) {
+                const cleanedExclusions = filterGenresValue
+                  .split(',')
+                  .filter((id) => !selectedGenres.includes(id))
+                  .join(',');
+
+                batchUpdateQueryParams({
+                  genre: selectedGenres.join(',') || undefined,
+                  filterGenre: cleanedExclusions || 'none',
+                });
+              } else {
+                updateQueryParams(
+                  'genre',
+                  selectedGenres.join(',') || undefined
+                );
+              }
+            } else {
+              updateQueryParams('genre', selectedGenres.join(',') || undefined);
+            }
           }}
         />
         <span className="text-lg font-semibold">
-          {intl.formatMessage(messages.withoutGenres)}
+          {intl.formatMessage(messages.filterGenres)}
         </span>
         <GenreSelector
           type={type}
-          defaultValue={currentFilters.withoutGenre}
+          defaultValue={filterGenresValue}
           isMulti
           onChange={(value) => {
-            updateQueryParams(
-              'withoutGenre',
-              value?.map((v) => v.value).join(',')
-            );
+            const filterGenres = value?.map((v) => v.value.toString()) || [];
+
+            // Remove conflicting genres from inclusions
+            if (filterGenres.length > 0 && currentFilters.genre) {
+              const hasConflicts = filterGenres.some((genre) =>
+                currentFilters.genre!.includes(genre)
+              );
+              if (hasConflicts) {
+                const cleanedInclusions = currentFilters.genre
+                  .split(',')
+                  .filter((id) => !filterGenres.includes(id))
+                  .join(',');
+
+                batchUpdateQueryParams({
+                  filterGenre: filterGenres.join(',') || 'none',
+                  genre: cleanedInclusions || undefined,
+                });
+              } else {
+                updateQueryParams(
+                  'filterGenre',
+                  filterGenres.join(',') || 'none'
+                );
+              }
+            } else {
+              updateQueryParams(
+                'filterGenre',
+                filterGenres.join(',') || 'none'
+              );
+            }
           }}
         />
         <span className="text-lg font-semibold">
@@ -335,7 +399,7 @@ const FilterSlideover = ({
               (
                 Object.keys(copyCurrent) as (keyof typeof currentFilters)[]
               ).forEach((k) => {
-                copyCurrent[k] = undefined;
+                copyCurrent[k] = k === 'filterGenre' ? 'none' : undefined;
               });
               batchUpdateQueryParams(copyCurrent);
               onClose();

--- a/src/components/Discover/FilterSlideover/index.tsx
+++ b/src/components/Discover/FilterSlideover/index.tsx
@@ -29,6 +29,7 @@ const messages = defineMessages({
   to: 'To',
   studio: 'Studio',
   genres: 'Genres',
+  withoutGenres: 'Exclude genres',
   keywords: 'Keywords',
   originalLanguage: 'Original Language',
   runtimeText: '{minValue}-{maxValue} minute runtime',
@@ -147,6 +148,20 @@ const FilterSlideover = ({
           isMulti
           onChange={(value) => {
             updateQueryParams('genre', value?.map((v) => v.value).join(','));
+          }}
+        />
+        <span className="text-lg font-semibold">
+          {intl.formatMessage(messages.withoutGenres)}
+        </span>
+        <GenreSelector
+          type={type}
+          defaultValue={currentFilters.withoutGenre}
+          isMulti
+          onChange={(value) => {
+            updateQueryParams(
+              'withoutGenre',
+              value?.map((v) => v.value).join(',')
+            );
           }}
         />
         <span className="text-lg font-semibold">

--- a/src/components/Discover/MovieGenreSlider/index.tsx
+++ b/src/components/Discover/MovieGenreSlider/index.tsx
@@ -24,6 +24,7 @@ const MovieGenreSlider = () => {
 
   return (
     <>
+      MovieGenreSlider
       <div className="slider-header">
         <Link href="/discover/movies/genres">
           <a className="slider-title">

--- a/src/components/Discover/constants.ts
+++ b/src/components/Discover/constants.ts
@@ -98,6 +98,7 @@ export const QueryFilterOptions = z.object({
   firstAirDateLte: z.string().optional(),
   studio: z.string().optional(),
   genre: z.string().optional(),
+  withoutGenre: z.string().optional(),
   keywords: z.string().optional(),
   language: z.string().optional(),
   withRuntimeGte: z.string().optional(),
@@ -118,7 +119,6 @@ export const prepareFilterValues = (
   const filterValues: FilterOptions = {};
 
   const values = QueryFilterOptions.parse(inputValues);
-
   if (values.sortBy) {
     filterValues.sortBy = values.sortBy;
   }
@@ -145,6 +145,10 @@ export const prepareFilterValues = (
 
   if (values.genre) {
     filterValues.genre = values.genre;
+  }
+
+  if (values.withoutGenre) {
+    filterValues.withoutGenre = values.withoutGenre;
   }
 
   if (values.keywords) {

--- a/src/components/Discover/constants.ts
+++ b/src/components/Discover/constants.ts
@@ -98,7 +98,7 @@ export const QueryFilterOptions = z.object({
   firstAirDateLte: z.string().optional(),
   studio: z.string().optional(),
   genre: z.string().optional(),
-  withoutGenre: z.string().optional(),
+  filterGenre: z.string().optional(),
   keywords: z.string().optional(),
   language: z.string().optional(),
   withRuntimeGte: z.string().optional(),
@@ -147,8 +147,8 @@ export const prepareFilterValues = (
     filterValues.genre = values.genre;
   }
 
-  if (values.withoutGenre) {
-    filterValues.withoutGenre = values.withoutGenre;
+  if (values.filterGenre) {
+    filterValues.filterGenre = values.filterGenre;
   }
 
   if (values.keywords) {
@@ -194,9 +194,18 @@ export const prepareFilterValues = (
   return filterValues;
 };
 
-export const countActiveFilters = (filterValues: FilterOptions): number => {
+export const countActiveFilters = (
+  filterValues: FilterOptions,
+  userDefaultExcludedGenres?: boolean
+): number => {
   let totalCount = 0;
   const clonedFilters = Object.assign({}, filterValues);
+
+  if (clonedFilters.filterGenre === 'none') {
+    delete clonedFilters.filterGenre;
+  } else if (!clonedFilters.filterGenre && userDefaultExcludedGenres) {
+    totalCount += 1;
+  }
 
   if (clonedFilters.voteAverageGte || filterValues.voteAverageLte) {
     totalCount += 1;

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -233,8 +233,8 @@ const Discover = () => {
               <MediaSlider
                 sliderKey="popular-movies"
                 title={intl.formatMessage(sliderTitles.popularmovies)}
-                url="/api/v1/discover/movies?without_genres=42"
-                linkUrl="/discover/movies?without_genres=42"
+                url="/api/v1/discover/movies"
+                linkUrl="/discover/movies"
               />
             );
             break;

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -233,8 +233,8 @@ const Discover = () => {
               <MediaSlider
                 sliderKey="popular-movies"
                 title={intl.formatMessage(sliderTitles.popularmovies)}
-                url="/api/v1/discover/movies"
-                linkUrl="/discover/movies"
+                url="/api/v1/discover/movies?without_genres=42"
+                linkUrl="/discover/movies?without_genres=42"
               />
             );
             break;

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -148,6 +148,7 @@ export const GenreSelector = ({
   useEffect(() => {
     const loadDefaultGenre = async (): Promise<void> => {
       if (!defaultValue) {
+        setDefaultDataValue([]);
         return;
       }
 
@@ -184,21 +185,30 @@ export const GenreSelector = ({
       );
   };
 
+  const handleChange = (
+    value: MultiValue<SingleVal> | SingleValue<SingleVal> | null
+  ) => {
+    if (isMulti) {
+      setDefaultDataValue(value ? [...(value as MultiValue<SingleVal>)] : []);
+    } else {
+      setDefaultDataValue(value ? [value as SingleVal] : []);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onChange(value as any);
+  };
+
   return (
     <AsyncSelect
-      key={`genre-select-${defaultDataValue}`}
       className="react-select-container"
       classNamePrefix="react-select"
-      defaultValue={isMulti ? defaultDataValue : defaultDataValue?.[0]}
+      value={isMulti ? defaultDataValue : defaultDataValue?.[0]}
       defaultOptions
       cacheOptions
       isMulti={isMulti}
       loadOptions={loadGenreOptions}
       placeholder={intl.formatMessage(messages.searchGenres)}
-      onChange={(value) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onChange(value as any);
-      }}
+      onChange={handleChange}
     />
   );
 };

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -35,6 +35,8 @@ const messages = defineMessages({
   regionTip: 'Filter content by regional availability',
   originallanguage: 'Discover Language',
   originallanguageTip: 'Filter content by original language',
+  filterMovieGenresDefault: 'Exclude movie genres by default',
+  filterTvGenresDefault: 'Exclude TV genres by default',
   toastApiKeySuccess: 'New API key generated successfully!',
   toastApiKeyFailure: 'Something went wrong while generating a new API key.',
   toastSettingsSuccess: 'Settings saved successfully!',

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -5,6 +5,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import LanguageSelector from '@app/components/LanguageSelector';
 import QuotaSelector from '@app/components/QuotaSelector';
 import RegionSelector from '@app/components/RegionSelector';
+import { GenreSelector } from '@app/components/Selector';
 import type { AvailableLocale } from '@app/context/LanguageContext';
 import { availableLanguages } from '@app/context/LanguageContext';
 import useLocale from '@app/hooks/useLocale';
@@ -40,6 +41,8 @@ const messages = defineMessages({
   regionTip: 'Filter content by regional availability',
   originallanguage: 'Discover Language',
   originallanguageTip: 'Filter content by original language',
+  filterMovieGenresDefault: 'Exclude movie genres by default',
+  filterTvGenresDefault: 'Exclude TV genres by default',
   movierequestlimit: 'Movie Request Limit',
   seriesrequestlimit: 'Series Request Limit',
   enableOverride: 'Override Global Limit',
@@ -124,6 +127,8 @@ const UserGeneralSettings = () => {
           locale: data?.locale,
           region: data?.region,
           originalLanguage: data?.originalLanguage,
+          filterMovieGenresDefault: data?.filterMovieGenresDefault,
+          filterTvGenresDefault: data?.filterTvGenresDefault,
           movieQuotaLimit: data?.movieQuotaLimit,
           movieQuotaDays: data?.movieQuotaDays,
           tvQuotaLimit: data?.tvQuotaLimit,
@@ -141,6 +146,8 @@ const UserGeneralSettings = () => {
               locale: values.locale,
               region: values.region,
               originalLanguage: values.originalLanguage,
+              filterMovieGenresDefault: values.filterMovieGenresDefault,
+              filterTvGenresDefault: values.filterTvGenresDefault,
               movieQuotaLimit: movieQuotaEnabled
                 ? values.movieQuotaLimit
                 : null,
@@ -330,6 +337,51 @@ const UserGeneralSettings = () => {
                       serverValue={currentSettings.originalLanguage}
                       value={values.originalLanguage}
                       isUserSettings
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="form-row">
+                <label
+                  htmlFor="filterMovieGenresDefault"
+                  className="text-label"
+                >
+                  <span>
+                    {intl.formatMessage(messages.filterMovieGenresDefault)}
+                  </span>
+                </label>
+                <div className="form-input-area">
+                  <div className="form-input-field">
+                    <GenreSelector
+                      type="movie"
+                      isMulti
+                      defaultValue={values.filterMovieGenresDefault}
+                      onChange={(value) => {
+                        const genreIds =
+                          value?.map((v) => v.value).join(',') || '';
+                        setFieldValue('filterMovieGenresDefault', genreIds);
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="form-row">
+                <label htmlFor="filterTvGenresDefault" className="text-label">
+                  <span>
+                    {intl.formatMessage(messages.filterTvGenresDefault)}
+                  </span>
+                </label>
+                <div className="form-input-area">
+                  <div className="form-input-field">
+                    <GenreSelector
+                      type="tv"
+                      isMulti
+                      defaultValue={values.filterTvGenresDefault}
+                      onChange={(value) => {
+                        const genreIds =
+                          value?.map((v) => v.value).join(',') || '';
+                        setFieldValue('filterTvGenresDefault', genreIds);
+                      }}
                     />
                   </div>
                 </div>

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -17,6 +17,8 @@ const defaultSettings = {
   series4kEnabled: false,
   region: '',
   originalLanguage: '',
+  filterMovieGenresDefault: '',
+  filterTvGenresDefault: '',
   partialRequestsEnabled: true,
   cacheImages: false,
   vapidPublic: '',

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -30,6 +30,8 @@ export interface UserSettings {
   region?: string;
   originalLanguage?: string;
   locale?: string;
+  filterMovieGenresDefault?: string;
+  filterTvGenresDefault?: string;
   notificationTypes: Partial<NotificationAgentTypes>;
   watchlistSyncMovies?: boolean;
   watchlistSyncTv?: boolean;


### PR DESCRIPTION
#### Description
Using TheMovieDB's `without_genres` query parameter, we are able to filter out chosen genres out of our search for movies and TV Shows.
Added user settings for both categories, as these have different genres, which automatically gets applied every time the user goes to the Discover pages and when viewing the Popular X.

If a user adds a genre to the (Exclude) Genre, it gets removed from the other one and vice versa.

#### Screenshot (if UI-related)
![image](https://github.com/user-attachments/assets/7be71dfc-a1a9-4a33-9277-6b82c38f716c)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Closes #3293
