### PR TITLE
fix(docker): add py3-setuptools for arm builds on node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
   case "${TARGETPLATFORM}" in \
   'linux/arm64' | 'linux/arm/v7') \
   apk update && \
-  apk add --no-cache python3 make g++ gcc libc6-compat bash && \
+  apk add --no-cache python3 py3-setuptools make g++ gcc libc6-compat bash && \
   yarn global add node-gyp \
   ;; \
   esac


### PR DESCRIPTION
#### Description

No idea if this fixes it but trying anyways

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image dependencies for ARM-based builds to include Python setuptools support alongside existing development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->