### PR TITLE
fix: delete endpoint on push notification disable

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -230,15 +230,18 @@ router.delete<{ userId: number; endpoint: string }>(
     try {
       const userPushSubRepository = getRepository(UserPushSubscription);
 
-      const userPushSub = await userPushSubRepository.findOneOrFail({
-        relations: {
-          user: true,
-        },
+      const userPushSub = await userPushSubRepository.findOne({
+        relations: { user: true },
         where: {
           user: { id: req.params.userId },
           endpoint: req.params.endpoint,
         },
       });
+
+      // If not found, just return 204 (no content)
+      if (!userPushSub) {
+        return res.status(204).send();
+      }
 
       await userPushSubRepository.remove(userPushSub);
       return res.status(204).send();

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -107,6 +107,11 @@ const UserWebPushSettings = () => {
     try {
       await unsubscribeToPushNotifications(user?.id, endpoint);
 
+      // Delete from backend if endpoint is available
+      if (subEndpoint) {
+        await deletePushSubscriptionFromBackend(subEndpoint);
+      }
+
       localStorage.setItem('pushNotificationsEnabled', 'false');
       setWebPushEnabled(false);
       addToast(intl.formatMessage(messages.webpushhasbeendisabled), {


### PR DESCRIPTION
#### Description

Quick PR that deletes the current endpoint on the users device when disabling the push subscription. Added a check on the backend in case the endpoint doesn't match to prevent any errors. It's possible there is a scenario where the endpoint has changed due to it being refreshed.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn build`