### PR TITLE
feat: add media ratingKey and ratingKey4k to webhook payload

### DIFF
--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -78,13 +78,15 @@ The `{{media}}` will be `null` if there is no relevant media object for the noti
 
 These following special variables are only included in media-related notifications, such as requests.
 
-| Variable             | Value                                                                                                          |
-| -------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `{{media_type}}`     | The media type (`movie` or `tv`)                                                                               |
-| `{{media_tmdbid}}`   | The media's TMDB ID                                                                                            |
-| `{{media_tvdbid}}`   | The media's TheTVDB ID                                                                                         |
-| `{{media_status}}`   | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
-| `{{media_status4k}}` | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
+| Variable                | Value                                                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `{{media_type}}`        | The media type (`movie` or `tv`)                                                                               |
+| `{{media_tmdbid}}`      | The media's TMDB ID                                                                                            |
+| `{{media_tvdbid}}`      | The media's TheTVDB ID                                                                                         |
+| `{{media_status}}`      | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
+| `{{media_status4k}}`    | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
+| `{{media_ratingKey}}`   | The media's Plex ratingKey, if available (for standard library match)                                          |
+| `{{media_ratingKey4k}}` | The media's Plex ratingKey for 4K match, if available                                                          |
 
 #### Request
 

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -32,6 +32,8 @@ const KeyMap: Record<string, string | KeyMapFunction> = {
     payload.media ? MediaStatus[payload.media.status] : '',
   media_status4k: (payload) =>
     payload.media ? MediaStatus[payload.media.status4k] : '',
+  media_ratingKey: (payload) => payload.media?.ratingKey ?? '',
+  media_ratingKey4k: (payload) => payload.media?.ratingKey4k ?? '',
   request_id: 'request.id',
   requestedBy_username: 'request.requestedBy.displayName',
   requestedBy_email: 'request.requestedBy.email',


### PR DESCRIPTION
#### Description

- Adds the plex ratingKey to the webhook JSON payload. 
- Updates docs with new newly added keys.

Allows the user to generate direct links to plex media. 

Example: HomeAssistant notification when tapped, opens plex to the media.



