### PR TITLE
Fix mobile-web-app-capable warning

### DIFF
--- a/src/components/PWAHeader/index.tsx
+++ b/src/components/PWAHeader/index.tsx
@@ -152,7 +152,7 @@ const PWAHeader = ({ applicationTitle = 'Overseerr' }: PWAHeaderProps) => {
         href="/apple-splash-1136-640.jpg"
         media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
       />
-      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <meta name="mobile-web-app-capable" content="yes" />
       <meta
         name="apple-mobile-web-app-status-bar-style"
         content="black-translucent"


### PR DESCRIPTION
#### Description

`<meta name="apple-mobile-web-app-capable" content="yes">` is deprecated. `<meta name="mobile-web-app-capable" content="yes">` should be used instead.

This causes a browser warning.

#### Screenshot (if UI-related)

<img width="559" height="148" alt="image" src="https://github.com/user-attachments/assets/7493e3d6-4fdc-4e85-a467-dad3dba6e1ba" />

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
