### PR TITLE
feat(search.ts): improve search ranking by incorporating popularity score

### DIFF
--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,5 +1,11 @@
 import TheMovieDb from '@server/api/themoviedb';
-import type { TmdbSearchMultiResponse } from '@server/api/themoviedb/interfaces';
+import type {
+  TmdbCollectionResult,
+  TmdbMovieResult,
+  TmdbPersonResult,
+  TmdbSearchMultiResponse,
+  TmdbTvResult,
+} from '@server/api/themoviedb/interfaces';
 import Media from '@server/entity/Media';
 import { findSearchProvider } from '@server/lib/search';
 import logger from '@server/logger';
@@ -7,6 +13,58 @@ import { mapSearchResults } from '@server/models/Search';
 import { Router } from 'express';
 
 const searchRoutes = Router();
+
+type SearchResultItem =
+  | TmdbMovieResult
+  | TmdbTvResult
+  | TmdbPersonResult
+  | TmdbCollectionResult;
+
+const getResultTitle = (result: SearchResultItem): string => {
+  if ('title' in result) return result.title;
+  if ('name' in result) return result.name;
+  return '';
+};
+
+const getResultPopularity = (result: SearchResultItem): number => {
+  return 'popularity' in result ? result.popularity : 0;
+};
+
+const calculateSearchScore = (
+  result: SearchResultItem,
+  query: string
+): number => {
+  const title = getResultTitle(result).toLowerCase();
+  const popularity = getResultPopularity(result);
+
+  // Popularity is the main factor (normalized to make the boost meaningful)
+  let score = popularity * 10;
+
+  // Small boost for titles that start with the query
+  if (title.startsWith(query)) {
+    score += 15;
+  }
+
+  // Tiny boost for exact matches (but not enough to override popularity)
+  if (title === query) {
+    score += 5;
+  }
+
+  return score;
+};
+
+const sortResultsByRelevanceAndPopularity = (
+  results: SearchResultItem[],
+  query: string
+): SearchResultItem[] => {
+  const normalizedQuery = query.toLowerCase().trim();
+
+  return [...results].sort((a, b) => {
+    const scoreA = calculateSearchScore(a, normalizedQuery);
+    const scoreB = calculateSearchScore(b, normalizedQuery);
+    return scoreB - scoreA;
+  });
+};
 
 searchRoutes.get('/', async (req, res, next) => {
   const queryString = req.query.query as string;
@@ -33,15 +91,20 @@ searchRoutes.get('/', async (req, res, next) => {
       });
     }
 
+    const sortedResults = sortResultsByRelevanceAndPopularity(
+      results.results,
+      queryString
+    );
+
     const media = await Media.getRelatedMedia(
-      results.results.map((result) => result.id)
+      sortedResults.map((result) => result.id)
     );
 
     return res.status(200).json({
       page: results.page,
       totalPages: results.total_pages,
       totalResults: results.total_results,
-      results: mapSearchResults(results.results, media),
+      results: mapSearchResults(sortedResults, media),
     });
   } catch (e) {
     logger.debug('Something went wrong retrieving search results', {


### PR DESCRIPTION
#### Description
Improves search result ranking by incorporating TMDB popularity scores into the sorting algorithm. Previously, search results were returned in TMDB's default order which prioritizes text matching over popularity, causing obscure titles to appear above well-known ones.

**Problem**
When searching for partial titles (e.g., "the hunger"), less popular movies with closer text matches would appear before highly popular titles like "The Hunger Games" franchise.

**Solution**
Implemented a scoring system that combines:
Popularity (primary factor) - TMDB popularity score weighted heavily
Text relevance (secondary factor) - small boosts for titles starting with or exactly matching the query
This ensures popular titles rank appropriately while still giving slight preference to closer text matches when popularity is similar.

**Changes**
Added calculateSearchScore() function that computes a weighted score
Added sortResultsByRelevanceAndPopularity() to sort results by combined score
Applied sorting to all search results including special search providers (year:, tmdb:, etc.)

**Testing**
Tested with queries like "the hunger" - The Hunger Games movies now appear before obscure titles like "The Hunger".

#### To-Dos

- [X] Successful build `yarn build`


