### PR TITLE
fix: correct permission check in watchlist sync

### DIFF
--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -44,7 +44,7 @@ class WatchlistSync {
         [
           Permission.AUTO_REQUEST,
           Permission.AUTO_REQUEST_MOVIE,
-          Permission.AUTO_APPROVE_TV,
+          Permission.AUTO_REQUEST_TV,
         ],
         { type: 'or' }
       )


### PR DESCRIPTION
## Summary

Fixes a typo in `server/lib/watchlistsync.ts` where the permission check incorrectly uses `AUTO_APPROVE_TV` instead of `AUTO_REQUEST_TV`.

## The Bug

```typescript
// Line 47 - Current (buggy)
[Permission.AUTO_REQUEST, Permission.AUTO_REQUEST_MOVIE, Permission.AUTO_APPROVE_TV]

// Correct
[Permission.AUTO_REQUEST, Permission.AUTO_REQUEST_MOVIE, Permission.AUTO_REQUEST_TV]
```

## Impact

Users with only `AUTO_REQUEST_TV` permission are incorrectly skipped during watchlist sync because their TV permission isn't recognized by this check.

## Fix

Simple one-line change: `AUTO_APPROVE_TV` → `AUTO_REQUEST_TV`

## Related Issues

- Fixes #4309
- May resolve #4202 (Watchlist auto-request not populating)

## Testing

Verified that the permission check now correctly recognizes `AUTO_REQUEST_TV` in the OR condition.