### PR TITLE
fix: add push subscription verification and resubscribe logic

### DIFF
--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -18,15 +18,19 @@ const ServiceWorkerSetup = () => {
             registration.scope
           );
 
-          // Do not prompt for permissions as we will handle this in the settings
+          // Do not prompt for permissions as we will handle this in the settings.
           if (Notification.permission !== 'granted') {
             console.warn(
               '[SW] Push permissions not granted — skipping resubscribe'
             );
-            return false;
+            return;
           }
 
           const subscription = await registration.pushManager.getSubscription();
+          // Bypass resubscribing if we have manually disabled the subscription
+          if (!subscription) {
+            return;
+          }
 
           if (subscription) {
             console.log(

--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -1,10 +1,13 @@
 /* eslint-disable no-console */
 
+import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
+import { verifyAndResubscribePushSubscription } from '@app/utils/pushSubscriptionHelpers';
 import { useEffect } from 'react';
 
 const ServiceWorkerSetup = () => {
   const { user } = useUser();
+  const { currentSettings } = useSettings();
   useEffect(() => {
     if ('serviceWorker' in navigator && user?.id) {
       navigator.serviceWorker
@@ -14,6 +17,28 @@ const ServiceWorkerSetup = () => {
             '[SW] Registration successful, scope is:',
             registration.scope
           );
+
+          const subscription = await registration.pushManager.getSubscription();
+
+          if (subscription) {
+            console.log(
+              '[SW] Existing push subscription:',
+              subscription.endpoint
+            );
+          }
+
+          const verified = await verifyAndResubscribePushSubscription(
+            user.id,
+            currentSettings
+          );
+
+          if (verified) {
+            console.log('[SW] Push subscription verified or refreshed.');
+          } else {
+            console.warn(
+              '[SW] Push subscription verification failed or not available.'
+            );
+          }
         })
         .catch(function (error) {
           console.log('[SW] Service worker registration failed, error:', error);

--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -18,6 +18,14 @@ const ServiceWorkerSetup = () => {
             registration.scope
           );
 
+          // Do not prompt for permissions as we will handle this in the settings
+          if (Notification.permission !== 'granted') {
+            console.warn(
+              '[SW] Push permissions not granted — skipping resubscribe'
+            );
+            return false;
+          }
+
           const subscription = await registration.pushManager.getSubscription();
 
           if (subscription) {

--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -33,12 +33,10 @@ const ServiceWorkerSetup = () => {
             return;
           }
 
-          if (subscription) {
-            console.log(
-              '[SW] Existing push subscription:',
-              subscription.endpoint
-            );
-          }
+          console.log(
+            '[SW] Existing push subscription:',
+            subscription.endpoint
+          );
 
           const verified = await verifyAndResubscribePushSubscription(
             user.id,

--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
 const ServiceWorkerSetup = () => {
   const { user } = useUser();
   const { currentSettings } = useSettings();
+
   useEffect(() => {
     if ('serviceWorker' in navigator && user?.id) {
       navigator.serviceWorker
@@ -56,7 +57,7 @@ const ServiceWorkerSetup = () => {
           console.log('[SW] Service worker registration failed, error:', error);
         });
     }
-  }, [user]);
+  }, [currentSettings, user]);
   return null;
 };
 

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/DeviceItem.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/DeviceItem.tsx
@@ -1,8 +1,10 @@
+import Button from '@app/components/Common/Button';
 import ConfirmButton from '@app/components/Common/ConfirmButton';
 import globalMessages from '@app/i18n/globalMessages';
 import {
   ComputerDesktopIcon,
   DevicePhoneMobileIcon,
+  LockClosedIcon,
   TrashIcon,
 } from '@heroicons/react/24/solid';
 import { defineMessages, useIntl } from 'react-intl';
@@ -17,6 +19,7 @@ interface DeviceItemProps {
     userAgent: string;
     createdAt: Date;
   };
+  subEndpoint: string | null;
 }
 
 const messages = defineMessages({
@@ -25,11 +28,13 @@ const messages = defineMessages({
   engine: 'Engine',
   deletesubscription: 'Delete Subscription',
   unknown: 'Unknown',
+  activesubscription: 'Active Subscription',
 });
 
 const DeviceItem = ({
   deletePushSubscriptionFromBackend,
   device,
+  subEndpoint,
 }: DeviceItemProps) => {
   const intl = useIntl();
   const parsedUserAgent = UAParser(device.userAgent);
@@ -90,14 +95,21 @@ const DeviceItem = ({
         </div>
       </div>
       <div className="z-10 mt-4 flex w-full flex-col justify-center space-y-2 pl-4 pr-4 xl:mt-0 xl:w-96 xl:items-end xl:pl-0">
-        <ConfirmButton
-          onClick={() => deletePushSubscriptionFromBackend(device.endpoint)}
-          confirmText={intl.formatMessage(globalMessages.areyousure)}
-          className="w-full"
-        >
-          <TrashIcon />
-          <span>{intl.formatMessage(messages.deletesubscription)}</span>
-        </ConfirmButton>
+        {subEndpoint === device.endpoint ? (
+          <Button buttonType="primary" disabled>
+            <LockClosedIcon />{' '}
+            <span>{intl.formatMessage(messages.activesubscription)}</span>
+          </Button>
+        ) : (
+          <ConfirmButton
+            onClick={() => deletePushSubscriptionFromBackend(device.endpoint)}
+            confirmText={intl.formatMessage(globalMessages.areyousure)}
+            className="w-full"
+          >
+            <TrashIcon />
+            <span>{intl.formatMessage(messages.deletesubscription)}</span>
+          </ConfirmButton>
+        )}
       </div>
     </div>
   );

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/DeviceItem.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/DeviceItem.tsx
@@ -9,7 +9,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { UAParser } from 'ua-parser-js';
 
 interface DeviceItemProps {
-  disablePushNotifications: (p256dh: string) => void;
+  deletePushSubscriptionFromBackend: (endpoint: string) => void;
   device: {
     endpoint: string;
     p256dh: string;
@@ -27,7 +27,10 @@ const messages = defineMessages({
   unknown: 'Unknown',
 });
 
-const DeviceItem = ({ disablePushNotifications, device }: DeviceItemProps) => {
+const DeviceItem = ({
+  deletePushSubscriptionFromBackend,
+  device,
+}: DeviceItemProps) => {
   const intl = useIntl();
   const parsedUserAgent = UAParser(device.userAgent);
 
@@ -88,7 +91,7 @@ const DeviceItem = ({ disablePushNotifications, device }: DeviceItemProps) => {
       </div>
       <div className="z-10 mt-4 flex w-full flex-col justify-center space-y-2 pl-4 pr-4 xl:mt-0 xl:w-96 xl:items-end xl:pl-0">
         <ConfirmButton
-          onClick={() => disablePushNotifications(device.endpoint)}
+          onClick={() => deletePushSubscriptionFromBackend(device.endpoint)}
           confirmText={intl.formatMessage(globalMessages.areyousure)}
           className="w-full"
         >

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -8,12 +8,16 @@ import DeviceItem from '@app/components/UserProfile/UserSettings/UserNotificatio
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import {
+  subscribeToPushNotifications,
+  unsubscribeToPushNotifications,
+  verifyPushSubscription,
+} from '@app/utils/pushSubscriptionHelpers';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import {
   CloudArrowDownIcon,
   CloudArrowUpIcon,
 } from '@heroicons/react/24/solid';
-import type { UserPushSubscription } from '@server/entity/UserPushSubscription';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import axios from 'axios';
 import { Form, Formik } from 'formik';
@@ -68,141 +72,84 @@ const UserWebPushSettings = () => {
 
   // Subscribes to the push manager
   // Will only add to the database if subscribing for the first time
-  const enablePushNotifications = () => {
-    if ('serviceWorker' in navigator && user?.id) {
-      navigator.serviceWorker
-        .getRegistration('/sw.js')
-        .then(async (registration) => {
-          if (currentSettings.enablePushRegistration) {
-            const sub = await registration?.pushManager.subscribe({
-              userVisibleOnly: true,
-              applicationServerKey: currentSettings.vapidPublic,
-            });
-            const parsedSub = JSON.parse(JSON.stringify(sub));
+  const enablePushNotifications = async () => {
+    try {
+      const isSubscribed = await subscribeToPushNotifications(
+        user?.id,
+        currentSettings
+      );
 
-            if (parsedSub.keys.p256dh && parsedSub.keys.auth) {
-              await axios.post('/api/v1/user/registerPushSubscription', {
-                endpoint: parsedSub.endpoint,
-                p256dh: parsedSub.keys.p256dh,
-                auth: parsedSub.keys.auth,
-                userAgent: navigator.userAgent,
-              });
-              setWebPushEnabled(true);
-              addToast(intl.formatMessage(messages.webpushhasbeenenabled), {
-                appearance: 'success',
-                autoDismiss: true,
-              });
-            }
-          }
-        })
-        .catch(function () {
-          addToast(intl.formatMessage(messages.enablingwebpusherror), {
-            autoDismiss: true,
-            appearance: 'error',
-          });
-        })
-        .finally(function () {
-          revalidateDevices();
+      if (isSubscribed) {
+        setWebPushEnabled(true);
+        addToast(intl.formatMessage(messages.webpushhasbeenenabled), {
+          appearance: 'success',
+          autoDismiss: true,
         });
+      } else {
+        throw new Error('Subscription failed');
+      }
+    } catch (error) {
+      addToast(intl.formatMessage(messages.enablingwebpusherror), {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    } finally {
+      revalidateDevices();
     }
   };
 
   // Unsubscribes from the push manager
   // Deletes/disables corresponding push subscription from database
   const disablePushNotifications = async (endpoint?: string) => {
-    if ('serviceWorker' in navigator && user?.id) {
-      navigator.serviceWorker.getRegistration('/sw.js').then((registration) => {
-        registration?.pushManager
-          .getSubscription()
-          .then(async (subscription) => {
-            const parsedSub = JSON.parse(JSON.stringify(subscription));
+    try {
+      const isUnsubscribed = await unsubscribeToPushNotifications(
+        user?.id,
+        endpoint
+      );
 
-            await axios.delete(
-              `/api/v1/user/${user.id}/pushSubscription/${encodeURIComponent(
-                endpoint ?? parsedSub.endpoint
-              )}`
-            );
-
-            if (
-              subscription &&
-              (endpoint === parsedSub.endpoint || !endpoint)
-            ) {
-              subscription.unsubscribe();
-              setWebPushEnabled(false);
-            }
-            addToast(
-              intl.formatMessage(
-                endpoint
-                  ? messages.subscriptiondeleted
-                  : messages.webpushhasbeendisabled
-              ),
-              {
-                autoDismiss: true,
-                appearance: 'success',
-              }
-            );
-          })
-          .catch(function () {
-            addToast(
-              intl.formatMessage(
-                endpoint
-                  ? messages.subscriptiondeleteerror
-                  : messages.disablingwebpusherror
-              ),
-              {
-                autoDismiss: true,
-                appearance: 'error',
-              }
-            );
-          })
-          .finally(function () {
-            revalidateDevices();
-          });
-      });
+      if (isUnsubscribed) {
+        setWebPushEnabled(false);
+        addToast(
+          intl.formatMessage(
+            endpoint
+              ? messages.subscriptiondeleted
+              : messages.webpushhasbeendisabled
+          ),
+          {
+            autoDismiss: true,
+            appearance: 'success',
+          }
+        );
+      } else {
+        throw new Error('Unsubscribe failed');
+      }
+    } catch (error) {
+      addToast(
+        intl.formatMessage(
+          endpoint
+            ? messages.subscriptiondeleteerror
+            : messages.disablingwebpusherror
+        ),
+        {
+          autoDismiss: true,
+          appearance: 'error',
+        }
+      );
+    } finally {
+      revalidateDevices();
     }
   };
 
-  // Checks our current subscription on page load
-  // Will set the web push state to true if subscribed
   useEffect(() => {
-    if ('serviceWorker' in navigator && user?.id) {
-      navigator.serviceWorker
-        .getRegistration('/sw.js')
-        .then(async (registration) => {
-          await registration?.pushManager
-            .getSubscription()
-            .then(async (subscription) => {
-              if (subscription) {
-                const parsedKey = JSON.parse(JSON.stringify(subscription));
-                const currentUserPushSub =
-                  await axios.get<UserPushSubscription>(
-                    `/api/v1/user/${
-                      user.id
-                    }/pushSubscription/${encodeURIComponent(
-                      parsedKey.endpoint
-                    )}`
-                  );
+    const verifyWebPush = async () => {
+      const enabled = await verifyPushSubscription(user?.id, currentSettings);
+      setWebPushEnabled(enabled);
+    };
 
-                if (currentUserPushSub.data.endpoint !== parsedKey.endpoint) {
-                  return;
-                }
-
-                setWebPushEnabled(true);
-              } else {
-                setWebPushEnabled(false);
-              }
-            });
-        })
-        .catch(function (error) {
-          setWebPushEnabled(false);
-          // eslint-disable-next-line no-console
-          console.log(
-            '[SW] Failure retrieving push manager subscription, error:',
-            error
-          );
-        });
+    if (user?.id) {
+      verifyWebPush();
     }
-  }, [user?.id]);
+  }, [user?.id, currentSettings]);
 
   if (!data && !error) {
     return <LoadingSpinner />;

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -53,7 +53,6 @@ const UserWebPushSettings = () => {
   const { user } = useUser({ id: Number(router.query.userId) });
   const { currentSettings } = useSettings();
   const [webPushEnabled, setWebPushEnabled] = useState(false);
-
   const [subEndpoint, setSubEndpoint] = useState<string | null>(null);
   const {
     data,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -102,39 +102,40 @@ const UserWebPushSettings = () => {
   // Deletes/disables corresponding push subscription from database
   const disablePushNotifications = async (endpoint?: string) => {
     try {
-      const isUnsubscribed = await unsubscribeToPushNotifications(
-        user?.id,
-        endpoint
+      await unsubscribeToPushNotifications(user?.id, endpoint);
+
+      setWebPushEnabled(false);
+      addToast(intl.formatMessage(messages.webpushhasbeendisabled), {
+        autoDismiss: true,
+        appearance: 'success',
+      });
+    } catch (error) {
+      addToast(intl.formatMessage(messages.disablingwebpusherror), {
+        autoDismiss: true,
+        appearance: 'error',
+      });
+    } finally {
+      revalidateDevices();
+    }
+  };
+
+  const deletePushSubscriptionFromBackend = async (endpoint: string) => {
+    try {
+      await axios.delete(
+        `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
+          endpoint
+        )}`
       );
 
-      if (isUnsubscribed) {
-        setWebPushEnabled(false);
-        addToast(
-          intl.formatMessage(
-            endpoint
-              ? messages.subscriptiondeleted
-              : messages.webpushhasbeendisabled
-          ),
-          {
-            autoDismiss: true,
-            appearance: 'success',
-          }
-        );
-      } else {
-        throw new Error('Unsubscribe failed');
-      }
+      addToast(intl.formatMessage(messages.subscriptiondeleted), {
+        autoDismiss: true,
+        appearance: 'success',
+      });
     } catch (error) {
-      addToast(
-        intl.formatMessage(
-          endpoint
-            ? messages.subscriptiondeleteerror
-            : messages.disablingwebpusherror
-        ),
-        {
-          autoDismiss: true,
-          appearance: 'error',
-        }
-      );
+      addToast(intl.formatMessage(messages.subscriptiondeleteerror), {
+        autoDismiss: true,
+        appearance: 'error',
+      });
     } finally {
       revalidateDevices();
     }
@@ -274,11 +275,12 @@ const UserWebPushSettings = () => {
                 const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
                 return dateB - dateA;
               })
-              .map((device, index) => (
-                <div className="py-2" key={`device-list-${index}`}>
+              .map((device) => (
+                <div className="py-2" key={`device-list-${device.endpoint}`}>
                   <DeviceItem
-                    key={index}
-                    disablePushNotifications={disablePushNotifications}
+                    deletePushSubscriptionFromBackend={
+                      deletePushSubscriptionFromBackend
+                    }
                     device={device}
                   />
                 </div>

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -9,6 +9,7 @@ import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import {
+  getPushSubscription,
   subscribeToPushNotifications,
   unsubscribeToPushNotifications,
   verifyPushSubscription,
@@ -156,8 +157,7 @@ const UserWebPushSettings = () => {
   useEffect(() => {
     const getSubscriptionEndpoint = async () => {
       if ('serviceWorker' in navigator && 'PushManager' in window) {
-        const registration = await navigator.serviceWorker.ready;
-        const subscription = await registration.pushManager.getSubscription();
+        const { subscription } = await getPushSubscription();
 
         if (subscription) {
           setSubEndpoint(subscription.endpoint);

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -53,6 +53,8 @@ const UserWebPushSettings = () => {
   const { user } = useUser({ id: Number(router.query.userId) });
   const { currentSettings } = useSettings();
   const [webPushEnabled, setWebPushEnabled] = useState(false);
+
+  const [subEndpoint, setSubEndpoint] = useState<string | null>(null);
   const {
     data,
     error,
@@ -151,6 +153,23 @@ const UserWebPushSettings = () => {
       verifyWebPush();
     }
   }, [user?.id, currentSettings]);
+
+  useEffect(() => {
+    const getSubscriptionEndpoint = async () => {
+      if ('serviceWorker' in navigator && 'PushManager' in window) {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+
+        if (subscription) {
+          setSubEndpoint(subscription.endpoint);
+        } else {
+          setSubEndpoint(null);
+        }
+      }
+    };
+
+    getSubscriptionEndpoint();
+  }, [webPushEnabled]);
 
   if (!data && !error) {
     return <LoadingSpinner />;
@@ -282,6 +301,7 @@ const UserWebPushSettings = () => {
                       deletePushSubscriptionFromBackend
                     }
                     device={device}
+                    subEndpoint={subEndpoint}
                   />
                 </div>
               ))

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -23,7 +23,7 @@ import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/u
 import axios from 'axios';
 import { Form, Formik } from 'formik';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR, { mutate } from 'swr';
@@ -170,6 +170,25 @@ const UserWebPushSettings = () => {
     getSubscriptionEndpoint();
   }, [webPushEnabled]);
 
+  const sortedDevices = useMemo(() => {
+    if (!dataDevices || !subEndpoint) {
+      return dataDevices;
+    }
+
+    return [...dataDevices].sort((a, b) => {
+      if (a.endpoint === subEndpoint) {
+        return -1;
+      }
+      if (b.endpoint === subEndpoint) {
+        return 1;
+      }
+
+      const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return dateB - dateA;
+    });
+  }, [dataDevices, subEndpoint]);
+
   if (!data && !error) {
     return <LoadingSpinner />;
   }
@@ -286,24 +305,18 @@ const UserWebPushSettings = () => {
           {intl.formatMessage(messages.managedevices)}
         </h3>
         <div className="section">
-          {dataDevices?.length ? (
-            dataDevices
-              ?.sort((a, b) => {
-                const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-                const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-                return dateB - dateA;
-              })
-              .map((device) => (
-                <div className="py-2" key={`device-list-${device.endpoint}`}>
-                  <DeviceItem
-                    deletePushSubscriptionFromBackend={
-                      deletePushSubscriptionFromBackend
-                    }
-                    device={device}
-                    subEndpoint={subEndpoint}
-                  />
-                </div>
-              ))
+          {sortedDevices?.length ? (
+            sortedDevices.map((device) => (
+              <div className="py-2" key={`device-list-${device.endpoint}`}>
+                <DeviceItem
+                  deletePushSubscriptionFromBackend={
+                    deletePushSubscriptionFromBackend
+                  }
+                  device={device}
+                  subEndpoint={subEndpoint}
+                />
+              </div>
+            ))
           ) : (
             <>
               <Alert

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1106,6 +1106,7 @@
   "components.UserProfile.UserSettings.UserGeneralSettings.toastSettingsSuccess": "Settings saved successfully!",
   "components.UserProfile.UserSettings.UserGeneralSettings.user": "User",
   "components.UserProfile.UserSettings.UserGeneralSettings.validationDiscordId": "You must provide a valid Discord user ID",
+  "components.UserProfile.UserSettings.UserNotificationSettings.UserNotificationsWebPush.activesubscription": "Active Subscription",
   "components.UserProfile.UserSettings.UserNotificationSettings.UserNotificationsWebPush.browser": "Browser",
   "components.UserProfile.UserSettings.UserNotificationSettings.UserNotificationsWebPush.created": "Created",
   "components.UserProfile.UserSettings.UserNotificationSettings.UserNotificationsWebPush.deletesubscription": "Delete Subscription",

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -1,0 +1,163 @@
+import type { UserPushSubscription } from '@server/entity/UserPushSubscription';
+import type { PublicSettingsResponse } from '@server/interfaces/api/settingsInterfaces';
+import axios from 'axios';
+
+// Taken from https://www.npmjs.com/package/web-push
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = `${base64String}${padding}`
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i)
+    outputArray[i] = rawData.charCodeAt(i);
+
+  return outputArray;
+}
+
+export const verifyPushSubscription = async (
+  userId: number | undefined,
+  currentSettings: PublicSettingsResponse
+): Promise<boolean> => {
+  if (!('serviceWorker' in navigator) || !userId) {
+    return false;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration(
+      '/sw.js'
+    );
+    const subscription = await registration?.pushManager.getSubscription();
+    if (!subscription) {
+      return false;
+    }
+
+    const appServerKey = subscription.options?.applicationServerKey;
+    if (!(appServerKey instanceof ArrayBuffer)) {
+      return false;
+    }
+
+    const currentServerKey = new Uint8Array(appServerKey).toString();
+    const expectedServerKey = urlBase64ToUint8Array(
+      currentSettings.vapidPublic
+    ).toString();
+
+    const endpoint = subscription.endpoint;
+
+    const { data } = await axios.get<UserPushSubscription>(
+      `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(endpoint)}`
+    );
+
+    return expectedServerKey === currentServerKey && data.endpoint === endpoint;
+  } catch (err) {
+    console.warn('[SW] verifyPushSubscription failed:', err);
+    return false;
+  }
+};
+
+export const verifyAndResubscribePushSubscription = async (
+  userId: number | undefined,
+  currentSettings: PublicSettingsResponse
+): Promise<boolean> => {
+  const isValid = await verifyPushSubscription(userId, currentSettings);
+
+  if (isValid) {
+    return true;
+  }
+
+  if (currentSettings.enablePushRegistration) {
+    try {
+      await unsubscribeToPushNotifications(userId);
+      await subscribeToPushNotifications(userId, currentSettings);
+      return true;
+    } catch (err) {
+      console.error('[SW] Resubscribe failed:', err);
+    }
+  }
+
+  return false;
+};
+
+export const subscribeToPushNotifications = async (
+  userId: number | undefined,
+  currentSettings: PublicSettingsResponse
+) => {
+  if (
+    !('serviceWorker' in navigator) ||
+    !userId ||
+    !currentSettings.enablePushRegistration
+  ) {
+    return false;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration(
+      '/sw.js'
+    );
+    if (!registration) {
+      return false;
+    }
+
+    const sub = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: currentSettings.vapidPublic,
+    });
+
+    const { endpoint, keys } = JSON.parse(JSON.stringify(sub));
+
+    if (keys?.p256dh && keys?.auth) {
+      await axios.post('/api/v1/user/registerPushSubscription', {
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        userAgent: navigator.userAgent,
+      });
+
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    console.log('Issue subscribing to push notifications: ', { error });
+  }
+};
+
+export const unsubscribeToPushNotifications = async (
+  userId: number | undefined,
+  endpoint?: string
+) => {
+  if (!('serviceWorker' in navigator) || !userId) {
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration(
+      '/sw.js'
+    );
+    const subscription = await registration?.pushManager.getSubscription();
+    if (!subscription) {
+      return false;
+    }
+
+    const { endpoint: currentEndpoint } = JSON.parse(
+      JSON.stringify(subscription)
+    );
+    const resolvedEndpoint = endpoint ?? currentEndpoint;
+
+    await axios.delete(
+      `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(
+        resolvedEndpoint
+      )}`
+    );
+
+    if (!endpoint || endpoint === currentEndpoint) {
+      await subscription.unsubscribe();
+      return true;
+    }
+  } catch (error) {
+    console.log('Issue unsubscribing to push notifications: ', { error });
+  }
+};

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -70,8 +70,12 @@ export const verifyAndResubscribePushSubscription = async (
 
   if (currentSettings.enablePushRegistration) {
     try {
+      // Unsubscribe from the backend to clear the existing push subscription (keys and endpoint)
       await unsubscribeToPushNotifications(userId);
+
+      // Subscribe again to generate a fresh push subscription with updated keys and endpoint
       await subscribeToPushNotifications(userId, currentSettings);
+
       return true;
     } catch (err) {
       console.error('[SW] Resubscribe failed:', err);
@@ -101,12 +105,12 @@ export const subscribeToPushNotifications = async (
       return false;
     }
 
-    const sub = await registration.pushManager.subscribe({
+    const subscription = await registration.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: currentSettings.vapidPublic,
     });
 
-    const { endpoint, keys } = JSON.parse(JSON.stringify(sub));
+    const { endpoint, keys } = JSON.parse(JSON.stringify(subscription));
 
     if (keys?.p256dh && keys?.auth) {
       await axios.post('/api/v1/user/registerPushSubscription', {

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -18,6 +18,12 @@ function urlBase64ToUint8Array(base64String: string) {
   return outputArray;
 }
 
+export const getPushSubscription = async () => {
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  return { registration, subscription };
+};
+
 export const verifyPushSubscription = async (
   userId: number | undefined,
   currentSettings: PublicSettingsResponse
@@ -27,10 +33,8 @@ export const verifyPushSubscription = async (
   }
 
   try {
-    const registration = await navigator.serviceWorker.getRegistration(
-      '/sw.js'
-    );
-    const subscription = await registration?.pushManager.getSubscription();
+    const { subscription } = await getPushSubscription();
+
     if (!subscription) {
       return false;
     }
@@ -99,9 +103,8 @@ export const subscribeToPushNotifications = async (
   }
 
   try {
-    const registration = await navigator.serviceWorker.getRegistration(
-      '/sw.js'
-    );
+    const { registration } = await getPushSubscription();
+
     if (!registration) {
       return false;
     }
@@ -141,10 +144,7 @@ export const unsubscribeToPushNotifications = async (
   }
 
   try {
-    const registration = await navigator.serviceWorker.getRegistration(
-      '/sw.js'
-    );
-    const subscription = await registration?.pushManager.getSubscription();
+    const { subscription } = await getPushSubscription();
 
     if (!subscription) {
       return false;

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -52,8 +52,7 @@ export const verifyPushSubscription = async (
     );
 
     return expectedServerKey === currentServerKey && data.endpoint === endpoint;
-  } catch (err) {
-    console.warn('[SW] verifyPushSubscription failed:', err);
+  } catch {
     return false;
   }
 };
@@ -79,8 +78,8 @@ export const verifyAndResubscribePushSubscription = async (
       }
 
       return true;
-    } catch (err) {
-      console.error('[SW] Resubscribe failed:', err);
+    } catch (error) {
+      throw new Error(`[SW] Resubscribe failed: ${error.message}`);
     }
   }
 
@@ -112,7 +111,7 @@ export const subscribeToPushNotifications = async (
       applicationServerKey: currentSettings.vapidPublic,
     });
 
-    const { endpoint, keys } = JSON.parse(JSON.stringify(subscription));
+    const { endpoint, keys } = subscription.toJSON();
 
     if (keys?.p256dh && keys?.auth) {
       await axios.post('/api/v1/user/registerPushSubscription', {
@@ -127,7 +126,9 @@ export const subscribeToPushNotifications = async (
 
     return false;
   } catch (error) {
-    console.log('Issue subscribing to push notifications: ', { error });
+    throw new Error(
+      `Issue subscribing to push notifications: ${error.message}`
+    );
   }
 };
 
@@ -149,15 +150,15 @@ export const unsubscribeToPushNotifications = async (
       return false;
     }
 
-    const { endpoint: currentEndpoint } = JSON.parse(
-      JSON.stringify(subscription)
-    );
+    const { endpoint: currentEndpoint } = subscription.toJSON();
 
     if (!endpoint || endpoint === currentEndpoint) {
       await subscription.unsubscribe();
       return true;
     }
   } catch (error) {
-    console.log('Issue unsubscribing to push notifications: ', { error });
+    throw new Error(
+      `Issue unsubscribing to push notifications: ${error.message}`
+    );
   }
 };

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -71,10 +71,12 @@ export const verifyAndResubscribePushSubscription = async (
   if (currentSettings.enablePushRegistration) {
     try {
       // Unsubscribe from the backend to clear the existing push subscription (keys and endpoint)
-      await unsubscribeToPushNotifications(userId);
+      const hasUnsubscribed = await unsubscribeToPushNotifications(userId);
 
       // Subscribe again to generate a fresh push subscription with updated keys and endpoint
-      await subscribeToPushNotifications(userId, currentSettings);
+      if (hasUnsubscribed) {
+        await subscribeToPushNotifications(userId, currentSettings);
+      }
 
       return true;
     } catch (err) {
@@ -142,19 +144,13 @@ export const unsubscribeToPushNotifications = async (
       '/sw.js'
     );
     const subscription = await registration?.pushManager.getSubscription();
+
     if (!subscription) {
       return false;
     }
 
     const { endpoint: currentEndpoint } = JSON.parse(
       JSON.stringify(subscription)
-    );
-    const resolvedEndpoint = endpoint ?? currentEndpoint;
-
-    await axios.delete(
-      `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(
-        resolvedEndpoint
-      )}`
     );
 
     if (!endpoint || endpoint === currentEndpoint) {


### PR DESCRIPTION
#### Description

This PR introduces a new flow that improves how we manage Web Push subscriptions. Previously, subscriptions were created but there was no verification or refresh logic whenever the endpoint/keys expire.

With this update:

We now verify the existing subscription’s endpoint and VAPID key against what the backend expects.

If the subscription is invalid or missing, we unsubscribe from the backend and generate a new subscription.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
