### PR TITLE
privacy: don't leak origin via referer header

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -206,6 +206,7 @@ const CoreApp: Omit<NextAppComponentType, 'origGetInitialProps'> = ({
                     name="viewport"
                     content="initial-scale=1, viewport-fit=cover, width=device-width"
                   ></meta>
+                  <meta name="referrer" content="no-referrer" />
                   <PWAHeader
                     applicationTitle={currentSettings.applicationTitle}
                   />


### PR DESCRIPTION
#### Description
Overseerr web-ui leaks the origin site URL via the `Referer` http request header when loading resources from some 3rd party websites. Examples include:
- Logging in: `https://plex.tv/users/<redacted>/avatar?c=<redacted>`
- Loading home page: `https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7W0Q5nw.woff2`
- Loading settings page: `https://secure.gravatar.com/avatar/<redacted>?d=<redacted>`

I've got image caching enabled atm, but when disabled, loading images from tmdb & friends also leaks the origin via referer header.

Unless the referrer header is necessary for correct functionality, it would be a good idea to set a site wide referrer policy to `no-referrer` in the interest of privacy.

Tested with the change I'm not seeing the referer header being sent anymore.