### PR TITLE
feat: add setting to hide specials season and prevent requesting specials

### DIFF
--- a/cypress/config/settings.cypress.json
+++ b/cypress/config/settings.cypress.json
@@ -20,6 +20,7 @@
     "originalLanguage": "",
     "trustProxy": false,
     "partialRequestsEnabled": true,
+    "hideSpecials": false,
     "locale": "en"
   },
   "plex": {

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -126,6 +126,9 @@ components:
         partialRequestsEnabled:
           type: boolean
           example: false
+        hideSpecials:
+          type: boolean
+          example: false
         localLogin:
           type: boolean
           example: true

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -32,6 +32,7 @@ export interface PublicSettingsResponse {
   originalLanguage: string;
   partialRequestsEnabled: boolean;
   cacheImages: boolean;
+  hideSpecials: boolean;
   vapidPublic: string;
   enablePushRegistration: boolean;
   locale: string;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -104,6 +104,7 @@ export interface MainSettings {
   trustProxy: boolean;
   partialRequestsEnabled: boolean;
   locale: string;
+  hideSpecials: boolean;
 }
 
 interface PublicSettings {
@@ -126,6 +127,7 @@ interface FullPublicSettings extends PublicSettings {
   locale: string;
   emailEnabled: boolean;
   newPlexLogin: boolean;
+  hideSpecials: boolean;
 }
 
 export interface NotificationAgentConfig {
@@ -301,6 +303,7 @@ class Settings {
         trustProxy: false,
         partialRequestsEnabled: true,
         locale: 'en',
+        hideSpecials: false,
       },
       plex: {
         name: '',
@@ -507,6 +510,7 @@ class Settings {
       originalLanguage: this.data.main.originalLanguage,
       partialRequestsEnabled: this.data.main.partialRequestsEnabled,
       cacheImages: this.data.main.cacheImages,
+      hideSpecials: this.data.main.hideSpecials,
       vapidPublic: this.vapidPublic,
       enablePushRegistration: this.data.notifications.agents.webpush.enabled,
       locale: this.data.main.locale,

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -97,7 +97,9 @@ const ManageSlideOver = ({
       await axios.post(`/api/v1/media/${data.mediaInfo?.id}/available`, {
         is4k,
         ...(mediaType === 'tv' && {
-          seasons: data.seasons.filter((season) => season.seasonNumber !== 0),
+          seasons: data.seasons.filter((season) => 
+            settings.currentSettings.hideSpecials ? season.seasonNumber !== 0 : true
+          ),
         }),
       });
       revalidate();

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -201,7 +201,7 @@ const TvRequestModal = ({
           ? selectedSeasons
           : getAllSeasons().filter(
               (season) =>
-                !getAllRequestedSeasons().includes(season) && season !== 0
+                !getAllRequestedSeasons().includes(season) && (!settings.currentSettings.hideSpecials || season !== 0)
             ),
         ...overrideParams,
       });
@@ -235,7 +235,7 @@ const TvRequestModal = ({
 
   const getAllSeasons = (): number[] => {
     return (data?.seasons ?? [])
-      .filter((season) => season.episodeCount !== 0)
+      .filter((season) => season.episodeCount !== 0 && (!settings.currentSettings.hideSpecials || season.seasonNumber !== 0))
       .map((season) => season.seasonNumber);
   };
 
@@ -568,11 +568,15 @@ const TvRequestModal = ({
                 </thead>
                 <tbody className="divide-y divide-gray-700">
                   {data?.seasons
-                    .filter((season) =>
-                      !settings.currentSettings.partialRequestsEnabled
-                        ? season.episodeCount !== 0 && season.seasonNumber !== 0
-                        : season.episodeCount !== 0
-                    )
+                    .filter((season) => {
+                      if (settings.currentSettings.hideSpecials && season.seasonNumber === 0) {
+                        return false;
+                      }
+                      if (!settings.currentSettings.partialRequestsEnabled) {
+                        return season.episodeCount !== 0 && season.seasonNumber !== 0;
+                      }
+                      return season.episodeCount !== 0;
+                    })
                     .map((season) => {
                       const seasonRequest = getSeasonRequest(
                         season.seasonNumber

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -54,6 +54,8 @@ const messages = defineMessages({
   validationApplicationUrl: 'You must provide a valid URL',
   validationApplicationUrlTrailingSlash: 'URL must not end in a trailing slash',
   partialRequestsEnabled: 'Allow Partial Series Requests',
+  hideSpecials: 'Hide Specials Season',
+  hideSpecialsTip: 'Hide specials season and prevent requesting specials',
   locale: 'Display Language',
 });
 
@@ -132,6 +134,7 @@ const SettingsMain = () => {
             region: data?.region,
             originalLanguage: data?.originalLanguage,
             partialRequestsEnabled: data?.partialRequestsEnabled,
+            hideSpecials: data?.hideSpecials,
             trustProxy: data?.trustProxy,
             cacheImages: data?.cacheImages,
           }}
@@ -148,6 +151,7 @@ const SettingsMain = () => {
                 region: values.region,
                 originalLanguage: values.originalLanguage,
                 partialRequestsEnabled: values.partialRequestsEnabled,
+                hideSpecials: values.hideSpecials,
                 trustProxy: values.trustProxy,
                 cacheImages: values.cacheImages,
               });
@@ -400,6 +404,31 @@ const SettingsMain = () => {
                       name="hideAvailable"
                       onChange={() => {
                         setFieldValue('hideAvailable', !values.hideAvailable);
+                      }}
+                    />                  </div>
+                </div>
+                <div className="form-row">
+                  <label
+                    htmlFor="hideSpecials"
+                    className="checkbox-label"
+                  >
+                    <span className="mr-2">
+                      {intl.formatMessage(messages.hideSpecials)}
+                    </span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.hideSpecialsTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <Field
+                      type="checkbox"
+                      id="hideSpecials"
+                      name="hideSpecials"
+                      onChange={() => {
+                        setFieldValue(
+                          'hideSpecials',
+                          !values.hideSpecials
+                        );
                       }}
                     />
                   </div>

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -202,7 +202,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
 
   // Does NOT include "Specials"
   const seasonCount = data.seasons.filter(
-    (season) => season.seasonNumber !== 0 && season.episodeCount !== 0
+    (season) => (settings.currentSettings.hideSpecials ? season.seasonNumber !== 0 : true) && season.episodeCount !== 0
   ).length;
 
   if (seasonCount) {
@@ -259,17 +259,13 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     return [...requestedSeasons, ...availableSeasons];
   };
 
-  const showHasSpecials = data.seasons.some(
-    (season) => season.seasonNumber === 0
-  );
-
-  const isComplete =
-    (showHasSpecials ? seasonCount + 1 : seasonCount) <=
-    getAllRequestedSeasons(false).length;
-
-  const is4kComplete =
-    (showHasSpecials ? seasonCount + 1 : seasonCount) <=
-    getAllRequestedSeasons(true).length;
+  // Calculate total seasons to consider for completion status
+  const totalSeasons = settings.currentSettings.hideSpecials 
+    ? seasonCount 
+    : (data.seasons.some(s => s.seasonNumber === 0) ? seasonCount + 1 : seasonCount);
+    
+  const isComplete = totalSeasons <= getAllRequestedSeasons(false).length;
+  const is4kComplete = totalSeasons <= getAllRequestedSeasons(true).length;
 
   const streamingProviders =
     data?.watchProviders?.find((provider) => provider.iso_3166_1 === region)
@@ -530,6 +526,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
           <h2 className="py-4">{intl.formatMessage(messages.seasonstitle)}</h2>
           <div className="flex w-full flex-col space-y-2">
             {data.seasons
+              .filter((season) => !settings.currentSettings.hideSpecials || season.seasonNumber !== 0)
               .slice()
               .reverse()
               .map((season) => {

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -24,6 +24,7 @@ const defaultSettings = {
   locale: 'en',
   emailEnabled: false,
   newPlexLogin: true,
+  hideSpecials: false,
 };
 
 export const SettingsContext = React.createContext<SettingsContextProps>({

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -804,6 +804,8 @@
   "components.Settings.SettingsMain.generalsettings": "General Settings",
   "components.Settings.SettingsMain.generalsettingsDescription": "Configure global and default settings for Overseerr.",
   "components.Settings.SettingsMain.hideAvailable": "Hide Available Media",
+  "components.Settings.SettingsMain.hideSpecials": "Hide Specials Season",
+  "components.Settings.SettingsMain.hideSpecialsTip": "Hide specials season and prevent requesting specials",
   "components.Settings.SettingsMain.locale": "Display Language",
   "components.Settings.SettingsMain.originallanguage": "Discover Language",
   "components.Settings.SettingsMain.originallanguageTip": "Filter content by original language",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -242,6 +242,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     locale: 'en',
     emailEnabled: false,
     newPlexLogin: true,
+    hideSpecials: false,
   };
 
   if (ctx.res) {


### PR DESCRIPTION
#### Description

- Add hideSpecials boolean setting to MainSettings interface
- Add UI checkbox in Settings to toggle hiding specials season
- Filter out season 0 (specials) from TvRequestModal when hideSpecials enabled
- Hide specials season from TvDetails page season list when setting enabled
- Update completion status calculation to exclude specials when hidden
- Add hideSpecials to API documentation and test configurations
- Add English translations for new setting labels

#### Screenshot (if UI-related)
<img width="1477" height="289" alt="image" src="https://github.com/user-attachments/assets/717a6df6-2708-4450-9979-8ea4d381d8a9" />
<img width="781" height="541" alt="image" src="https://github.com/user-attachments/assets/b5f4092f-b12e-4317-b3d2-a809f88eeaa4" />

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] ~~Database migration (if required)~~ N/A

#### Issues Fixed or Closed

- Enhances #4101
- Partial fix on #3796 (if specials are set to hidden)

