### PR TITLE
feat: decline-reasons

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -1770,6 +1770,26 @@ components:
           type: number
         name:
           type: string
+    DeclineReason:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+          readOnly: true
+        reason:
+          type: string
+          example: 'Content not suitable for our server'
+        createdAt:
+          type: string
+          format: date-time
+          example: '2024-01-15T09:45:00.000Z'
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: '2024-01-15T09:45:00.000Z'
+          readOnly: true
     Issue:
       type: object
       properties:
@@ -3256,6 +3276,67 @@ paths:
       responses:
         '204':
           description: All sliders reset to defaults
+  /settings/decline-reasons:
+    get:
+      summary: Get all custom decline reasons
+      description: Returns all custom decline reasons in a JSON array.
+      tags:
+        - settings
+      responses:
+        '200':
+          description: Custom decline reasons returned
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DeclineReason'
+    post:
+      summary: Create a new custom decline reason
+      description: Creates a new custom decline reason. Requires the `ADMIN` permission.
+      tags:
+        - settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  example: 'Content not suitable for our server'
+              required:
+                - reason
+      responses:
+        '201':
+          description: Custom decline reason created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeclineReason'
+        '400':
+          description: Bad request - reason is required
+        '409':
+          description: Conflict - decline reason already exists
+  /settings/decline-reasons/{reasonId}:
+    delete:
+      summary: Delete a custom decline reason
+      description: Deletes a custom decline reason by ID. Requires the `ADMIN` permission.
+      tags:
+        - settings
+      parameters:
+        - in: path
+          name: reasonId
+          required: true
+          schema:
+            type: number
+            example: 1
+      responses:
+        '204':
+          description: Custom decline reason deleted
+        '404':
+          description: Decline reason not found
   /settings/about:
     get:
       summary: Get server stats

--- a/server/entity/DeclineReason.ts
+++ b/server/entity/DeclineReason.ts
@@ -1,0 +1,28 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class DeclineReason {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @Column({ type: 'text' })
+  public reason: string;
+
+  @CreateDateColumn()
+  public createdAt: Date;
+
+  @UpdateDateColumn()
+  public updatedAt: Date;
+
+  constructor(init?: Partial<DeclineReason>) {
+    Object.assign(this, init);
+  }
+}
+
+export default DeclineReason;

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -454,6 +454,9 @@ export class MediaRequest {
   @Column({ default: false })
   public isAutoRequest: boolean;
 
+  @Column({ nullable: true, type: 'text' })
+  public declineReason?: string;
+
   constructor(init?: Partial<MediaRequest>) {
     Object.assign(this, init);
   }
@@ -594,6 +597,18 @@ export class MediaRequest {
 
       if (entity.type === MediaType.MOVIE) {
         const movie = await tmdb.getMovie({ movieId: media.tmdbId });
+
+        // For declined requests, include the decline reason in the message
+        let notificationMessage = truncate(movie.overview, {
+          length: 500,
+          separator: /\s/,
+          omission: '…',
+        });
+
+        if (type === Notification.MEDIA_DECLINED && entity.declineReason) {
+          notificationMessage = `Decline reason: ${entity.declineReason}\n\n${notificationMessage}`;
+        }
+
         notificationManager.sendNotification(type, {
           media,
           request: entity,
@@ -604,15 +619,40 @@ export class MediaRequest {
           subject: `${movie.title}${
             movie.release_date ? ` (${movie.release_date.slice(0, 4)})` : ''
           }`,
-          message: truncate(movie.overview, {
-            length: 500,
-            separator: /\s/,
-            omission: '…',
-          }),
+          message: notificationMessage,
           image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${movie.poster_path}`,
         });
       } else if (entity.type === MediaType.TV) {
         const tv = await tmdb.getTvShow({ tvId: media.tmdbId });
+
+        // For declined requests, include the decline reason in the message
+        let notificationMessage = truncate(tv.overview, {
+          length: 500,
+          separator: /\s/,
+          omission: '…',
+        });
+
+        if (type === Notification.MEDIA_DECLINED && entity.declineReason) {
+          notificationMessage = `Decline reason: ${entity.declineReason}\n\n${notificationMessage}`;
+        }
+
+        const extraFields = [
+          {
+            name: 'Requested Seasons',
+            value: entity.seasons
+              .map((season) => season.seasonNumber)
+              .join(', '),
+          },
+        ];
+
+        // Add decline reason as an extra field for declined requests
+        if (type === Notification.MEDIA_DECLINED && entity.declineReason) {
+          extraFields.unshift({
+            name: 'Decline Reason',
+            value: entity.declineReason,
+          });
+        }
+
         notificationManager.sendNotification(type, {
           media,
           request: entity,
@@ -623,20 +663,9 @@ export class MediaRequest {
           subject: `${tv.name}${
             tv.first_air_date ? ` (${tv.first_air_date.slice(0, 4)})` : ''
           }`,
-          message: truncate(tv.overview, {
-            length: 500,
-            separator: /\s/,
-            omission: '…',
-          }),
+          message: notificationMessage,
           image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${tv.poster_path}`,
-          extra: [
-            {
-              name: 'Requested Seasons',
-              value: entity.seasons
-                .map((season) => season.seasonNumber)
-                .join(', '),
-            },
-          ],
+          extra: extraFields,
         });
       }
     } catch (e) {

--- a/server/migration/1740717744279-AddDeclineReasonToMediaRequest.ts
+++ b/server/migration/1740717744279-AddDeclineReasonToMediaRequest.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDeclineReasonToMediaRequest1740717744279
+  implements MigrationInterface
+{
+  name = 'AddDeclineReasonToMediaRequest1740717744279';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media_request" ADD "declineReason" text`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media_request" DROP COLUMN "declineReason"`
+    );
+  }
+}

--- a/server/migration/1740717744280-CreateDeclineReasonTable.ts
+++ b/server/migration/1740717744280-CreateDeclineReasonTable.ts
@@ -1,0 +1,28 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateDeclineReasonTable1740717744280
+  implements MigrationInterface
+{
+  name = 'CreateDeclineReasonTable1740717744280';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "decline_reason" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "reason" text NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`
+    );
+
+    // Insert default decline reasons
+    await queryRunner.query(`
+      INSERT INTO "decline_reason" ("reason") VALUES 
+      ('Inappropriate content'),
+      ('Low quality content'),
+      ('Not available - too niche'),
+      ('Please request only a few seasons at a time'),
+      ('Available on YouTube'),
+      ('No reality TV sorry')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "decline_reason"`);
+  }
+}

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -548,6 +548,12 @@ requestRoutes.post<{
 
       request.status = newStatus;
       request.modifiedBy = req.user;
+
+      // If declining with a reason, save the decline reason
+      if (newStatus === MediaRequestStatus.DECLINED && req.body.reason) {
+        request.declineReason = req.body.reason;
+      }
+
       await requestRepository.save(request);
 
       return res.status(200).json(request);

--- a/server/routes/settings/declineReasons.ts
+++ b/server/routes/settings/declineReasons.ts
@@ -1,0 +1,101 @@
+import { getRepository } from '@server/datasource';
+import DeclineReason from '@server/entity/DeclineReason';
+import { Permission } from '@server/lib/permissions';
+import logger from '@server/logger';
+import { isAuthenticated } from '@server/middleware/auth';
+import { Router } from 'express';
+
+const declineReasonsRoutes = Router();
+
+// Get all custom decline reasons
+declineReasonsRoutes.get('/', async (_req, res, next) => {
+  try {
+    const declineReasonRepository = getRepository(DeclineReason);
+    const reasons = await declineReasonRepository.find({
+      order: { createdAt: 'ASC' },
+    });
+
+    return res.status(200).json(reasons);
+  } catch (e) {
+    logger.error('Something went wrong retrieving decline reasons', {
+      label: 'API',
+      errorMessage: e.message,
+    });
+    next({ status: 500, message: 'Unable to retrieve decline reasons.' });
+  }
+});
+
+// Create a new custom decline reason
+declineReasonsRoutes.post<never, DeclineReason, { reason: string }>(
+  '/',
+  isAuthenticated(Permission.ADMIN),
+  async (req, res, next) => {
+    try {
+      const { reason } = req.body;
+
+      if (!reason || !reason.trim()) {
+        return next({ status: 400, message: 'Reason is required.' });
+      }
+
+      const declineReasonRepository = getRepository(DeclineReason);
+
+      // Check if reason already exists
+      const existingReason = await declineReasonRepository.findOne({
+        where: { reason: reason.trim() },
+      });
+
+      if (existingReason) {
+        return next({
+          status: 409,
+          message: 'This decline reason already exists.',
+        });
+      }
+
+      const newReason = new DeclineReason({
+        reason: reason.trim(),
+      });
+
+      await declineReasonRepository.save(newReason);
+
+      return res.status(201).json(newReason);
+    } catch (e) {
+      logger.error('Something went wrong creating decline reason', {
+        label: 'API',
+        errorMessage: e.message,
+      });
+      next({ status: 500, message: 'Unable to create decline reason.' });
+    }
+  }
+);
+
+// Delete a custom decline reason
+declineReasonsRoutes.delete<{ reasonId: string }>(
+  '/:reasonId',
+  isAuthenticated(Permission.ADMIN),
+  async (req, res, next) => {
+    try {
+      const declineReasonRepository = getRepository(DeclineReason);
+      const reasonId = Number(req.params.reasonId);
+
+      const reason = await declineReasonRepository.findOne({
+        where: { id: reasonId },
+      });
+
+      if (!reason) {
+        return next({ status: 404, message: 'Decline reason not found.' });
+      }
+
+      await declineReasonRepository.remove(reason);
+
+      return res.status(204).send();
+    } catch (e) {
+      logger.error('Something went wrong deleting decline reason', {
+        label: 'API',
+        errorMessage: e.message,
+      });
+      next({ status: 500, message: 'Unable to delete decline reason.' });
+    }
+  }
+);
+
+export default declineReasonsRoutes;

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -32,6 +32,7 @@ import { rescheduleJob } from 'node-schedule';
 import path from 'path';
 import semver from 'semver';
 import { URL } from 'url';
+import declineReasonsRoutes from './declineReasons';
 import notificationRoutes from './notifications';
 import radarrRoutes from './radarr';
 import sonarrRoutes from './sonarr';
@@ -42,6 +43,7 @@ settingsRoutes.use('/notifications', notificationRoutes);
 settingsRoutes.use('/radarr', radarrRoutes);
 settingsRoutes.use('/sonarr', sonarrRoutes);
 settingsRoutes.use('/discover', discoverSettingRoutes);
+settingsRoutes.use('/decline-reasons', declineReasonsRoutes);
 
 const filteredMainSettings = (
   user: User,

--- a/src/components/DeclineReasonModal/index.tsx
+++ b/src/components/DeclineReasonModal/index.tsx
@@ -1,0 +1,265 @@
+import Button from '@app/components/Common/Button';
+import Modal from '@app/components/Common/Modal';
+import { useDeclineReasons } from '@app/hooks/useDeclineReasons';
+import globalMessages from '@app/i18n/globalMessages';
+import { Transition } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/solid';
+import type { MediaRequest } from '@server/entity/MediaRequest';
+import type { MovieDetails } from '@server/models/Movie';
+import type { TvDetails } from '@server/models/Tv';
+import axios from 'axios';
+import type React from 'react';
+import { useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import { useToasts } from 'react-toast-notifications';
+import useSWR, { mutate } from 'swr';
+
+const messages = defineMessages({
+  declineRequestTitle: 'Decline Request',
+  declineRequest4kTitle: 'Decline 4K Request',
+  declineReason: 'Decline Reason',
+  customReason: 'Custom Reason',
+  customReasonPlaceholder: 'Enter a custom decline reason…',
+  declineWithReason: 'Decline With Reason',
+  requestDeclined: 'Request for <strong>{title}</strong> declined.',
+  errorDeclining: 'Something went wrong while declining the request.',
+  presetSaved: 'Decline reason saved as preset.',
+  presetSaveFailed: 'Failed to save preset.',
+  presetDeleted: 'Preset deleted successfully.',
+  presetDeleteFailed: 'Failed to delete preset.',
+  removePreset: 'Remove Preset',
+  quickReasons: 'Quick Reasons',
+  saveAsPresetLabel: 'Save as preset for future use',
+});
+
+interface DeclineReasonModalProps {
+  request: MediaRequest;
+  onCancel: () => void;
+  onComplete: () => void;
+}
+
+const DeclineReasonModal = ({
+  request,
+  onCancel,
+  onComplete,
+}: DeclineReasonModalProps) => {
+  const intl = useIntl();
+  const { addToast } = useToasts();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [customReason, setCustomReason] = useState('');
+  const [saveAsPreset, setSaveAsPreset] = useState(false);
+  const { customReasons, addCustomReason, removeCustomReason } =
+    useDeclineReasons();
+
+  const { data: mediaData } = useSWR<MovieDetails | TvDetails>(
+    request.type === 'movie'
+      ? `/api/v1/movie/${request.media.tmdbId}`
+      : `/api/v1/tv/${request.media.tmdbId}`
+  );
+
+  const isMovie = (media: MovieDetails | TvDetails): media is MovieDetails => {
+    return (media as MovieDetails).title !== undefined;
+  };
+
+  const getMediaTitle = () => {
+    if (!mediaData) return '';
+    return isMovie(mediaData) ? mediaData.title : mediaData.name;
+  };
+
+  const getMediaYear = () => {
+    if (!mediaData) return '';
+    const date = isMovie(mediaData)
+      ? mediaData.releaseDate
+      : mediaData.firstAirDate;
+    return date ? ` (${date.slice(0, 4)})` : '';
+  };
+
+  const declineWithReason = async (reason: string) => {
+    setIsSubmitting(true);
+
+    try {
+      await axios.post(`/api/v1/request/${request.id}/decline`, {
+        reason: reason.trim(),
+      });
+
+      // Immediately revalidate the request data and counts
+      mutate(`/api/v1/request/${request.id}`);
+      mutate('/api/v1/request/count');
+
+      addToast(
+        <span>
+          {intl.formatMessage(messages.requestDeclined, {
+            title: getMediaTitle(),
+            strong: (msg: React.ReactNode) => <strong>{msg}</strong>,
+          })}
+        </span>,
+        { appearance: 'success', autoDismiss: true }
+      );
+
+      onComplete();
+    } catch (error) {
+      addToast(intl.formatMessage(messages.errorDeclining), {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCustomReasonSubmit = async () => {
+    if (customReason.trim()) {
+      if (saveAsPreset) {
+        try {
+          await addCustomReason(customReason.trim());
+          addToast(intl.formatMessage(messages.presetSaved), {
+            appearance: 'success',
+            autoDismiss: true,
+          });
+        } catch (error) {
+          addToast(intl.formatMessage(messages.presetSaveFailed), {
+            appearance: 'error',
+            autoDismiss: true,
+          });
+        }
+      }
+
+      declineWithReason(customReason);
+    }
+  };
+
+  const handleDeleteCustomReason = async (reasonId: number) => {
+    try {
+      await removeCustomReason(reasonId);
+      addToast(intl.formatMessage(messages.presetDeleted), {
+        appearance: 'success',
+        autoDismiss: true,
+      });
+    } catch (error) {
+      addToast(intl.formatMessage(messages.presetDeleteFailed), {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    }
+  };
+
+  return (
+    <Transition
+      as="div"
+      enter="transition-opacity duration-300"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave="transition-opacity duration-300"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+      show={true}
+    >
+      <Modal
+        title={intl.formatMessage(
+          request.is4k
+            ? messages.declineRequest4kTitle
+            : messages.declineRequestTitle
+        )}
+        subTitle={`${getMediaTitle()}${getMediaYear()}`}
+        onCancel={onCancel}
+        cancelText={intl.formatMessage(globalMessages.cancel)}
+        backdrop={
+          mediaData &&
+          `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${
+            isMovie(mediaData) ? mediaData.backdropPath : mediaData.backdropPath
+          }`
+        }
+      >
+        <div className="space-y-6">
+          <div>
+            <h3 className="mb-4 text-lg font-medium leading-6 text-gray-100">
+              {intl.formatMessage(messages.declineReason)}
+            </h3>
+
+            {/* Preset Reasons */}
+            <div className="space-y-3">
+              <div className="text-sm font-medium text-gray-200">
+                {intl.formatMessage(messages.quickReasons)}
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {customReasons.map((customReason) => (
+                  <div
+                    key={customReason.id}
+                    className="relative flex items-center rounded-md border border-gray-600 bg-gray-800 transition-colors duration-200 focus-within:border-indigo-500 focus-within:ring-2 focus-within:ring-indigo-500 hover:bg-gray-700"
+                  >
+                    <button
+                      type="button"
+                      className="flex flex-grow items-center justify-start px-4 py-3 text-sm font-medium text-gray-300 hover:text-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => declineWithReason(customReason.reason)}
+                      disabled={isSubmitting}
+                    >
+                      {customReason.reason}
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 p-2 text-gray-400 hover:text-red-400 focus:outline-none"
+                      onClick={() => handleDeleteCustomReason(customReason.id)}
+                      title={intl.formatMessage(messages.removePreset)}
+                    >
+                      <XMarkIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Custom Reason */}
+          <div className="space-y-3">
+            <label className="block text-sm font-medium text-gray-200">
+              {intl.formatMessage(messages.customReason)}
+            </label>
+            <div className="space-y-3">
+              <textarea
+                className="block w-full rounded-md border border-gray-500 bg-gray-700 px-3 py-2 text-white placeholder-gray-400 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                rows={3}
+                placeholder={intl.formatMessage(
+                  messages.customReasonPlaceholder
+                )}
+                value={customReason}
+                onChange={(e) => setCustomReason(e.target.value)}
+                disabled={isSubmitting}
+              />
+
+              {/* Save as Preset Checkbox */}
+              <div className="flex items-center">
+                <input
+                  id="save-as-preset"
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-gray-500 bg-gray-700 text-indigo-600 focus:ring-2 focus:ring-indigo-500"
+                  checked={saveAsPreset}
+                  onChange={(e) => setSaveAsPreset(e.target.checked)}
+                  disabled={isSubmitting}
+                />
+                <label
+                  htmlFor="save-as-preset"
+                  className="ml-2 text-sm text-gray-300"
+                >
+                  {intl.formatMessage(messages.saveAsPresetLabel)}
+                </label>
+              </div>
+
+              <Button
+                buttonType="danger"
+                onClick={handleCustomReasonSubmit}
+                disabled={!customReason.trim() || isSubmitting}
+                className="w-full sm:w-auto"
+              >
+                {isSubmitting
+                  ? intl.formatMessage(globalMessages.declining)
+                  : intl.formatMessage(globalMessages.decline)}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  );
+};
+
+export default DeclineReasonModal;

--- a/src/components/RequestButton/index.tsx
+++ b/src/components/RequestButton/index.tsx
@@ -1,9 +1,15 @@
+import Button from '@app/components/Common/Button';
 import ButtonWithDropdown from '@app/components/Common/ButtonWithDropdown';
+import DeclineReasonModal from '@app/components/DeclineReasonModal';
 import RequestModal from '@app/components/RequestModal';
+import { useDeclineReasons } from '@app/hooks/useDeclineReasons';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
-import { ArrowDownTrayIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowDownTrayIcon,
+  DocumentTextIcon,
+} from '@heroicons/react/24/outline';
 import {
   CheckIcon,
   InformationCircleIcon,
@@ -26,6 +32,7 @@ const messages = defineMessages({
   approverequest4k: 'Approve 4K Request',
   declinerequest: 'Decline Request',
   declinerequest4k: 'Decline 4K Request',
+  declinewithreason: 'Decline With Reason',
   approverequests:
     'Approve {requestCount, plural, one {Request} other {{requestCount} Requests}}',
   declinerequests:
@@ -66,6 +73,12 @@ const RequestButton = ({
   const [showRequestModal, setShowRequestModal] = useState(false);
   const [showRequest4kModal, setShowRequest4kModal] = useState(false);
   const [editRequest, setEditRequest] = useState(false);
+  const [showDeclineModal, setShowDeclineModal] = useState(false);
+  const [declineRequest, setDeclineRequest] = useState<MediaRequest | null>(
+    null
+  );
+
+  useDeclineReasons();
 
   // All pending requests
   const activeRequests = media?.requests.filter(
@@ -162,6 +175,15 @@ const RequestButton = ({
             modifyRequest(activeRequest, 'decline');
           },
           svg: <XMarkIcon />,
+        },
+        {
+          id: 'decline-request-with-reason',
+          text: intl.formatMessage(messages.declinewithreason),
+          action: () => {
+            setDeclineRequest(activeRequest);
+            setShowDeclineModal(true);
+          },
+          svg: <XMarkIcon />,
         }
       );
     } else if (
@@ -230,6 +252,15 @@ const RequestButton = ({
           text: intl.formatMessage(messages.declinerequest4k),
           action: () => {
             modifyRequest(active4kRequest, 'decline');
+          },
+          svg: <XMarkIcon />,
+        },
+        {
+          id: 'decline-4k-request-with-reason',
+          text: intl.formatMessage(messages.declinewithreason),
+          action: () => {
+            setDeclineRequest(active4kRequest);
+            setShowDeclineModal(true);
           },
           svg: <XMarkIcon />,
         }
@@ -387,28 +418,77 @@ const RequestButton = ({
         }}
         onCancel={() => setShowRequest4kModal(false)}
       />
-      <ButtonWithDropdown
-        text={
-          <>
-            {buttonOne.svg}
-            <span>{buttonOne.text}</span>
-          </>
-        }
-        onClick={buttonOne.action}
-        className="ml-2"
-      >
-        {others && others.length > 0
-          ? others.map((button) => (
-              <ButtonWithDropdown.Item
-                onClick={button.action}
-                key={`request-option-${button.id}`}
-              >
-                {button.svg}
-                <span>{button.text}</span>
-              </ButtonWithDropdown.Item>
-            ))
-          : null}
-      </ButtonWithDropdown>
+      {showDeclineModal && declineRequest && (
+        <DeclineReasonModal
+          request={declineRequest}
+          onCancel={() => {
+            setShowDeclineModal(false);
+            setDeclineRequest(null);
+          }}
+          onComplete={() => {
+            setShowDeclineModal(false);
+            setDeclineRequest(null);
+            onUpdate();
+          }}
+        />
+      )}
+      {buttons.length === 1 ? (
+        <Button
+          buttonType="primary"
+          onClick={buttonOne.action}
+          className="ml-2"
+        >
+          {buttonOne.svg}
+          <span>{buttonOne.text}</span>
+        </Button>
+      ) : buttons.length === 2 &&
+        buttons[0].id.includes('decline') &&
+        buttons[1].id.includes('decline-') &&
+        buttons[1].id.includes('-with-reason') ? (
+        // Special case: decline + decline with reason - render side by side
+        <div className="ml-2 flex">
+          <Button
+            buttonType="danger"
+            onClick={buttons[0].action}
+            className="flex-grow"
+          >
+            {buttons[0].svg}
+            <span>{buttons[0].text}</span>
+          </Button>
+          <Button
+            buttonType="danger"
+            onClick={buttons[1].action}
+            className="w-8 px-2"
+            style={{ marginLeft: '8px' }}
+            title={intl.formatMessage(messages.declinewithreason)}
+          >
+            <DocumentTextIcon className="h-4 w-4" />
+          </Button>
+        </div>
+      ) : (
+        <ButtonWithDropdown
+          text={
+            <>
+              {buttonOne.svg}
+              <span>{buttonOne.text}</span>
+            </>
+          }
+          onClick={buttonOne.action}
+          className="ml-2"
+        >
+          {others && others.length > 0
+            ? others.map((button) => (
+                <ButtonWithDropdown.Item
+                  onClick={button.action}
+                  key={`request-option-${button.id}`}
+                >
+                  {button.svg}
+                  <span>{button.text}</span>
+                </ButtonWithDropdown.Item>
+              ))
+            : null}
+        </ButtonWithDropdown>
+      )}
     </>
   );
 };

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -2,13 +2,16 @@ import Badge from '@app/components/Common/Badge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import Tooltip from '@app/components/Common/Tooltip';
+import DeclineReasonModal from '@app/components/DeclineReasonModal';
 import RequestModal from '@app/components/RequestModal';
 import StatusBadge from '@app/components/StatusBadge';
+import { useDeclineReasons } from '@app/hooks/useDeclineReasons';
 import useDeepLinks from '@app/hooks/useDeepLinks';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import { withProperties } from '@app/utils/typeHelpers';
+import { DocumentTextIcon } from '@heroicons/react/24/outline';
 import {
   ArrowPathIcon,
   CheckIcon,
@@ -22,7 +25,7 @@ import type { MovieDetails } from '@server/models/Movie';
 import type { TvDetails } from '@server/models/Tv';
 import axios from 'axios';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
@@ -36,6 +39,7 @@ const messages = defineMessages({
   tvdbid: 'TheTVDB ID',
   approverequest: 'Approve Request',
   declinerequest: 'Decline Request',
+  declinewithreason: 'Decline With Reason',
   editrequest: 'Edit Request',
   cancelrequest: 'Cancel Request',
   deleterequest: 'Delete Request',
@@ -63,6 +67,57 @@ interface RequestCardErrorProps {
 const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
   const { hasPermission } = useUser();
   const intl = useIntl();
+  const [isTextTruncated, setIsTextTruncated] = useState(false);
+  const textElementRef = useRef<HTMLSpanElement>(null);
+
+  const getDeclineText = (reason: string) =>
+    `${intl.formatMessage(globalMessages.declined)} - ${reason}`;
+
+  const checkTruncation = useCallback(() => {
+    if (textElementRef.current) {
+      const element = textElementRef.current;
+      const isOverflowing = element.scrollWidth > element.clientWidth;
+      setIsTextTruncated(isOverflowing);
+    }
+  }, []);
+
+  const setTextElementRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (textElementRef.current !== node) {
+        (
+          textElementRef as React.MutableRefObject<HTMLSpanElement | null>
+        ).current = node;
+        if (node) {
+          setTimeout(() => {
+            checkTruncation();
+          }, 0);
+        }
+      }
+    },
+    [checkTruncation]
+  );
+
+  useEffect(() => {
+    if (requestData?.declineReason) {
+      const timeoutId = setTimeout(() => {
+        checkTruncation();
+      }, 0);
+
+      // Use ResizeObserver to detect when container size changes
+      const resizeObserver = new ResizeObserver(() => {
+        checkTruncation();
+      });
+
+      if (textElementRef.current) {
+        resizeObserver.observe(textElementRef.current);
+      }
+
+      return () => {
+        clearTimeout(timeoutId);
+        resizeObserver.disconnect();
+      };
+    }
+  }, [checkTruncation, requestData?.declineReason]);
 
   const { plexUrl, plexUrl4k } = useDeepLinks({
     plexUrl: requestData?.media?.plexUrl,
@@ -127,11 +182,46 @@ const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
                   </span>
                   {requestData.status === MediaRequestStatus.DECLINED ||
                   requestData.status === MediaRequestStatus.FAILED ? (
-                    <Badge badgeType="danger">
-                      {requestData.status === MediaRequestStatus.DECLINED
-                        ? intl.formatMessage(globalMessages.declined)
-                        : intl.formatMessage(globalMessages.failed)}
-                    </Badge>
+                    requestData.status === MediaRequestStatus.DECLINED ? (
+                      requestData.declineReason ? (
+                        <>
+                          {isTextTruncated ? (
+                            <Tooltip
+                              content={getDeclineText(
+                                requestData.declineReason
+                              )}
+                              className="!rounded-full !border-red-700 !bg-red-600 !px-2 !py-1 !text-xs !font-semibold !text-white"
+                            >
+                              <Badge badgeType="danger" className="min-w-0">
+                                <span
+                                  ref={setTextElementRef}
+                                  className="truncate"
+                                >
+                                  {getDeclineText(requestData.declineReason)}
+                                </span>
+                              </Badge>
+                            </Tooltip>
+                          ) : (
+                            <Badge badgeType="danger" className="min-w-0 !px-2">
+                              <span
+                                ref={setTextElementRef}
+                                className="block truncate"
+                              >
+                                {getDeclineText(requestData.declineReason)}
+                              </span>
+                            </Badge>
+                          )}
+                        </>
+                      ) : (
+                        <Badge badgeType="danger">
+                          {intl.formatMessage(globalMessages.declined)}
+                        </Badge>
+                      )
+                    ) : (
+                      <Badge badgeType="danger">
+                        {intl.formatMessage(globalMessages.failed)}
+                      </Badge>
+                    )
                   ) : (
                     <StatusBadge
                       status={
@@ -218,6 +308,39 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
   const { addToast } = useToasts();
   const [isRetrying, setRetrying] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showDeclineModal, setShowDeclineModal] = useState(false);
+  const [isTextTruncated, setIsTextTruncated] = useState(false);
+  const textElementRef = useRef<HTMLSpanElement>(null);
+
+  useDeclineReasons();
+
+  const getDeclineText = (reason: string) =>
+    `${intl.formatMessage(globalMessages.declined)} - ${reason}`;
+
+  const checkTruncation = useCallback(() => {
+    if (textElementRef.current) {
+      const element = textElementRef.current;
+      const isOverflowing = element.scrollWidth > element.clientWidth;
+      setIsTextTruncated(isOverflowing);
+    }
+  }, []);
+
+  const setTextElementRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (textElementRef.current !== node) {
+        (
+          textElementRef as React.MutableRefObject<HTMLSpanElement | null>
+        ).current = node;
+        if (node) {
+          setTimeout(() => {
+            checkTruncation();
+          }, 0);
+        }
+      }
+    },
+    [checkTruncation]
+  );
+
   const url =
     request.type === 'movie'
       ? `/api/v1/movie/${request.media.tmdbId}`
@@ -240,6 +363,28 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
       15000
     ),
   });
+
+  useEffect(() => {
+    if (requestData?.declineReason) {
+      const timeoutId = setTimeout(() => {
+        checkTruncation();
+      }, 0);
+
+      // Use ResizeObserver to detect when container size changes
+      const resizeObserver = new ResizeObserver(() => {
+        checkTruncation();
+      });
+
+      if (textElementRef.current) {
+        resizeObserver.observe(textElementRef.current);
+      }
+
+      return () => {
+        clearTimeout(timeoutId);
+        resizeObserver.disconnect();
+      };
+    }
+  }, [checkTruncation, requestData?.declineReason]);
 
   const { plexUrl, plexUrl4k } = useDeepLinks({
     plexUrl: requestData?.media?.plexUrl,
@@ -297,7 +442,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
   }
 
   if (!requestData && !requestError) {
-    return <RequestCardError />;
+    return <RequestCardError requestData={request} />;
   }
 
   if (!title || !requestData) {
@@ -318,6 +463,17 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
           setShowEditModal(false);
         }}
       />
+      {showDeclineModal && (
+        <DeclineReasonModal
+          request={requestData}
+          onCancel={() => setShowDeclineModal(false)}
+          onComplete={() => {
+            setShowDeclineModal(false);
+            revalidate();
+            mutate('/api/v1/request/count');
+          }}
+        />
+      )}
       <div
         className="relative flex w-72 overflow-hidden rounded-xl bg-gray-800 bg-cover bg-center p-4 text-gray-400 shadow ring-1 ring-gray-700 sm:w-96"
         data-testid="request-card"
@@ -407,9 +563,35 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
               {intl.formatMessage(globalMessages.status)}
             </span>
             {requestData.status === MediaRequestStatus.DECLINED ? (
-              <Badge badgeType="danger">
-                {intl.formatMessage(globalMessages.declined)}
-              </Badge>
+              requestData.declineReason ? (
+                <>
+                  {isTextTruncated ? (
+                    <Tooltip
+                      content={getDeclineText(requestData.declineReason)}
+                      className="!rounded-full !border-red-700 !bg-red-600 !px-2 !py-1 !text-xs !font-semibold !text-white"
+                    >
+                      <Badge badgeType="danger" className="min-w-0 !px-2">
+                        <span
+                          ref={setTextElementRef}
+                          className="block truncate"
+                        >
+                          {getDeclineText(requestData.declineReason)}
+                        </span>
+                      </Badge>
+                    </Tooltip>
+                  ) : (
+                    <Badge badgeType="danger" className="min-w-0 !px-2">
+                      <span ref={setTextElementRef} className="block truncate">
+                        {getDeclineText(requestData.declineReason)}
+                      </span>
+                    </Badge>
+                  )}
+                </>
+              ) : (
+                <Badge badgeType="danger">
+                  {intl.formatMessage(globalMessages.declined)}
+                </Badge>
+              )
             ) : requestData.status === MediaRequestStatus.FAILED ? (
               <Badge
                 badgeType="danger"
@@ -500,28 +682,54 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
                       </Button>
                     </Tooltip>
                   </div>
-                  <div>
-                    <Button
-                      buttonType="danger"
-                      buttonSize="sm"
-                      className="hidden sm:block"
-                      onClick={() => modifyRequest('decline')}
-                    >
-                      <XMarkIcon />
-                      <span>{intl.formatMessage(globalMessages.decline)}</span>
-                    </Button>
-                    <Tooltip
-                      content={intl.formatMessage(messages.declinerequest)}
-                    >
+                  <div className="flex">
+                    {/* Desktop two buttons */}
+                    <div className="hidden sm:flex">
                       <Button
                         buttonType="danger"
                         buttonSize="sm"
-                        className="sm:hidden"
+                        className="flex-grow"
                         onClick={() => modifyRequest('decline')}
                       >
                         <XMarkIcon />
+                        <span>
+                          {intl.formatMessage(globalMessages.decline)}
+                        </span>
                       </Button>
-                    </Tooltip>
+                      <Button
+                        buttonType="danger"
+                        buttonSize="sm"
+                        className="ml-1 w-8 px-2"
+                        onClick={() => setShowDeclineModal(true)}
+                        title={intl.formatMessage(messages.declinewithreason)}
+                      >
+                        <DocumentTextIcon className="h-4 w-4" />
+                      </Button>
+                    </div>
+
+                    {/* Mobile buttons */}
+                    <div className="flex sm:hidden">
+                      <Tooltip
+                        content={intl.formatMessage(messages.declinerequest)}
+                      >
+                        <Button
+                          buttonType="danger"
+                          buttonSize="sm"
+                          onClick={() => modifyRequest('decline')}
+                        >
+                          <XMarkIcon />
+                        </Button>
+                      </Tooltip>
+                      <Button
+                        buttonType="danger"
+                        buttonSize="sm"
+                        className="ml-1 w-8 px-2"
+                        onClick={() => setShowDeclineModal(true)}
+                        title={intl.formatMessage(messages.declinewithreason)}
+                      >
+                        <DocumentTextIcon className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
                 </>
               )}

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -2,12 +2,16 @@ import Badge from '@app/components/Common/Badge';
 import Button from '@app/components/Common/Button';
 import CachedImage from '@app/components/Common/CachedImage';
 import ConfirmButton from '@app/components/Common/ConfirmButton';
+import Tooltip from '@app/components/Common/Tooltip';
+import DeclineReasonModal from '@app/components/DeclineReasonModal';
 import RequestModal from '@app/components/RequestModal';
 import StatusBadge from '@app/components/StatusBadge';
+import { useDeclineReasons } from '@app/hooks/useDeclineReasons';
 import useDeepLinks from '@app/hooks/useDeepLinks';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
+import { DocumentTextIcon } from '@heroicons/react/24/outline';
 import {
   ArrowPathIcon,
   CheckIcon,
@@ -21,7 +25,7 @@ import type { MovieDetails } from '@server/models/Movie';
 import type { TvDetails } from '@server/models/Tv';
 import axios from 'axios';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { defineMessages, FormattedRelativeTime, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
@@ -38,6 +42,7 @@ const messages = defineMessages({
   editrequest: 'Edit Request',
   deleterequest: 'Delete Request',
   cancelRequest: 'Cancel Request',
+  declinewithreason: 'Decline With Reason',
   tmdbid: 'TMDB ID',
   tvdbid: 'TheTVDB ID',
   unknowntitle: 'Unknown Title',
@@ -58,6 +63,57 @@ const RequestItemError = ({
 }: RequestItemErrorProps) => {
   const intl = useIntl();
   const { hasPermission } = useUser();
+  const [isTextTruncated, setIsTextTruncated] = useState(false);
+  const textElementRef = useRef<HTMLSpanElement>(null);
+
+  const getDeclineText = (reason: string) =>
+    `${intl.formatMessage(globalMessages.declined)} - ${reason}`;
+
+  const checkTruncation = useCallback(() => {
+    if (textElementRef.current) {
+      const element = textElementRef.current;
+      const isOverflowing = element.scrollWidth > element.clientWidth;
+      setIsTextTruncated(isOverflowing);
+    }
+  }, []);
+
+  const setTextElementRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (textElementRef.current !== node) {
+        (
+          textElementRef as React.MutableRefObject<HTMLSpanElement | null>
+        ).current = node;
+        if (node) {
+          setTimeout(() => {
+            checkTruncation();
+          }, 0);
+        }
+      }
+    },
+    [checkTruncation]
+  );
+
+  useEffect(() => {
+    if (requestData?.declineReason) {
+      const timeoutId = setTimeout(() => {
+        checkTruncation();
+      }, 0);
+
+      // Use ResizeObserver to detect when container size changes
+      const resizeObserver = new ResizeObserver(() => {
+        checkTruncation();
+      });
+
+      if (textElementRef.current) {
+        resizeObserver.observe(textElementRef.current);
+      }
+
+      return () => {
+        clearTimeout(timeoutId);
+        resizeObserver.disconnect();
+      };
+    }
+  }, [checkTruncation, requestData?.declineReason]);
 
   const deleteRequest = async () => {
     await axios.delete(`/api/v1/media/${requestData?.media.id}`);
@@ -119,11 +175,41 @@ const RequestItemError = ({
                 </span>
                 {requestData.status === MediaRequestStatus.DECLINED ||
                 requestData.status === MediaRequestStatus.FAILED ? (
-                  <Badge badgeType="danger">
-                    {requestData.status === MediaRequestStatus.DECLINED
-                      ? intl.formatMessage(globalMessages.declined)
-                      : intl.formatMessage(globalMessages.failed)}
-                  </Badge>
+                  requestData.status === MediaRequestStatus.DECLINED ? (
+                    requestData.declineReason ? (
+                      <>
+                        {isTextTruncated ? (
+                          <Tooltip
+                            content={getDeclineText(requestData.declineReason)}
+                            className="!rounded-full !border-red-700 !bg-red-600 !px-2 !py-1 !text-xs !font-semibold !text-white"
+                          >
+                            <Badge badgeType="danger" className="min-w-0">
+                              <span
+                                ref={setTextElementRef}
+                                className="truncate"
+                              >
+                                {getDeclineText(requestData.declineReason)}
+                              </span>
+                            </Badge>
+                          </Tooltip>
+                        ) : (
+                          <Badge badgeType="danger" className="min-w-0">
+                            <span ref={setTextElementRef} className="truncate">
+                              {getDeclineText(requestData.declineReason)}
+                            </span>
+                          </Badge>
+                        )}
+                      </>
+                    ) : (
+                      <Badge badgeType="danger">
+                        {intl.formatMessage(globalMessages.declined)}
+                      </Badge>
+                    )
+                  ) : (
+                    <Badge badgeType="danger">
+                      {intl.formatMessage(globalMessages.failed)}
+                    </Badge>
+                  )
                 ) : (
                   <StatusBadge
                     status={
@@ -284,6 +370,39 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
   const intl = useIntl();
   const { user, hasPermission } = useUser();
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showDeclineModal, setShowDeclineModal] = useState(false);
+  const [isTextTruncated, setIsTextTruncated] = useState(false);
+  const textElementRef = useRef<HTMLSpanElement>(null);
+
+  useDeclineReasons();
+
+  const getDeclineText = (reason: string) =>
+    `${intl.formatMessage(globalMessages.declined)} - ${reason}`;
+
+  const checkTruncation = useCallback(() => {
+    if (textElementRef.current) {
+      const element = textElementRef.current;
+      const isOverflowing = element.scrollWidth > element.clientWidth;
+      setIsTextTruncated(isOverflowing);
+    }
+  }, []);
+
+  const setTextElementRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (textElementRef.current !== node) {
+        (
+          textElementRef as React.MutableRefObject<HTMLSpanElement | null>
+        ).current = node;
+        if (node) {
+          setTimeout(() => {
+            checkTruncation();
+          }, 0);
+        }
+      }
+    },
+    [checkTruncation]
+  );
+
   const url =
     request.type === 'movie'
       ? `/api/v1/movie/${request.media.tmdbId}`
@@ -304,6 +423,28 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
       ),
     }
   );
+
+  useEffect(() => {
+    if (requestData?.declineReason) {
+      const timeoutId = setTimeout(() => {
+        checkTruncation();
+      }, 0);
+
+      // Use ResizeObserver to detect when container size changes
+      const resizeObserver = new ResizeObserver(() => {
+        checkTruncation();
+      });
+
+      if (textElementRef.current) {
+        resizeObserver.observe(textElementRef.current);
+      }
+
+      return () => {
+        clearTimeout(timeoutId);
+        resizeObserver.disconnect();
+      };
+    }
+  }, [checkTruncation, requestData?.declineReason]);
 
   const [isRetrying, setRetrying] = useState(false);
 
@@ -378,6 +519,17 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
           setShowEditModal(false);
         }}
       />
+      {showDeclineModal && (
+        <DeclineReasonModal
+          request={requestData}
+          onCancel={() => setShowDeclineModal(false)}
+          onComplete={() => {
+            setShowDeclineModal(false);
+            revalidateList();
+            mutate('/api/v1/request/count');
+          }}
+        />
+      )}
       <div className="relative flex w-full flex-col justify-between overflow-hidden rounded-xl bg-gray-800 py-4 text-gray-400 shadow-md ring-1 ring-gray-700 xl:h-28 xl:flex-row">
         {title.backdropPath && (
           <div className="absolute inset-0 z-0 w-full bg-cover bg-center xl:w-2/3">
@@ -469,9 +621,32 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                 {intl.formatMessage(globalMessages.status)}
               </span>
               {requestData.status === MediaRequestStatus.DECLINED ? (
-                <Badge badgeType="danger">
-                  {intl.formatMessage(globalMessages.declined)}
-                </Badge>
+                requestData.declineReason ? (
+                  <>
+                    {isTextTruncated ? (
+                      <Tooltip
+                        content={getDeclineText(requestData.declineReason)}
+                        className="!rounded-full !border-red-700 !bg-red-600 !px-2 !py-1 !text-xs !font-semibold !text-white"
+                      >
+                        <Badge badgeType="danger" className="min-w-0">
+                          <span ref={setTextElementRef} className="truncate">
+                            {getDeclineText(requestData.declineReason)}
+                          </span>
+                        </Badge>
+                      </Tooltip>
+                    ) : (
+                      <Badge badgeType="danger" className="min-w-0">
+                        <span ref={setTextElementRef} className="truncate">
+                          {getDeclineText(requestData.declineReason)}
+                        </span>
+                      </Badge>
+                    )}
+                  </>
+                ) : (
+                  <Badge badgeType="danger">
+                    {intl.formatMessage(globalMessages.declined)}
+                  </Badge>
+                )
               ) : requestData.status === MediaRequestStatus.FAILED ? (
                 <Badge
                   badgeType="danger"
@@ -658,14 +833,22 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                     <span>{intl.formatMessage(globalMessages.approve)}</span>
                   </Button>
                 </span>
-                <span className="w-full">
+                <span className="flex w-full">
                   <Button
-                    className="w-full"
+                    className="flex-grow"
                     buttonType="danger"
                     onClick={() => modifyRequest('decline')}
                   >
                     <XMarkIcon />
                     <span>{intl.formatMessage(globalMessages.decline)}</span>
+                  </Button>
+                  <Button
+                    className="ml-1 w-8 px-2"
+                    buttonType="danger"
+                    onClick={() => setShowDeclineModal(true)}
+                    title={intl.formatMessage(messages.declinewithreason)}
+                  >
+                    <DocumentTextIcon className="h-4 w-4" />
                   </Button>
                 </span>
               </div>

--- a/src/hooks/useDeclineReasons.ts
+++ b/src/hooks/useDeclineReasons.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { useCallback } from 'react';
+import useSWR, { mutate } from 'swr';
+
+export interface CustomDeclineReason {
+  id: number;
+  reason: string;
+  createdAt: string;
+}
+
+export const useDeclineReasons = () => {
+  const { data: customReasons, error } = useSWR<CustomDeclineReason[]>(
+    '/api/v1/settings/decline-reasons'
+  );
+
+  const addCustomReason = useCallback(async (reason: string) => {
+    await axios.post('/api/v1/settings/decline-reasons', { reason });
+    mutate('/api/v1/settings/decline-reasons');
+  }, []);
+
+  const removeCustomReason = useCallback(async (id: number) => {
+    await axios.delete(`/api/v1/settings/decline-reasons/${id}`);
+    mutate('/api/v1/settings/decline-reasons');
+  }, []);
+
+  return {
+    customReasons: customReasons || [],
+    isLoading: !customReasons && !error,
+    error,
+    addCustomReason,
+    removeCustomReason,
+  };
+};

--- a/src/i18n/globalMessages.ts
+++ b/src/i18n/globalMessages.ts
@@ -25,6 +25,7 @@ const globalMessages = defineMessages({
   canceling: 'Canceling…',
   approve: 'Approve',
   decline: 'Decline',
+  declining: 'Declining…',
   delete: 'Delete',
   retry: 'Retry',
   retrying: 'Retrying…',


### PR DESCRIPTION
Adds Decline with Reasons feature, includes custom message and saveable presets

#### Description
Adds new button next to existing Decline button that opens Decline with Reasons, presets are displayed that if clicked on immedaitely submit the form, meaning only one extra button press to add a preset reason. Custom text box with option to save as a preset for future use. Displays decline reason in Declined badge (truncated with tooltip for long messages/small screens) and also intergrated into notifications.

#### Screenshot (if UI-related)
![desktop example - frame at 0m0s](https://github.com/user-attachments/assets/efe6f07c-54c8-499e-be64-9f481b377d64)
![desktop example - frame at 0m31s](https://github.com/user-attachments/assets/64e2dab7-6376-4d9f-a0a5-fc4131622811)
![desktop example - frame at 1m10s](https://github.com/user-attachments/assets/3e8e34ca-86b2-42d3-893e-2cc520d3bdbf)
![mobile example - frame at 0m0s](https://github.com/user-attachments/assets/200e9ac9-9eee-4ad9-bf87-b52b23733e5c)
![mobile example - frame at 0m3s](https://github.com/user-attachments/assets/eca7e540-8da2-48b6-b7ee-8f4ff687e3ca)
![mobile example - frame at 0m8s](https://github.com/user-attachments/assets/496c48cb-0498-4906-aa5d-9ffd1e1a727c)
![mobile example - frame at 0m16s](https://github.com/user-attachments/assets/f1b2c370-219a-47dd-b1ba-bf01f443eb25)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [] Database migration (if required)

#### Issues Fixed or Closed

#4184 , #2270 , #593 

