### PR TITLE
feat(discover): add TMDB List slider support

### DIFF
--- a/cypress/e2e/settings/discover-customization.cy.ts
+++ b/cypress/e2e/settings/discover-customization.cy.ts
@@ -160,4 +160,68 @@ describe('Discover Customization', () => {
       .first()
       .should('not.contain', sliderTitle);
   });
+
+  it('can create a TMDB List slider and remove it', () => {
+    cy.visit('/');
+    cy.intercept('/api/v1/settings/discover/*').as('discoverSlider');
+    cy.intercept('/api/v1/discover/tmdb-list/*').as('getTmdbList');
+
+    cy.get('[data-testid=discover-start-editing]').click();
+
+    const sliderTitle = 'Test TMDB List';
+    const listId = '1'; // The Marvel Universe list
+
+    cy.get('#sliderType').select('TMDB List');
+
+    cy.get('#title').type(sliderTitle);
+    cy.get('#data').type(listId);
+
+    cy.wait('@getTmdbList');
+
+    // Confirming we have some results
+    cy.contains('.slider-header', sliderTitle)
+      .next('[data-testid=media-slider]')
+      .find('[data-testid=title-card]');
+
+    cy.get('[data-testid=create-discover-option-form]').submit();
+
+    cy.wait('@discoverSlider');
+    cy.wait('@getDiscoverSliders');
+    cy.wait(1000);
+
+    cy.get('[data-testid=discover-slider-edit-mode]')
+      .first()
+      .should('contain', sliderTitle);
+
+    // Enable it and verify it shows on discover page
+    cy.get('[data-testid=discover-slider-edit-mode]')
+      .first()
+      .find('[role="checkbox"]')
+      .click();
+
+    cy.get('[data-testid=discover-customize-submit').click();
+    cy.wait('@getDiscoverSliders');
+
+    cy.visit('/');
+
+    cy.contains('.slider-header', sliderTitle)
+      .next('[data-testid=media-slider]')
+      .find('[data-testid=title-card]');
+
+    cy.get('[data-testid=discover-start-editing]').click();
+
+    // Delete the slider
+    cy.get('[data-testid=discover-slider-edit-mode]')
+      .first()
+      .find('[data-testid=discover-slider-remove-button]')
+      .click();
+
+    cy.wait('@discoverSlider');
+    cy.wait('@getDiscoverSliders');
+    cy.wait(1000);
+
+    cy.get('[data-testid=discover-slider-edit-mode]')
+      .first()
+      .should('not.contain', sliderTitle);
+  });
 });

--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -5009,6 +5009,58 @@ paths:
                           type: string
                         title:
                           type: string
+  /discover/tmdb-list/{listId}:
+    get:
+      summary: Get TMDB list contents
+      description: Returns items from a TMDB list by list ID
+      tags:
+        - search
+      parameters:
+        - in: path
+          name: listId
+          required: true
+          schema:
+            type: string
+          description: TMDB list ID
+        - in: query
+          name: page
+          schema:
+            type: number
+            example: 1
+            default: 1
+        - in: query
+          name: language
+          schema:
+            type: string
+      responses:
+        '200':
+          description: TMDB list data returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  page:
+                    type: number
+                  totalPages:
+                    type: number
+                  totalResults:
+                    type: number
+                  list:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      description:
+                        type: string
+                  results:
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '#/components/schemas/MovieResult'
+                        - $ref: '#/components/schemas/TvResult'
   /request:
     get:
       summary: Get all requests

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -10,6 +10,7 @@ import type {
   TmdbKeyword,
   TmdbKeywordSearchResponse,
   TmdbLanguage,
+  TmdbListResponse,
   TmdbMovieDetails,
   TmdbNetwork,
   TmdbPersonCombinedCredits,
@@ -1121,6 +1122,29 @@ class TheMovieDb extends ExternalAPI {
       throw new Error(
         `[TMDB] Failed to fetch TV watch providers: ${e.message}`
       );
+    }
+  }
+
+  public async getList({
+    listId,
+    page = 1,
+    language = 'en-US',
+  }: {
+    listId: string;
+    page?: number;
+    language?: string;
+  }): Promise<TmdbListResponse> {
+    try {
+      const data = await this.get<TmdbListResponse>(`/list/${listId}`, {
+        params: {
+          page,
+          language,
+        },
+      });
+
+      return data;
+    } catch (e) {
+      throw new Error(`[TMDB] Failed to fetch list: ${e.message}`);
     }
   }
 }

--- a/server/api/themoviedb/interfaces.ts
+++ b/server/api/themoviedb/interfaces.ts
@@ -469,3 +469,55 @@ export interface TmdbWatchProviderRegion {
   english_name: string;
   native_name: string;
 }
+
+export interface TmdbListItem {
+  id: number;
+  media_type: 'movie' | 'tv';
+  adult?: boolean;
+  backdrop_path?: string;
+  genre_ids?: number[];
+  original_language?: string;
+  original_title?: string;
+  overview?: string;
+  popularity?: number;
+  poster_path?: string;
+  release_date?: string;
+  title?: string;
+  video?: boolean;
+  vote_average?: number;
+  vote_count?: number;
+  name?: string;
+  original_name?: string;
+  first_air_date?: string;
+  origin_country?: string[];
+}
+
+export interface TmdbList {
+  id: string;
+  name: string;
+  description: string;
+  favorite_count: number;
+  item_count: number;
+  iso_639_1: string;
+  list_type: string;
+  poster_path?: string;
+  backdrop_path?: string;
+  created_by?: string;
+  items: TmdbListItem[];
+}
+
+export interface TmdbListResponse {
+  id: string;
+  items: TmdbListItem[];
+  name: string;
+  description: string;
+  favorite_count: number;
+  item_count: number;
+  iso_639_1: string;
+  created_by?: string;
+  poster_path?: string;
+  // TMDB List API v4 may include pagination fields
+  page?: number;
+  total_pages?: number;
+  total_results?: number;
+}

--- a/server/constants/discover.ts
+++ b/server/constants/discover.ts
@@ -22,6 +22,7 @@ export enum DiscoverSliderType {
   TMDB_NETWORK,
   TMDB_MOVIE_STREAMING_SERVICES,
   TMDB_TV_STREAMING_SERVICES,
+  TMDB_LIST,
 }
 
 export const defaultSliders: Partial<DiscoverSlider>[] = [

--- a/server/interfaces/api/discoverInterfaces.ts
+++ b/server/interfaces/api/discoverInterfaces.ts
@@ -1,3 +1,5 @@
+import type { MovieResult, TvResult } from '@server/models/Search';
+
 export interface GenreSliderItem {
   id: number;
   name: string;
@@ -16,4 +18,16 @@ export interface WatchlistResponse {
   totalPages: number;
   totalResults: number;
   results: WatchlistItem[];
+}
+
+export interface TmdbListResponse {
+  page: number;
+  totalPages: number;
+  totalResults: number;
+  list: {
+    id: string;
+    name: string;
+    description: string;
+  };
+  results: (MovieResult | TvResult)[];
 }

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -8,6 +8,7 @@ import Media from '@server/entity/Media';
 import { User } from '@server/entity/User';
 import type {
   GenreSliderItem,
+  TmdbListResponse,
   WatchlistResponse,
 } from '@server/interfaces/api/discoverInterfaces';
 import { getSettings } from '@server/lib/settings';
@@ -847,6 +848,66 @@ discoverRoutes.get<Record<string, unknown>, WatchlistResponse>(
         tmdbId: item.tmdbId,
       })),
     });
+  }
+);
+
+discoverRoutes.get<{ listId: string }, TmdbListResponse>(
+  '/tmdb-list/:listId',
+  async (req, res, next) => {
+    const tmdb = createTmdbWithRegionLanguage(req.user);
+
+    try {
+      const data = await tmdb.getList({
+        listId: req.params.listId,
+        page: Number(req.query.page) || 1,
+        language: (req.query.language as string) ?? req.locale,
+      });
+
+      // Extract all media IDs from list items
+      const mediaIds = data.items.map((item) => item.id);
+      const media = await Media.getRelatedMedia(mediaIds);
+
+      // TMDB List API returns different structure than discover endpoints
+      // It uses page/total_pages/total_results for pagination
+      return res.status(200).json({
+        page: data.page || 1,
+        totalPages: data.total_pages || 1,
+        totalResults:
+          data.total_results || data.item_count || data.items.length,
+        list: {
+          id: data.id,
+          name: data.name,
+          description: data.description,
+        },
+        results: data.items.map((item) =>
+          item.media_type === 'movie'
+            ? mapMovieResult(
+                item as any,
+                media.find(
+                  (med) =>
+                    med.tmdbId === item.id && med.mediaType === MediaType.MOVIE
+                )
+              )
+            : mapTvResult(
+                item as any,
+                media.find(
+                  (med) =>
+                    med.tmdbId === item.id && med.mediaType === MediaType.TV
+                )
+              )
+        ),
+      });
+    } catch (e) {
+      logger.debug('Something went wrong retrieving TMDB list', {
+        label: 'API',
+        errorMessage: e.message,
+        listId: req.params.listId,
+      });
+      return next({
+        status: 500,
+        message: 'Unable to retrieve TMDB list.',
+      });
+    }
   }
 );
 

--- a/src/components/Discover/CreateSlider/index.tsx
+++ b/src/components/Discover/CreateSlider/index.tsx
@@ -30,6 +30,7 @@ const messages = defineMessages({
   providetmdbsearch: 'Provide a search query',
   providetmdbstudio: 'Provide TMDB Studio ID',
   providetmdbnetwork: 'Provide TMDB Network ID',
+  providetmdblist: 'Provide a TMDB List ID',
   addsuccess: 'Created new slider and saved discover customization settings.',
   addfail: 'Failed to create new slider.',
   editsuccess: 'Edited slider and saved discover customization settings.',
@@ -225,6 +226,13 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
   };
 
   const options: CreateOption[] = [
+    {
+      type: DiscoverSliderType.TMDB_LIST,
+      title: intl.formatMessage(sliderTitles.tmdblist),
+      dataUrl: '/api/v1/discover/tmdb-list/$value',
+      titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
+      dataPlaceholderText: intl.formatMessage(messages.providetmdblist),
+    },
     {
       type: DiscoverSliderType.TMDB_MOVIE_KEYWORD,
       title: intl.formatMessage(sliderTitles.tmdbmoviekeyword),

--- a/src/components/Discover/DiscoverSliderEdit/index.tsx
+++ b/src/components/Discover/DiscoverSliderEdit/index.tsx
@@ -168,6 +168,8 @@ const DiscoverSliderEdit = ({
         return intl.formatMessage(sliderTitles.tmdbmoviestreamingservices);
       case DiscoverSliderType.TMDB_TV_STREAMING_SERVICES:
         return intl.formatMessage(sliderTitles.tmdbtvstreamingservices);
+      case DiscoverSliderType.TMDB_LIST:
+        return intl.formatMessage(sliderTitles.tmdblist);
       default:
         return 'Unknown Slider';
     }
@@ -243,6 +245,9 @@ const DiscoverSliderEdit = ({
           )}
           {slider.type === DiscoverSliderType.TMDB_SEARCH && (
             <Tag iconSvg={<MagnifyingGlassIcon />}>{slider.data}</Tag>
+          )}
+          {slider.type === DiscoverSliderType.TMDB_LIST && (
+            <Tag>{`List ID: ${slider.data}`}</Tag>
           )}
         </div>
         <div className="flex items-center space-x-2">

--- a/src/components/Discover/TmdbListView.tsx
+++ b/src/components/Discover/TmdbListView.tsx
@@ -1,0 +1,56 @@
+import Header from '@app/components/Common/Header';
+import ListView from '@app/components/Common/ListView';
+import PageTitle from '@app/components/Common/PageTitle';
+import useDiscover from '@app/hooks/useDiscover';
+import Error from '@app/pages/_error';
+import type { MovieResult, TvResult } from '@server/models/Search';
+import { useRouter } from 'next/router';
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  tmdblist: 'TMDB List',
+});
+
+const TmdbListView = () => {
+  const intl = useIntl();
+  const router = useRouter();
+  const { listId } = router.query;
+
+  const {
+    isLoadingInitialData,
+    isEmpty,
+    isLoadingMore,
+    isReachingEnd,
+    titles,
+    fetchMore,
+    error,
+  } = useDiscover<MovieResult | TvResult>(
+    `/api/v1/discover/tmdb-list/${listId}`
+  );
+
+  if (error) {
+    return <Error statusCode={500} />;
+  }
+
+  const title = intl.formatMessage(messages.tmdblist);
+
+  return (
+    <>
+      <PageTitle title={title} />
+      <div className="mt-1 mb-5">
+        <Header>{title}</Header>
+      </div>
+      <ListView
+        items={titles}
+        isEmpty={isEmpty}
+        isLoading={
+          isLoadingInitialData || (isLoadingMore && (titles?.length ?? 0) > 0)
+        }
+        isReachingEnd={isReachingEnd}
+        onScrollBottom={fetchMore}
+      />
+    </>
+  );
+};
+
+export default TmdbListView;

--- a/src/components/Discover/constants.ts
+++ b/src/components/Discover/constants.ts
@@ -88,6 +88,7 @@ export const sliderTitles = defineMessages({
   tmdbsearch: 'TMDB Search',
   tmdbmoviestreamingservices: 'TMDB Movie Streaming Services',
   tmdbtvstreamingservices: 'TMDB TV Streaming Services',
+  tmdblist: 'TMDB List',
 });
 
 export const QueryFilterOptions = z.object({

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -395,6 +395,16 @@ const Discover = () => {
               />
             );
             break;
+          case DiscoverSliderType.TMDB_LIST:
+            sliderComponent = (
+              <MediaSlider
+                sliderKey={`custom-slider-${slider.id}`}
+                title={slider.title ?? ''}
+                url={`/api/v1/discover/tmdb-list/${slider.data}`}
+                linkUrl={`/discover/tmdb-list/${slider.data}`}
+              />
+            );
+            break;
         }
 
         if (isEditing) {

--- a/src/pages/discover/tmdb-list/[listId].tsx
+++ b/src/pages/discover/tmdb-list/[listId].tsx
@@ -1,0 +1,8 @@
+import TmdbListView from '@app/components/Discover/TmdbListView';
+import type { NextPage } from 'next';
+
+const TmdbListPage: NextPage = () => {
+  return <TmdbListView />;
+};
+
+export default TmdbListPage;


### PR DESCRIPTION
Implements TMDB List slider type allowing admins
to create custom discovery sliders from public TMDB lists.

- Add TMDB List API integration (getList method)
- Add TMDB_LIST slider type to DiscoverSliderType enum
- Create /api/v1/discover/tmdb-list/:listId endpoint
- Add UI for creating and displaying TMDB List sliders
- Add dedicated list view page at /discover/tmdb-list/:id
- Update OpenAPI spec with new route definition
- Add Cypress e2e test for TMDB List slider creation

Closes https://github.com/sct/overseerr/discussions/4270

### Screenshots

<img width="2525" height="1286" alt="image" src="https://github.com/user-attachments/assets/3cabca25-809e-4d7c-925b-29e0d1bdfd4b" />

<img width="2538" height="1336" alt="image" src="https://github.com/user-attachments/assets/8ce5bc47-bfe5-4e66-b25f-5fb18df75d22" />
