### PR TITLE
fix: add flag in local storage for notifications

### DIFF
--- a/src/components/ServiceWorkerSetup/index.tsx
+++ b/src/components/ServiceWorkerSetup/index.tsx
@@ -19,23 +19,32 @@ const ServiceWorkerSetup = () => {
             registration.scope
           );
 
-          // Do not prompt for permissions as we will handle this in the settings.
-          if (Notification.permission !== 'granted') {
+          const pushNotificationsEnabled =
+            localStorage.getItem('pushNotificationsEnabled') === 'true';
+
+          // Reset the notifications flag if permissions were revoked
+          if (
+            Notification.permission !== 'granted' &&
+            pushNotificationsEnabled
+          ) {
+            localStorage.setItem('pushNotificationsEnabled', 'false');
             console.warn(
               '[SW] Push permissions not granted — skipping resubscribe'
             );
+
+            return;
+          }
+
+          // Bypass resubscribing if we have manually disabled push notifications
+          if (!pushNotificationsEnabled) {
             return;
           }
 
           const subscription = await registration.pushManager.getSubscription();
-          // Bypass resubscribing if we have manually disabled the subscription
-          if (!subscription) {
-            return;
-          }
 
           console.log(
             '[SW] Existing push subscription:',
-            subscription.endpoint
+            subscription?.endpoint
           );
 
           const verified = await verifyAndResubscribePushSubscription(

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -82,6 +82,7 @@ const UserWebPushSettings = () => {
       );
 
       if (isSubscribed) {
+        localStorage.setItem('pushNotificationsEnabled', 'true');
         setWebPushEnabled(true);
         addToast(intl.formatMessage(messages.webpushhasbeenenabled), {
           appearance: 'success',
@@ -106,6 +107,7 @@ const UserWebPushSettings = () => {
     try {
       await unsubscribeToPushNotifications(user?.id, endpoint);
 
+      localStorage.setItem('pushNotificationsEnabled', 'false');
       setWebPushEnabled(false);
       addToast(intl.formatMessage(messages.webpushhasbeendisabled), {
         autoDismiss: true,

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -74,12 +74,10 @@ export const verifyAndResubscribePushSubscription = async (
   if (currentSettings.enablePushRegistration) {
     try {
       // Unsubscribe from the backend to clear the existing push subscription (keys and endpoint)
-      const hasUnsubscribed = await unsubscribeToPushNotifications(userId);
+      await unsubscribeToPushNotifications(userId);
 
       // Subscribe again to generate a fresh push subscription with updated keys and endpoint
-      if (hasUnsubscribed) {
-        await subscribeToPushNotifications(userId, currentSettings);
-      }
+      await subscribeToPushNotifications(userId, currentSettings);
 
       return true;
     } catch (error) {


### PR DESCRIPTION
#### Description

So push subscriptions are quite tricky, especially on webkit as it will randomly set the current subscription to null at random while there seems to be no issues with chrome based browsers. The previous PR was pushed up just to test and verify that this was happening. 

With the current logic already in place, we can now just add a local storage flag on the user device denoting if push notifications are enabled or not. This will allow us to resubscribe if the subscription becomes null.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
