### PR TITLE
fix: prevent the delete status from changing in certain scenarios

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -110,7 +110,10 @@ class BaseScanner<T> {
       if (existing) {
         let changedExisting = false;
 
-        if (existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE) {
+        if (
+          existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE &&
+          existing[is4k ? 'status4k' : 'status'] !== MediaStatus.DELETED
+        ) {
           existing[is4k ? 'status4k' : 'status'] = processing
             ? MediaStatus.PROCESSING
             : MediaStatus.AVAILABLE;

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -738,14 +738,16 @@ export class MediaRequestSubscriber
 
     if (
       !fullMedia.requests.some((request) => !request.is4k) &&
-      fullMedia.status !== MediaStatus.AVAILABLE
+      fullMedia.status !== MediaStatus.AVAILABLE &&
+      fullMedia.status !== MediaStatus.DELETED
     ) {
       fullMedia.status = MediaStatus.UNKNOWN;
     }
 
     if (
       !fullMedia.requests.some((request) => request.is4k) &&
-      fullMedia.status4k !== MediaStatus.AVAILABLE
+      fullMedia.status4k !== MediaStatus.AVAILABLE &&
+      fullMedia.status4k !== MediaStatus.DELETED
     ) {
       fullMedia.status4k = MediaStatus.UNKNOWN;
     }


### PR DESCRIPTION
#### Description

Small PR that fixes two cases where the DELETED status was being unintentionally overwritten:

- When the media is marked as deleted but still exists in radarr/sonarr, the status was changing back to requested.
- When all requests are removed, the media status was reverting to UNKNOWN instead of remaining as DELETED.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`
