### PR TITLE
feat: Add Genre filter for discover and search pages

### DIFF
--- a/cypress/e2e/settings/genre-selector.cy.ts
+++ b/cypress/e2e/settings/genre-selector.cy.ts
@@ -1,0 +1,281 @@
+describe('Genre Selector', () => {
+  beforeEach(() => {
+    cy.loginAsAdmin();
+    cy.intercept('/api/v1/genres/movie').as('getMovieGenres');
+    cy.intercept('/api/v1/genres/tv').as('getTvGenres');
+    cy.intercept('/api/v1/settings/main').as('getMainSettings');
+    cy.intercept('/api/v1/settings/discover').as('getDiscoverSettings');
+    cy.visit('/settings/discover');
+    cy.wait([
+      '@getMovieGenres',
+      '@getTvGenres',
+      '@getMainSettings',
+      '@getDiscoverSettings',
+    ]);
+  });
+
+  describe('Basic functionality', () => {
+    it('displays the genre selector in discover settings', () => {
+      cy.get('[data-testid="genre-selector"]').should('be.visible');
+    });
+
+    it('shows "No Exclusions" option by default', () => {
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('No Exclusions').should('be.visible');
+      });
+    });
+
+    it('opens dropdown when clicked', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__menu').should('be.visible');
+      cy.get('.react-select__option').should('have.length.greaterThan', 2);
+    });
+  });
+
+  describe('Genre selection', () => {
+    it('can select a single genre', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Action').click();
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('Action').should('be.visible');
+        cy.contains('No Exclusions').should('not.exist');
+      });
+    });
+
+    it('can select multiple genres', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Action').click();
+
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Comedy').click();
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('Action').should('be.visible');
+        cy.contains('Comedy').should('be.visible');
+      });
+    });
+
+    it('can remove selected genres', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Action').click();
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.get('.react-select__multi-value__remove').click();
+      });
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('Action').should('not.exist');
+        cy.contains('No Exclusions').should('be.visible');
+      });
+    });
+
+    it('can clear all selections by selecting "No Exclusions"', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Action').click();
+
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Comedy').click();
+
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('No Exclusions').click();
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('Action').should('not.exist');
+        cy.contains('Comedy').should('not.exist');
+        cy.contains('No Exclusions').should('be.visible');
+      });
+    });
+  });
+
+  describe('User settings mode', () => {
+    beforeEach(() => {
+      cy.loginAsUser();
+      cy.intercept('/api/v1/auth/me').as('getUser');
+      cy.intercept('/api/v1/user/*/settings/main').as('getUserSettings');
+      cy.visit('/profile/settings');
+      cy.wait([
+        '@getUser',
+        '@getUserSettings',
+        '@getMovieGenres',
+        '@getTvGenres',
+      ]);
+    });
+
+    it('displays server default option in user settings', () => {
+      cy.get('[data-testid="user-genre-selector"]').should('be.visible');
+      cy.get('[data-testid="user-genre-selector"]').click();
+
+      cy.get('.react-select__option').contains('Default').should('be.visible');
+    });
+
+    it('can select server default', () => {
+      cy.get('[data-testid="user-genre-selector"]').click();
+      cy.get('.react-select__option').contains('Default').click();
+
+      cy.get('[data-testid="user-genre-selector"]').within(() => {
+        cy.contains('Default').should('be.visible');
+      });
+    });
+
+    it('cannot remove server default option', () => {
+      cy.get('[data-testid="user-genre-selector"]').click();
+      cy.get('.react-select__option').contains('Default').click();
+
+      cy.get('[data-testid="user-genre-selector"]').within(() => {
+        cy.get('.react-select__multi-value__remove').should('not.exist');
+      });
+    });
+  });
+
+  describe('Persistence', () => {
+    it('saves and persists genre exclusions', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Action').click();
+
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Horror').click();
+
+      cy.intercept('POST', '/api/v1/settings/discover').as(
+        'saveDiscoverSettings'
+      );
+      cy.get('[data-testid="discover-settings-save"]').click();
+      cy.wait('@saveDiscoverSettings');
+
+      cy.reload();
+      cy.wait(['@getMovieGenres', '@getTvGenres', '@getDiscoverSettings']);
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('Action').should('be.visible');
+        cy.contains('Horror').should('be.visible');
+      });
+    });
+
+    it('persists "No Exclusions" selection', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Action').click();
+
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('No Exclusions').click();
+
+      cy.intercept('POST', '/api/v1/settings/discover').as(
+        'saveDiscoverSettings'
+      );
+      cy.get('[data-testid="discover-settings-save"]').click();
+      cy.wait('@saveDiscoverSettings');
+
+      cy.reload();
+      cy.wait(['@getMovieGenres', '@getTvGenres', '@getDiscoverSettings']);
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.contains('No Exclusions').should('be.visible');
+      });
+    });
+  });
+
+  describe('Genre filtering behavior', () => {
+    it('excludes selected genres from discover results', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('Horror').click();
+
+      cy.intercept('POST', '/api/v1/settings/discover').as(
+        'saveDiscoverSettings'
+      );
+      cy.get('[data-testid="discover-settings-save"]').click();
+      cy.wait('@saveDiscoverSettings');
+
+      cy.visit('/');
+      cy.intercept('/api/v1/discover/movies/popular*').as('getPopularMovies');
+      cy.wait('@getPopularMovies');
+
+      cy.get('[data-testid="title-card"]').first().click();
+      cy.get('[data-testid="movie-details"]').should('be.visible');
+
+      cy.get('[data-testid="genre-tag"]').should('not.contain', 'Horror');
+    });
+
+    it('shows all genres when "No Exclusions" is selected', () => {
+      cy.get('[data-testid="genre-selector"]').click();
+      cy.get('.react-select__option').contains('No Exclusions').click();
+
+      cy.intercept('POST', '/api/v1/settings/discover').as(
+        'saveDiscoverSettings'
+      );
+      cy.get('[data-testid="discover-settings-save"]').click();
+      cy.wait('@saveDiscoverSettings');
+
+      cy.visit('/');
+      cy.intercept('/api/v1/discover/movies/popular*').as('getPopularMovies');
+      cy.wait('@getPopularMovies');
+
+      cy.get('[data-testid="title-card"]').should('have.length.greaterThan', 0);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('is keyboard navigable', () => {
+      cy.get('[data-testid="genre-selector"]').focus();
+      cy.focused().type('{downarrow}');
+
+      cy.get('.react-select__menu').should('be.visible');
+
+      cy.focused().type('{downarrow}');
+      cy.focused().type('{enter}');
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.get('.react-select__multi-value').should('be.visible');
+      });
+    });
+
+    it('has proper ARIA attributes', () => {
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.get('[role="combobox"]').should('exist');
+        cy.get('[aria-expanded="false"]').should('exist');
+      });
+
+      cy.get('[data-testid="genre-selector"]').click();
+
+      cy.get('[data-testid="genre-selector"]').within(() => {
+        cy.get('[aria-expanded="true"]').should('exist');
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('handles API failures gracefully', () => {
+      cy.intercept('/api/v1/genres/movie', { statusCode: 500 }).as(
+        'getMovieGenresError'
+      );
+      cy.intercept('/api/v1/genres/tv', { statusCode: 500 }).as(
+        'getTvGenresError'
+      );
+
+      cy.reload();
+      cy.wait(['@getMovieGenresError', '@getTvGenresError']);
+
+      cy.get('[data-testid="genre-selector"]').should('be.visible');
+      cy.get('[data-testid="genre-selector"]').click();
+
+      cy.get('.react-select__option')
+        .contains('No Exclusions')
+        .should('be.visible');
+    });
+
+    it('handles invalid genre data', () => {
+      cy.intercept('/api/v1/genres/movie', { body: [] }).as(
+        'getEmptyMovieGenres'
+      );
+      cy.intercept('/api/v1/genres/tv', { body: [] }).as('getEmptyTvGenres');
+
+      cy.reload();
+      cy.wait(['@getEmptyMovieGenres', '@getEmptyTvGenres']);
+
+      cy.get('[data-testid="genre-selector"]').should('be.visible');
+      cy.get('[data-testid="genre-selector"]').click();
+
+      cy.get('.react-select__option')
+        .contains('No Exclusions')
+        .should('be.visible');
+    });
+  });
+});

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -69,6 +69,7 @@ interface DiscoverMovieOptions {
   voteCountLte?: string;
   originalLanguage?: string;
   genre?: string;
+  excludedGenres?: string;
   studio?: string;
   keywords?: string;
   sortBy?: SortOptions;
@@ -90,6 +91,7 @@ interface DiscoverTvOptions {
   includeEmptyReleaseDate?: boolean;
   originalLanguage?: string;
   genre?: string;
+  excludedGenres?: string;
   network?: number;
   keywords?: string;
   sortBy?: SortOptions;
@@ -100,10 +102,16 @@ interface DiscoverTvOptions {
 class TheMovieDb extends ExternalAPI {
   private region?: string;
   private originalLanguage?: string;
+  private excludedGenres?: string;
   constructor({
     region,
     originalLanguage,
-  }: { region?: string; originalLanguage?: string } = {}) {
+    excludedGenres,
+  }: {
+    region?: string;
+    originalLanguage?: string;
+    excludedGenres?: string;
+  } = {}) {
     super(
       'https://api.themoviedb.org/3',
       {
@@ -119,7 +127,44 @@ class TheMovieDb extends ExternalAPI {
     );
     this.region = region;
     this.originalLanguage = originalLanguage;
+    this.excludedGenres = excludedGenres;
   }
+
+  private filterByExcludedGenres = (
+    results: any[],
+    excludedGenres?: string
+  ): any[] => {
+    const genresToExclude = excludedGenres || this.excludedGenres;
+    if (!genresToExclude) {
+      return results;
+    }
+
+    const excludedGenreIds = genresToExclude.split('|').map(Number);
+    return results.filter((result) => {
+      // Skip filtering for items without genre_ids (like persons, collections)
+      if (!result.genre_ids || result.genre_ids.length === 0) {
+        return true;
+      }
+      return !result.genre_ids.some((genreId: number) =>
+        excludedGenreIds.includes(genreId)
+      );
+    });
+  };
+
+  private applyResultFilters = (
+    data: TmdbSearchMovieResponse | TmdbSearchTvResponse | TmdbSearchMultiResponse,
+    options: { excludedGenres?: string } = {}
+  ): typeof data => {
+    // Apply excluded genres filter
+    data.results = this.filterByExcludedGenres(data.results, options.excludedGenres);
+
+    // Future filters can be added here, for example:
+    // data.results = this.filterByRating(data.results, options.minRating);
+    // data.results = this.filterByLanguage(data.results, options.excludedLanguages);
+    // data.results = this.filterByYear(data.results, options.yearRange);
+
+    return data;
+  };
 
   public searchMulti = async ({
     query,
@@ -394,7 +439,7 @@ class TheMovieDb extends ExternalAPI {
         }
       );
 
-      return data;
+      return this.applyResultFilters(data);
     } catch (e) {
       throw new Error(`[TMDB] Failed to fetch movies by keyword: ${e.message}`);
     }
@@ -460,6 +505,7 @@ class TheMovieDb extends ExternalAPI {
     primaryReleaseDateLte,
     originalLanguage,
     genre,
+    excludedGenres,
     studio,
     keywords,
     withRuntimeGte,
@@ -506,6 +552,7 @@ class TheMovieDb extends ExternalAPI {
               ? defaultFutureDate
               : primaryReleaseDateLte,
           with_genres: genre,
+          without_genres: excludedGenres ?? this.excludedGenres,
           with_companies: studio,
           with_keywords: keywords,
           'with_runtime.gte': withRuntimeGte,
@@ -534,6 +581,7 @@ class TheMovieDb extends ExternalAPI {
     includeEmptyReleaseDate = false,
     originalLanguage,
     genre,
+    excludedGenres,
     network,
     keywords,
     withRuntimeGte,
@@ -580,6 +628,7 @@ class TheMovieDb extends ExternalAPI {
               : this.originalLanguage,
           include_null_first_air_dates: includeEmptyReleaseDate,
           with_genres: genre,
+          without_genres: excludedGenres ?? this.excludedGenres,
           with_networks: network,
           with_keywords: keywords,
           'with_runtime.gte': withRuntimeGte,
@@ -646,7 +695,7 @@ class TheMovieDb extends ExternalAPI {
         }
       );
 
-      return data;
+      return this.applyResultFilters(data);
     } catch (e) {
       throw new Error(`[TMDB] Failed to fetch all trending: ${e.message}`);
     }
@@ -669,7 +718,7 @@ class TheMovieDb extends ExternalAPI {
         }
       );
 
-      return data;
+      return this.applyResultFilters(data);
     } catch (e) {
       throw new Error(`[TMDB] Failed to fetch all trending: ${e.message}`);
     }
@@ -692,7 +741,7 @@ class TheMovieDb extends ExternalAPI {
         }
       );
 
-      return data;
+      return this.applyResultFilters(data);
     } catch (e) {
       throw new Error(`[TMDB] Failed to fetch all trending: ${e.message}`);
     }

--- a/server/entity/UserSettings.ts
+++ b/server/entity/UserSettings.ts
@@ -37,6 +37,9 @@ export class UserSettings {
   public originalLanguage?: string;
 
   @Column({ nullable: true })
+  public excludedGenres?: string;
+
+  @Column({ nullable: true })
   public pgpKey?: string;
 
   @Column({ nullable: true })

--- a/server/interfaces/api/userSettingsInterfaces.ts
+++ b/server/interfaces/api/userSettingsInterfaces.ts
@@ -6,6 +6,7 @@ export interface UserSettingsGeneralResponse {
   locale?: string;
   region?: string;
   originalLanguage?: string;
+  excludedGenres?: string;
   movieQuotaLimit?: number;
   movieQuotaDays?: number;
   tvQuotaLimit?: number;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -101,6 +101,7 @@ export interface MainSettings {
   newPlexLogin: boolean;
   region: string;
   originalLanguage: string;
+  excludedGenres: string;
   trustProxy: boolean;
   partialRequestsEnabled: boolean;
   locale: string;
@@ -298,6 +299,7 @@ class Settings {
         newPlexLogin: true,
         region: '',
         originalLanguage: '',
+        excludedGenres: '',
         trustProxy: false,
         partialRequestsEnabled: true,
         locale: 'en',

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -42,9 +42,17 @@ export const createTmdbWithRegionLanguage = (user?: User): TheMovieDb => {
       ? user?.settings?.originalLanguage
       : settings.main.originalLanguage;
 
+  const excludedGenres =
+    user?.settings?.excludedGenres === 'none'
+      ? ''
+      : user?.settings?.excludedGenres
+      ? user?.settings?.excludedGenres
+      : settings.main.excludedGenres;
+
   return new TheMovieDb({
     region,
     originalLanguage,
+    excludedGenres,
   });
 };
 
@@ -261,7 +269,7 @@ discoverRoutes.get<{ genreId: string }>(
 discoverRoutes.get<{ studioId: string }>(
   '/movies/studio/:studioId',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const studio = await tmdb.getStudio(Number(req.params.studioId));
@@ -537,7 +545,7 @@ discoverRoutes.get<{ genreId: string }>(
 discoverRoutes.get<{ networkId: string }>(
   '/tv/network/:networkId',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const network = await tmdb.getNetwork(Number(req.params.networkId));
@@ -680,7 +688,7 @@ discoverRoutes.get('/trending', async (req, res, next) => {
 discoverRoutes.get<{ keywordId: string }>(
   '/keyword/:keywordId/movies',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const data = await tmdb.getMoviesByKeyword({
@@ -724,14 +732,31 @@ discoverRoutes.get<{ keywordId: string }>(
 discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
   '/genreslider/movie',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const mappedGenres: GenreSliderItem[] = [];
 
-      const genres = await tmdb.getMovieGenres({
+      const allGenres = await tmdb.getMovieGenres({
         language: (req.query.language as string) ?? req.locale,
       });
+
+      // Filter out excluded genres
+      const settings = getSettings();
+      const user = req.user;
+      const excludedGenres =
+        user?.settings?.excludedGenres === 'none'
+          ? ''
+          : user?.settings?.excludedGenres
+          ? user?.settings?.excludedGenres
+          : settings.main.excludedGenres;
+
+      const excludedGenreIds = excludedGenres
+        ? excludedGenres.split('|').map(Number)
+        : [];
+      const genres = allGenres.filter(
+        (genre) => !excludedGenreIds.includes(genre.id)
+      );
 
       await Promise.all(
         genres.map(async (genre) => {
@@ -768,14 +793,31 @@ discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
 discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
   '/genreslider/tv',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const mappedGenres: GenreSliderItem[] = [];
 
-      const genres = await tmdb.getTvGenres({
+      const allGenres = await tmdb.getTvGenres({
         language: (req.query.language as string) ?? req.locale,
       });
+
+      // Filter out excluded genres
+      const settings = getSettings();
+      const user = req.user;
+      const excludedGenres =
+        user?.settings?.excludedGenres === 'none'
+          ? ''
+          : user?.settings?.excludedGenres
+          ? user?.settings?.excludedGenres
+          : settings.main.excludedGenres;
+
+      const excludedGenreIds = excludedGenres
+        ? excludedGenres.split('|').map(Number)
+        : [];
+      const genres = allGenres.filter(
+        (genre) => !excludedGenreIds.includes(genre.id)
+      );
 
       await Promise.all(
         genres.map(async (genre) => {

--- a/src/components/GenreSelector/__tests__/GenreSelector.test.tsx
+++ b/src/components/GenreSelector/__tests__/GenreSelector.test.tsx
@@ -1,0 +1,358 @@
+import GenreSelector from '@app/components/GenreSelector';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { SWRConfig } from 'swr';
+
+const mockGenres = [
+  { id: 28, name: 'Action' },
+  { id: 35, name: 'Comedy' },
+  { id: 18, name: 'Drama' },
+  { id: 27, name: 'Horror' },
+  { id: 10749, name: 'Romance' },
+];
+
+const MockSWRProvider = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig
+    value={{
+      provider: () =>
+        new Map([
+          ['/api/v1/genres/movie', { data: mockGenres }],
+          ['/api/v1/genres/tv', { data: mockGenres }],
+        ]),
+      dedupingInterval: 0,
+    }}
+  >
+    {children}
+  </SWRConfig>
+);
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <IntlProvider locale="en" messages={{}}>
+    <MockSWRProvider>{children}</MockSWRProvider>
+  </IntlProvider>
+);
+
+describe('GenreSelector', () => {
+  const mockSetFieldValue = jest.fn();
+
+  beforeEach(() => {
+    mockSetFieldValue.mockClear();
+  });
+
+  describe('Basic rendering', () => {
+    it('renders the genre selector', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('displays "No Exclusions" option by default', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('No Exclusions')).toBeInTheDocument();
+      });
+    });
+
+    it('displays server default option in user settings mode', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value=""
+            setFieldValue={mockSetFieldValue}
+            serverValue="28|35"
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Default \(Action, Comedy\)/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Genre selection', () => {
+    it('allows selecting individual genres', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      const selector = screen.getByRole('combobox');
+      fireEvent.focus(selector);
+      fireEvent.keyDown(selector, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const actionOption = screen.getByText('Action');
+        fireEvent.click(actionOption);
+      });
+
+      expect(mockSetFieldValue).toHaveBeenCalledWith('excludedGenres', '28');
+    });
+
+    it('allows selecting multiple genres', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="28" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      const selector = screen.getByRole('combobox');
+      fireEvent.focus(selector);
+      fireEvent.keyDown(selector, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const comedyOption = screen.getByText('Comedy');
+        fireEvent.click(comedyOption);
+      });
+
+      expect(mockSetFieldValue).toHaveBeenCalledWith('excludedGenres', '28|35');
+    });
+
+    it('handles "No Exclusions" selection in user settings', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value="28|35"
+            setFieldValue={mockSetFieldValue}
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      const selector = screen.getByRole('combobox');
+      fireEvent.focus(selector);
+      fireEvent.keyDown(selector, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const noneOption = screen.getByText('No Exclusions');
+        fireEvent.click(noneOption);
+      });
+
+      expect(mockSetFieldValue).toHaveBeenCalledWith('excludedGenres', 'none');
+    });
+
+    it('handles "No Exclusions" selection in non-user settings', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="28|35" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      const selector = screen.getByRole('combobox');
+      fireEvent.focus(selector);
+      fireEvent.keyDown(selector, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const noneOption = screen.getByText('No Exclusions');
+        fireEvent.click(noneOption);
+      });
+
+      expect(mockSetFieldValue).toHaveBeenCalledWith('excludedGenres', '');
+    });
+
+    it('handles server default selection', async () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value="28|35"
+            setFieldValue={mockSetFieldValue}
+            serverValue="18|27"
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      const selector = screen.getByRole('combobox');
+      fireEvent.focus(selector);
+      fireEvent.keyDown(selector, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const serverOption = screen.getByText(/Default \(Drama, Horror\)/);
+        fireEvent.click(serverOption);
+      });
+
+      expect(mockSetFieldValue).toHaveBeenCalledWith('excludedGenres', '');
+    });
+  });
+
+  describe('Value display', () => {
+    it('displays selected genres correctly', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="28|35" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByText('Action')).toBeInTheDocument();
+      expect(screen.getByText('Comedy')).toBeInTheDocument();
+    });
+
+    it('shows "No Exclusions" when value is empty', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByText('No Exclusions')).toBeInTheDocument();
+    });
+
+    it('shows server default in user settings mode when value is server', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value="server"
+            setFieldValue={mockSetFieldValue}
+            serverValue="28|35"
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      expect(
+        screen.getByText(/Default \(Action, Comedy\)/)
+      ).toBeInTheDocument();
+    });
+
+    it('shows "No Exclusions" in user settings when value is none', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value="none"
+            setFieldValue={mockSetFieldValue}
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      expect(screen.getByText('No Exclusions')).toBeInTheDocument();
+    });
+  });
+
+  describe('Genre deduplication', () => {
+    it('deduplicates genres by ID when movie and TV genres overlap', () => {
+      const duplicatedGenres = [
+        { id: 28, name: 'Action' },
+        { id: 35, name: 'Comedy' },
+      ];
+
+      const CustomSWRProvider = ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => (
+        <SWRConfig
+          value={{
+            provider: () =>
+              new Map([
+                ['/api/v1/genres/movie', { data: duplicatedGenres }],
+                ['/api/v1/genres/tv', { data: duplicatedGenres }],
+              ]),
+            dedupingInterval: 0,
+          }}
+        >
+          {children}
+        </SWRConfig>
+      );
+
+      render(
+        <IntlProvider locale="en" messages={{}}>
+          <CustomSWRProvider>
+            <GenreSelector value="" setFieldValue={mockSetFieldValue} />
+          </CustomSWRProvider>
+        </IntlProvider>
+      );
+
+      const selector = screen.getByRole('combobox');
+      fireEvent.focus(selector);
+      fireEvent.keyDown(selector, { key: 'ArrowDown' });
+
+      const actionOptions = screen.getAllByText('Action');
+      expect(actionOptions).toHaveLength(1);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles invalid genre IDs gracefully', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector value="999|28" setFieldValue={mockSetFieldValue} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByText('Action')).toBeInTheDocument();
+      expect(screen.queryByText('999')).not.toBeInTheDocument();
+    });
+
+    it('handles empty server value', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value="server"
+            setFieldValue={mockSetFieldValue}
+            serverValue=""
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      expect(screen.getByText(/Default \(No Exclusions\)/)).toBeInTheDocument();
+    });
+
+    it('handles undefined server value', () => {
+      render(
+        <TestWrapper>
+          <GenreSelector
+            value="server"
+            setFieldValue={mockSetFieldValue}
+            isUserSettings={true}
+          />
+        </TestWrapper>
+      );
+
+      expect(screen.getByText(/Default \(No Exclusions\)/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading states', () => {
+    it('handles loading state when genres are not available', () => {
+      const EmptySWRProvider = ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => (
+        <SWRConfig
+          value={{
+            provider: () => new Map(),
+            dedupingInterval: 0,
+          }}
+        >
+          {children}
+        </SWRConfig>
+      );
+
+      render(
+        <IntlProvider locale="en" messages={{}}>
+          <EmptySWRProvider>
+            <GenreSelector value="" setFieldValue={mockSetFieldValue} />
+          </EmptySWRProvider>
+        </IntlProvider>
+      );
+
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/GenreSelector/index.tsx
+++ b/src/components/GenreSelector/index.tsx
@@ -1,0 +1,175 @@
+import globalMessages from '@app/i18n/globalMessages';
+import type { TmdbGenre } from '@server/api/themoviedb/interfaces';
+import { sortBy } from 'lodash';
+import { useMemo } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import type { CSSObjectWithLabel } from 'react-select';
+import Select from 'react-select';
+import useSWR from 'swr';
+
+const messages = defineMessages({
+  genreDefault: 'No Exclusions',
+  genreServerDefault: 'Default ({genres})',
+});
+
+type OptionType = {
+  value: string;
+  label: string;
+  isFixed?: boolean;
+};
+
+const selectStyles = {
+  multiValueLabel: (base: CSSObjectWithLabel, props: { data: OptionType }) => {
+    return props.data?.isFixed ? { ...base, paddingRight: 6 } : base;
+  },
+  multiValueRemove: (base: CSSObjectWithLabel, props: { data: OptionType }) => {
+    return props.data?.isFixed ? { ...base, display: 'none' } : base;
+  },
+};
+
+interface GenreSelectorProps {
+  value?: string;
+  setFieldValue: (property: string, value: string) => void;
+  serverValue?: string;
+  isUserSettings?: boolean;
+}
+
+const GenreSelector = ({
+  value,
+  setFieldValue,
+  serverValue,
+  isUserSettings = false,
+}: GenreSelectorProps) => {
+  const intl = useIntl();
+  const { data: movieGenres } = useSWR<TmdbGenre[]>('/api/v1/genres/movie');
+  const { data: tvGenres } = useSWR<TmdbGenre[]>('/api/v1/genres/tv');
+
+  const allGenres = useMemo(() => {
+    if (!movieGenres || !tvGenres) return [];
+
+    // Combine and deduplicate genres by ID
+    const combined = [...movieGenres, ...tvGenres];
+    const uniqueGenres = combined.filter(
+      (genre, index, self) => self.findIndex((g) => g.id === genre.id) === index
+    );
+
+    return sortBy(uniqueGenres, 'name');
+  }, [movieGenres, tvGenres]);
+
+  const genreName = (genreId: string) =>
+    allGenres?.find((genre) => genre.id === Number(genreId))?.name ?? genreId;
+
+  const options: OptionType[] =
+    allGenres?.map((genre) => ({
+      label: genre.name,
+      value: genre.id.toString(),
+    })) ?? [];
+
+  if (isUserSettings) {
+    options.unshift({
+      value: 'server',
+      label: intl.formatMessage(messages.genreServerDefault, {
+        genres: serverValue
+          ? serverValue
+              .split('|')
+              .map((value) => genreName(value))
+              .reduce((prev, curr) =>
+                intl.formatMessage(globalMessages.delimitedlist, {
+                  a: prev,
+                  b: curr,
+                })
+              )
+          : intl.formatMessage(messages.genreDefault),
+      }),
+      isFixed: true,
+    });
+  }
+
+  options.unshift({
+    value: 'none',
+    label: intl.formatMessage(messages.genreDefault),
+    isFixed: true,
+  });
+
+  return (
+    <Select<OptionType, true>
+      options={options}
+      isMulti
+      className="react-select-container"
+      classNamePrefix="react-select"
+      value={
+        (isUserSettings && value === 'none') || (!isUserSettings && !value)
+          ? {
+              value: 'none',
+              label: intl.formatMessage(messages.genreDefault),
+              isFixed: true,
+            }
+          : (value === '' || !value || value === 'server') && isUserSettings
+          ? {
+              value: 'server',
+              label: intl.formatMessage(messages.genreServerDefault, {
+                genres: serverValue
+                  ? serverValue
+                      .split('|')
+                      .map((value) => genreName(value))
+                      .reduce((prev, curr) =>
+                        intl.formatMessage(globalMessages.delimitedlist, {
+                          a: prev,
+                          b: curr,
+                        })
+                      )
+                  : intl.formatMessage(messages.genreDefault),
+              }),
+              isFixed: true,
+            }
+          : (value
+              ?.split('|')
+              .map((id) => {
+                const matchedGenre = allGenres?.find(
+                  (genre) => genre.id === Number(id)
+                );
+
+                if (!matchedGenre) {
+                  return undefined;
+                }
+
+                return {
+                  label: matchedGenre.name,
+                  value: matchedGenre.id.toString(),
+                };
+              })
+              .filter((option) => option !== undefined) as OptionType[])
+      }
+      onChange={(value, options) => {
+        if (
+          (options &&
+            options.action === 'select-option' &&
+            options.option?.value === 'server') ||
+          value.every((v) => v.value === 'server')
+        ) {
+          return setFieldValue('excludedGenres', '');
+        }
+
+        if (
+          (options &&
+            options.action === 'select-option' &&
+            options.option?.value === 'none') ||
+          value.every((v) => v.value === 'none')
+        ) {
+          return setFieldValue('excludedGenres', isUserSettings ? 'none' : '');
+        }
+
+        setFieldValue(
+          'excludedGenres',
+          value
+            .map((genre) => genre.value)
+            .filter((v) => v !== 'none')
+            .join('|')
+        );
+      }}
+      styles={selectStyles}
+    />
+  );
+};
+
+export default GenreSelector;

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import Tooltip from '@app/components/Common/Tooltip';
+import GenreSelector from '@app/components/GenreSelector';
 import LanguageSelector from '@app/components/LanguageSelector';
 import RegionSelector from '@app/components/RegionSelector';
 import CopyButton from '@app/components/Settings/CopyButton';
@@ -35,6 +36,8 @@ const messages = defineMessages({
   regionTip: 'Filter content by regional availability',
   originallanguage: 'Discover Language',
   originallanguageTip: 'Filter content by original language',
+  excludedGenres: 'Genre Exclusions',
+  excludedGenresTip: 'Exclude content with specific genres from all pages',
   toastApiKeySuccess: 'New API key generated successfully!',
   toastApiKeyFailure: 'Something went wrong while generating a new API key.',
   toastSettingsSuccess: 'Settings saved successfully!',
@@ -131,6 +134,7 @@ const SettingsMain = () => {
             locale: data?.locale ?? 'en',
             region: data?.region,
             originalLanguage: data?.originalLanguage,
+            excludedGenres: data?.excludedGenres,
             partialRequestsEnabled: data?.partialRequestsEnabled,
             trustProxy: data?.trustProxy,
             cacheImages: data?.cacheImages,
@@ -147,6 +151,7 @@ const SettingsMain = () => {
                 locale: values.locale,
                 region: values.region,
                 originalLanguage: values.originalLanguage,
+                excludedGenres: values.excludedGenres,
                 partialRequestsEnabled: values.partialRequestsEnabled,
                 trustProxy: values.trustProxy,
                 cacheImages: values.cacheImages,
@@ -382,6 +387,22 @@ const SettingsMain = () => {
                       <LanguageSelector
                         setFieldValue={setFieldValue}
                         value={values.originalLanguage}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="excludedGenres" className="text-label">
+                    <span>{intl.formatMessage(messages.excludedGenres)}</span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.excludedGenresTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field">
+                      <GenreSelector
+                        setFieldValue={setFieldValue}
+                        value={values.excludedGenres}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
#### Description

Adds filtering to exclude genres that you might not be interested in.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Closes https://github.com/sct/overseerr/issues/3293
