### PR TITLE
fix(MediaRequestSubscriber): arr-compliant auto tagging

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -249,9 +249,15 @@ export class MediaRequestSubscriber
         }
 
         if (radarrSettings.tagRequests) {
-          let userTag = (await radarr.getTags()).find((v) =>
+          const radarrTags = await radarr.getTags();
+          let userTag = radarrTags.find((v) =>
             v.label.startsWith(entity.requestedBy.id + ' - ')
           );
+          if (!userTag) {
+            userTag = radarrTags.find((v) =>
+              v.label.startsWith(entity.requestedBy.id + '-')
+            );
+          }
           if (!userTag) {
             logger.info(`Requester has no active tag. Creating new`, {
               label: 'Media Request',
@@ -259,11 +265,11 @@ export class MediaRequestSubscriber
               mediaId: entity.media.id,
               userId: entity.requestedBy.id,
               newTag:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
             userTag = await radarr.createTag({
               label:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
           }
           if (userTag.id) {
@@ -550,9 +556,15 @@ export class MediaRequestSubscriber
         }
 
         if (sonarrSettings.tagRequests) {
-          let userTag = (await sonarr.getTags()).find((v) =>
+          const sonarrTags = await sonarr.getTags();
+          let userTag = sonarrTags.find((v) =>
             v.label.startsWith(entity.requestedBy.id + ' - ')
           );
+          if (!userTag) {
+            userTag = sonarrTags.find((v) =>
+              v.label.startsWith(entity.requestedBy.id + '-')
+            );
+          }
           if (!userTag) {
             logger.info(`Requester has no active tag. Creating new`, {
               label: 'Media Request',
@@ -560,11 +572,11 @@ export class MediaRequestSubscriber
               mediaId: entity.media.id,
               userId: entity.requestedBy.id,
               newTag:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
             userTag = await sonarr.createTag({
               label:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
           }
           if (userTag.id) {


### PR DESCRIPTION
#### Description

In Overseerr, if you have "auto tagging" enabled, sending an approved request to Radarr will quietly fail and it's kind of painful to go back and fix them (or perhaps my inexperience showing). I ran into this myself today, and found this reddit post promoting _disabling the feature_ as a fix: https://www.reddit.com/r/Overseerr/comments/1nscxd0/error_requesting_a_movie_returned_from_radarr/


Radarr v6 [deliberately stopped supporting spaces](https://github.com/Radarr/Radarr/issues/11251#issuecomment-3341943869) in tags/labels.

Radarr will log this event:
```
Invalid request Validation failed: 
 -- Label: Allowed characters a-z, 0-9 and -
```

Note: I found that [this was fixed](https://github.com/seerr-team/seerr/pull/1913) in `seerr` a few months ago and I decided against reinventing the wheel.

#### To-Dos

- [x] Successful build `yarn build`
- ~Translation keys `yarn i18n:extract`~
- ~Database migration (if required)~

#### Issues Fixed or Closed

- Fixes #4219
