### PR TITLE
fix: prevent settings from being overwritten on load (#4291)

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -592,7 +592,6 @@ class Settings {
 
     if (data) {
       this.data = merge(this.data, JSON.parse(data));
-      this.save();
     }
     return this;
   }


### PR DESCRIPTION
Remove automatic save call in Settings.load() method that was causing notification settings (particularly webhook URLs) to be unexpectedly overwritten after server restarts.

The load() method was automatically saving settings after merging with defaults, which could cause user configurations to be replaced with default or previously cached values due to the merge behavior.

Fixes #4291

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
