### PR TITLE
fix(api): update Plex Watchlist URL

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -291,7 +291,7 @@ class PlexTvAPI extends ExternalAPI {
           headers: {
             'If-None-Match': cachedWatchlist?.etag,
           },
-          baseURL: 'https://metadata.provider.plex.tv',
+          baseURL: 'https://discover.provider.plex.tv',
           validateStatus: (status) => status < 400, // Allow HTTP 304 to return without error
         }
       );
@@ -315,7 +315,7 @@ class PlexTvAPI extends ExternalAPI {
             const detailedResponse = await this.getRolling<MetadataResponse>(
               `/library/metadata/${watchlistItem.ratingKey}`,
               {
-                baseURL: 'https://metadata.provider.plex.tv',
+                baseURL: 'https://discover.provider.plex.tv',
               }
             );
 


### PR DESCRIPTION
#### Description
This PR updates the Plex watchlist base URL to the new endpoint, replacing the deprecated one.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
